### PR TITLE
Fix parser failure

### DIFF
--- a/Sources/Knit/FunctionCallRegistrationParsing.swift
+++ b/Sources/Knit/FunctionCallRegistrationParsing.swift
@@ -14,10 +14,10 @@ extension FunctionCallExprSyntax {
         var calledMethods = [(methodName: TokenSyntax, arguments: TupleExprElementListSyntax)]()
 
         // Returns the base identifier token that was called
-        func recurseCalledExpressions(_ funcCall: FunctionCallExprSyntax) -> TokenSyntax {
+        func recurseCalledExpressions(_ funcCall: FunctionCallExprSyntax) -> TokenSyntax? {
 
             guard let calledExpr = funcCall.calledExpression.as(MemberAccessExprSyntax.self) else {
-                fatalError("Unexpected calledExpression: \(funcCall.calledExpression.description)")
+                return nil
             }
 
             // Append the method call
@@ -31,7 +31,9 @@ extension FunctionCallExprSyntax {
         }
 
         // Kick off recursion with the current function call
-        let baseIdentfier = recurseCalledExpressions(self)
+        guard let baseIdentfier = recurseCalledExpressions(self) else {
+            return nil
+        }
 
         // The final base identifier must be the "container" local argument
         guard baseIdentfier.text == "container" else {

--- a/Tests/KnitTests/AssemblyParsingTests.swift
+++ b/Tests/KnitTests/AssemblyParsingTests.swift
@@ -112,6 +112,27 @@ final class AssemblyParsingTests: XCTestCase {
         )
     }
 
+    func testAdditionalFunctions() throws {
+        let sourceFile: SourceFile = """
+                class ExampleAssembly: Assembly {
+                    func assemble(container: Container) {
+                        partialAssemble(container: container)
+                    }
+                    func partialAssemble(container: Container) {
+                        container.register(MyService.self) { }
+                    }
+                }
+            """
+
+        let config = try parseSyntaxTree(sourceFile)
+        XCTAssertEqual(config.name, "Example")
+        XCTAssertEqual(
+            config.registrations.map { $0.service },
+            ["MyService"],
+            "Check that services can be registered in other functions"
+        )
+    }
+
     // MARK: - ClassDecl Extension
 
     func testClassDeclExtension() {

--- a/Tests/KnitTests/RegistrationParsingTests.swift
+++ b/Tests/KnitTests/RegistrationParsingTests.swift
@@ -75,6 +75,7 @@ final class RegistrationParsingTests: XCTestCase {
     func testIncorrectRegistrations() {
         assertNoRegistrationString("container.someOtherMethod(AType.self)", message: "Incorrect method name")
         assertNoRegistrationString("container.register(A)", message: "First param is not a metatype")
+        assertNoRegistrationString("doThing()", message:"Unrelated function call")
     }
 
 }


### PR DESCRIPTION
I hit an issue while writing some assembly code. I was able to work around the issue but this fix should save it coming up for other developers. The issue was that calling a function with no parameters (in my case it was `resolver()`) would cause the DI parsing to fail.

This fixes the issue, adds some extra tests and adds a message to contact our channel if anyone hits one of the other fatal errors.