### PR TITLE
Add CaseIterable to generated key enums

### DIFF
--- a/Sources/Knit/TypeSafetySourceFile.swift
+++ b/Sources/Knit/TypeSafetySourceFile.swift
@@ -50,7 +50,7 @@ public enum TypeSafetySourceFile {
         ExtensionDeclSyntax("extension \(assemblyName)") {
             for namedGroup in namedGroups {
                 let modifier = namedGroup.accessLevel == .public ? "public " : ""
-                EnumDeclSyntax("\(modifier)enum \(namedGroup.enumName): String") {
+                EnumDeclSyntax("\(modifier)enum \(namedGroup.enumName): String, CaseIterable") {
                     for test in namedGroup.registrations {
                         EnumCaseDeclSyntax("case \(raw: test.name!)")
                     }

--- a/Tests/KnitTests/TypeSafetySourceFileTests.swift
+++ b/Tests/KnitTests/TypeSafetySourceFileTests.swift
@@ -39,7 +39,7 @@ final class TypeSafetySourceFileTests: XCTestCase {
             }
         }
         extension ModuleAssembly {
-            enum ServiceB_ResolutionKey: String {
+            enum ServiceB_ResolutionKey: String, CaseIterable {
                 case name
                 case otherName
             }


### PR DESCRIPTION
I ran into a future case where this would be helpful, I don't see a downside in adding it.