### PR TITLE
Use `callAsFunction` instead of `resolve` for named instances

### DIFF
--- a/Sources/Knit/TypeSafetySourceFile.swift
+++ b/Sources/Knit/TypeSafetySourceFile.swift
@@ -31,7 +31,7 @@ public enum TypeSafetySourceFile {
                 for namedGroup in namedGroups {
                     let modifier = namedGroup.accessLevel == .public ? "public " : ""
                     // swiftlint:disable:next line_length
-                    FunctionDeclSyntax("\(modifier)func resolve(_ name: \(assemblyName).\(namedGroup.enumName)) -> \(namedGroup.service)") {
+                    FunctionDeclSyntax("\(modifier)func callAsFunction(named: \(assemblyName).\(namedGroup.enumName)) -> \(namedGroup.service)") {
                         ForcedValueExprSyntax("self.resolve(\(raw: namedGroup.service).self, name: name.rawValue)!")
                     }
                 }

--- a/Tests/KnitTests/TypeSafetySourceFileTests.swift
+++ b/Tests/KnitTests/TypeSafetySourceFileTests.swift
@@ -34,7 +34,7 @@ final class TypeSafetySourceFileTests: XCTestCase {
             func callAsFunction() -> ServiceA {
                 self.resolve(ServiceA.self)!
             }
-            func resolve(_ name: ModuleAssembly.ServiceB_ResolutionKey) -> ServiceB {
+            func callAsFunction(named: ModuleAssembly.ServiceB_ResolutionKey) -> ServiceB {
                 self.resolve(ServiceB.self, name: name.rawValue)!
             }
         }


### PR DESCRIPTION
Not sure why I deviated when building this the first time.