### PR TITLE
Fix broken variable name

### DIFF
--- a/Sources/Knit/TypeSafetySourceFile.swift
+++ b/Sources/Knit/TypeSafetySourceFile.swift
@@ -32,7 +32,7 @@ public enum TypeSafetySourceFile {
                     let modifier = namedGroup.accessLevel == .public ? "public " : ""
                     // swiftlint:disable:next line_length
                     FunctionDeclSyntax("\(modifier)func callAsFunction(named: \(assemblyName).\(namedGroup.enumName)) -> \(namedGroup.service)") {
-                        ForcedValueExprSyntax("self.resolve(\(raw: namedGroup.service).self, name: name.rawValue)!")
+                        ForcedValueExprSyntax("self.resolve(\(raw: namedGroup.service).self, name: named.rawValue)!")
                     }
                 }
             }

--- a/Tests/KnitTests/TypeSafetySourceFileTests.swift
+++ b/Tests/KnitTests/TypeSafetySourceFileTests.swift
@@ -35,7 +35,7 @@ final class TypeSafetySourceFileTests: XCTestCase {
                 self.resolve(ServiceA.self)!
             }
             func callAsFunction(named: ModuleAssembly.ServiceB_ResolutionKey) -> ServiceB {
-                self.resolve(ServiceB.self, name: name.rawValue)!
+                self.resolve(ServiceB.self, name: named.rawValue)!
             }
         }
         extension ModuleAssembly {


### PR DESCRIPTION
Added a named variable but forgot to rename the usage.