### PR TITLE
Add support for `.implements()`

### DIFF
--- a/Sources/KnitCodeGen/AssemblyParsing.swift
+++ b/Sources/KnitCodeGen/AssemblyParsing.swift
@@ -80,9 +80,8 @@ private class ClassDeclVisitor: SyntaxVisitor {
     private(set) var registrations = [Registration]()
 
     override func visit(_ node: FunctionCallExprSyntax) -> SyntaxVisitorContinueKind {
-        if let registration = node.getRegistration() {
-            registrations.append(registration)
-        }
+        registrations.append(contentsOf: node.getRegistrations())
+
         return .skipChildren
     }
 

--- a/Sources/KnitCodeGen/FunctionCallRegistrationParsing.swift
+++ b/Sources/KnitCodeGen/FunctionCallRegistrationParsing.swift
@@ -7,11 +7,11 @@ import SwiftSyntax
 
 extension FunctionCallExprSyntax {
 
-    /// Retrieve a registration if it exists in the function call expression.
+    /// Retrieve any registrations if they exist in the function call expression.
     /// Function call expressions can contain chained function calls, and this method will parse the chain.
-    func getRegistration() -> Registration? {
+    func getRegistrations() -> [Registration] {
         // Collect all chained method calls
-        var calledMethods = [(methodName: TokenSyntax, arguments: TupleExprElementListSyntax)]()
+        var calledMethods = [(calledExpr: MemberAccessExprSyntax, arguments: TupleExprElementListSyntax)]()
 
         // Returns the base identifier token that was called
         func recurseCalledExpressions(_ funcCall: FunctionCallExprSyntax) -> TokenSyntax? {
@@ -21,7 +21,7 @@ extension FunctionCallExprSyntax {
             }
 
             // Append the method call
-            calledMethods.append((methodName: calledExpr.name, arguments: funcCall.argumentList))
+            calledMethods.append((calledExpr: calledExpr, arguments: funcCall.argumentList))
             if let identifierToken = calledExpr.base?.as(IdentifierExprSyntax.self)?.identifier {
                 return identifierToken
             } else {
@@ -32,53 +32,93 @@ extension FunctionCallExprSyntax {
 
         // Kick off recursion with the current function call
         guard let baseIdentfier = recurseCalledExpressions(self) else {
-            return nil
+            return []
         }
 
         // The final base identifier must be the "container" local argument
         guard baseIdentfier.text == "container" else {
-            return nil
+            return []
         }
 
-        let registerMethods = calledMethods.filter { methodName, _ in
-            methodName.text == "register" || methodName.text == "autoregister" || methodName.text == "registerAbstract"
+        let registerMethods = calledMethods.filter { calledExpr, _ in
+            let name = calledExpr.name.text
+            return name == "register" || name == "autoregister" || name == "registerAbstract"
         }
 
         guard registerMethods.count <= 1 else {
             fatalError("Chained registration calls are not supported")
         }
 
-        if let registerMethod = registerMethods.first {
-            guard let firstParam = registerMethod.arguments.first?.as(TupleExprElementSyntax.self)?
-                .expression.as(MemberAccessExprSyntax.self) else { return nil }
-            guard firstParam.name.text == "self" else { return nil }
-
-            let registrationText = firstParam.base!.withoutTrivia().description
-            let accessLevel: AccessLevel
-            if let leadingTrivia, leadingTrivia.description.contains("@digen public") {
-                accessLevel = .public
-            } else if let leadingTrivia, leadingTrivia.description.contains("@digen hidden") {
-                accessLevel = .hidden
-            } else {
-                accessLevel = .internal
-            }
-            let name = getName(arguments: registerMethod.arguments)
-
-            return .init(service: registrationText, name: name, accessLevel: accessLevel)
+        guard let primaryRegisterMethod = registerMethods.first else {
+            return []
         }
 
+        // The primary registration (not `.implements()`)
+        guard let primaryRegistration = makeRegistrationFor(
+            arguments: primaryRegisterMethod.arguments,
+            leadingTrivia: self.leadingTrivia,
+            isForwarded: false
+        ) else {
+            return []
+        }
+
+        let implementsCalledMethods = calledMethods.filter { calledExpr, _ in
+            calledExpr.name.text == "implements"
+        }
+
+        var forwardedRegistrations = [Registration]()
+
+        for implementsCalledMethod in implementsCalledMethods {
+            // For `.implements()` the leading trivia is attached to the Dot syntax node
+            let leadingTrivia = implementsCalledMethod.calledExpr.dot.leadingTrivia
+
+            if let forwardedRegistration = makeRegistrationFor(
+                arguments: implementsCalledMethod.arguments,
+                leadingTrivia: leadingTrivia,
+                isForwarded: true
+            ) {
+                forwardedRegistrations.append(forwardedRegistration)
+            }
+        }
+
+        // The called methods process from the outside in, which is reverse order of how they read
+        forwardedRegistrations.reverse()
+
+        return [primaryRegistration] + forwardedRegistrations
+    }
+
+}
+
+private func makeRegistrationFor(
+    arguments: TupleExprElementListSyntax,
+    leadingTrivia: Trivia?,
+    isForwarded: Bool
+) -> Registration? {
+    guard let firstParam = arguments.first?.as(TupleExprElementSyntax.self)?
+        .expression.as(MemberAccessExprSyntax.self) else { return nil }
+    guard firstParam.name.text == "self" else { return nil }
+
+    let registrationText = firstParam.base!.withoutTrivia().description
+    let accessLevel: AccessLevel
+    if let leadingTrivia, leadingTrivia.description.contains("@digen public") {
+        accessLevel = .public
+    } else if let leadingTrivia, leadingTrivia.description.contains("@digen hidden") {
+        accessLevel = .hidden
+    } else {
+        accessLevel = .internal
+    }
+    let name = getName(arguments: arguments)
+
+    return Registration(service: registrationText, name: name, accessLevel: accessLevel, isForwarded: isForwarded)
+}
+
+private func getName(arguments: TupleExprElementListSyntax) -> String? {
+    let nameParam = arguments.first(where: {$0.label?.text == "name"})
+    guard let name = nameParam?.expression.as(StringLiteralExprSyntax.self)?.description else {
         return nil
     }
-
-    private func getName(arguments: TupleExprElementListSyntax) -> String? {
-        let nameParam = arguments.first(where: {$0.label?.text == "name"})
-        guard let name = nameParam?.expression.as(StringLiteralExprSyntax.self)?.description else {
-            return nil
-        }
-        guard name.hasPrefix("\"") && name.hasSuffix("\"") else {
-            fatalError("Service name must be a static string. Found: \(name)")
-        }
-        return String(name.dropFirst().dropLast())
+    guard name.hasPrefix("\"") && name.hasSuffix("\"") else {
+        fatalError("Service name must be a static string. Found: \(name)")
     }
-
+    return String(name.dropFirst().dropLast())
 }

--- a/Sources/KnitCodeGen/Registration.swift
+++ b/Sources/KnitCodeGen/Registration.swift
@@ -1,4 +1,4 @@
-public struct Registration {
+public struct Registration: Equatable {
 
     public var service: String
 
@@ -6,14 +6,19 @@ public struct Registration {
 
     public var accessLevel: AccessLevel
 
+    /// This registration is forwarded to another service entry.
+    public var isForwarded: Bool
+
     public init(
         service: String,
         name: String?,
-        accessLevel: AccessLevel
+        accessLevel: AccessLevel,
+        isForwarded: Bool
     ) {
         self.service = service
         self.name = name
         self.accessLevel = accessLevel
+        self.isForwarded = isForwarded
     }
 
 }

--- a/Tests/KnitCodeGenTests/NamedRegistrationGroupTests.swift
+++ b/Tests/KnitCodeGenTests/NamedRegistrationGroupTests.swift
@@ -8,11 +8,11 @@ final class NamedRegistrationGroupTests: XCTestCase {
 
     func testRegistrationGrouping() throws {
         let registrations: [Registration] = [
-            .init(service: "ServiceA", name: nil, accessLevel: .internal),
-            .init(service: "ServiceA", name: "name1", accessLevel: .internal),
-            .init(service: "ServiceB", name: "name1", accessLevel: .internal),
-            .init(service: "ServiceA", name: "name2", accessLevel: .internal),
-            .init(service: "ServiceB", name: "name3", accessLevel: .public),
+            .init(service: "ServiceA", name: nil, accessLevel: .internal, isForwarded: false),
+            .init(service: "ServiceA", name: "name1", accessLevel: .internal, isForwarded: false),
+            .init(service: "ServiceB", name: "name1", accessLevel: .internal, isForwarded: false),
+            .init(service: "ServiceA", name: "name2", accessLevel: .internal, isForwarded: false),
+            .init(service: "ServiceB", name: "name3", accessLevel: .public, isForwarded: false),
         ]
 
         let namedGroups = NamedRegistrationGroup.make(from: registrations)

--- a/Tests/KnitCodeGenTests/RegistrationParsingTests.swift
+++ b/Tests/KnitCodeGenTests/RegistrationParsingTests.swift
@@ -17,13 +17,16 @@ final class RegistrationParsingTests: XCTestCase {
             "container.autoregister(BType.self)",
             serviceName: "BType"
         )
-        assertRegistrationString(
+        assertMultipleRegistrationsString(
             """
             container.register(AType.self) { _ in }
             .implements(AnotherType.self)
             .inObjectScope(.container)
             """,
-            serviceName: "AType"
+            registrations: [
+                Registration(service: "AType", name: nil, accessLevel: .internal, isForwarded: false),
+                Registration(service: "AnotherType", name: nil, accessLevel: .internal, isForwarded: true),
+            ]
         )
         assertRegistrationString(
             """
@@ -100,35 +103,102 @@ final class RegistrationParsingTests: XCTestCase {
         )
     }
 
+    func testForwardedRegistration() throws {
+        assertMultipleRegistrationsString(
+            """
+            container.register(A.self) { }
+            .implements(B.self)
+            """,
+            registrations: [
+                Registration(service: "A", name: nil, accessLevel: .internal, isForwarded: false),
+                Registration(service: "B", name: nil, accessLevel: .internal, isForwarded: true),
+            ]
+        )
+
+        assertMultipleRegistrationsString(
+            """
+            container.autoregister(A.self, initializer: A.init)
+            .implements(B.self)
+            // @digen public
+            .implements(C.self, name: "foo")
+            .implements(D.self, name: "bar")
+            """,
+            registrations: [
+                Registration(service: "A", name: nil, accessLevel: .internal, isForwarded: false),
+                Registration(service: "B", name: nil, accessLevel: .internal, isForwarded: true),
+                Registration(service: "C", name: "foo", accessLevel: .public, isForwarded: true),
+                Registration(service: "D", name: "bar", accessLevel: .internal, isForwarded: true),
+            ]
+        )
+
+        assertMultipleRegistrationsString(
+            """
+            // @digen hidden
+            container.register(A.self) { }
+            // @digen public
+            .implements(B.self)
+            // @digen hidden
+            .implements(C.self)
+            """,
+            registrations: [
+                Registration(service: "A", name: nil, accessLevel: .hidden, isForwarded: false),
+                Registration(service: "B", name: nil, accessLevel: .public, isForwarded: true),
+                Registration(service: "C", name: nil, accessLevel: .hidden, isForwarded: true)
+            ]
+        )
+    }
+
     func testIncorrectRegistrations() {
-        assertNoRegistrationString("container.someOtherMethod(AType.self)", message: "Incorrect method name")
-        assertNoRegistrationString("container.register(A)", message: "First param is not a metatype")
-        assertNoRegistrationString("doThing()", message:"Unrelated function call")
+        assertNoRegistrationsString("container.someOtherMethod(AType.self)", message: "Incorrect method name")
+        assertNoRegistrationsString("container.register(A)", message: "First param is not a metatype")
+        assertNoRegistrationsString("doThing()", message:"Unrelated function call")
+        assertNoRegistrationsString("container.implements(AType.self)", message: "Missing primary registration")
     }
 
 }
 
+/// Assert that a single registration exists within the string, and that the registration matches provided parameters.
 private func assertRegistrationString(
     _ string: String,
     serviceName: String,
     accessLevel: AccessLevel = .internal,
     name: String? = nil,
+    isForwarded: Bool = false,
     file: StaticString = #filePath, line: UInt = #line
 ) {
     let functionCall = FunctionCallExpr(stringLiteral: string)
-    let registration = functionCall.getRegistration()
+
+    let registrations = functionCall.getRegistrations()
+    XCTAssertEqual(registrations.count, 1, file: file, line: line)
+
+    let registration = registrations.first
     XCTAssertNotNil(registration, file: file, line: line)
     XCTAssertEqual(registration?.service, serviceName, file: file, line: line)
     XCTAssertEqual(registration?.accessLevel, accessLevel, file: file, line: line)
     XCTAssertEqual(registration?.name, name, file: file, line: line)
+    XCTAssertEqual(registration?.isForwarded, isForwarded, file: file, line: line)
 }
 
-private func assertNoRegistrationString(
+/// Assert that multiple registrations exist within the string.
+private func assertMultipleRegistrationsString(
+    _ string: String,
+    registrations: [Registration],
+    file: StaticString = #filePath, line: UInt = #line
+) {
+    let functionCall = FunctionCallExpr(stringLiteral: string)
+
+    let parsedRegistrations = functionCall.getRegistrations()
+    XCTAssertEqual(parsedRegistrations.count, registrations.count, file: file, line: line)
+    XCTAssertEqual(parsedRegistrations, registrations, file: file, line: line)
+}
+
+/// Assert that no registrations exist within the string.
+private func assertNoRegistrationsString(
     _ string: String,
     message: String = "",
     file: StaticString = #filePath, line: UInt = #line
 ) {
     let functionCall = FunctionCallExpr(stringLiteral: string)
-    let registration = functionCall.getRegistration()
-    XCTAssertNil(registration, message, file: file, line: line)
+    let registrations = functionCall.getRegistrations()
+    XCTAssertEqual(registrations.count, 0, message, file: file, line: line)
 }

--- a/Tests/KnitCodeGenTests/TypeSafetySourceFileTests.swift
+++ b/Tests/KnitCodeGenTests/TypeSafetySourceFileTests.swift
@@ -13,10 +13,11 @@ final class TypeSafetySourceFileTests: XCTestCase {
             imports: [ImportDeclSyntax("import Swinject")],
             extensionTarget: "Resolve",
             registrations: [
-                .init(service: "ServiceA", name: nil, accessLevel: .internal),
-                .init(service: "ServiceB", name: "name", accessLevel: .internal),
-                .init(service: "ServiceB", name: "otherName", accessLevel: .internal),
-                .init(service: "ServiceC", name: nil, accessLevel: .hidden), // No resolver is created
+                .init(service: "ServiceA", name: nil, accessLevel: .internal, isForwarded: false),
+                .init(service: "ServiceB", name: "name", accessLevel: .internal, isForwarded: false),
+                .init(service: "ServiceB", name: "otherName", accessLevel: .internal, isForwarded: false),
+                .init(service: "ServiceC", name: nil, accessLevel: .hidden, isForwarded: false), // No resolver is created
+                .init(service: "ServiceD", name: nil, accessLevel: .public, isForwarded: true),
             ]
         )
 
@@ -34,6 +35,9 @@ final class TypeSafetySourceFileTests: XCTestCase {
         extension Resolve {
             func callAsFunction() -> ServiceA {
                 self.resolve(ServiceA.self)!
+            }
+            public func callAsFunction() -> ServiceD {
+                self.resolve(ServiceD.self)!
             }
             func callAsFunction(named: ModuleAssembly.ServiceB_ResolutionKey) -> ServiceB {
                 self.resolve(ServiceB.self, name: named.rawValue)!

--- a/Tests/KnitCodeGenTests/UnitTestSourceFileTests.swift
+++ b/Tests/KnitCodeGenTests/UnitTestSourceFileTests.swift
@@ -12,10 +12,10 @@ final class UnitTestSourceFileTests: XCTestCase {
             importDecls: [ImportDeclSyntax("import Swinject")],
             setupCodeBlock: nil,
             registrations: [
-                .init(service: "ServiceA", name: nil, accessLevel: .internal),
-                .init(service: "ServiceB", name: "name", accessLevel: .internal),
-                .init(service: "ServiceB", name: "otherName", accessLevel: .internal),
-                .init(service: "ServiceC", name: nil, accessLevel: .hidden),
+                .init(service: "ServiceA", name: nil, accessLevel: .internal, isForwarded: false),
+                .init(service: "ServiceB", name: "name", accessLevel: .internal, isForwarded: false),
+                .init(service: "ServiceB", name: "otherName", accessLevel: .internal, isForwarded: true),
+                .init(service: "ServiceC", name: nil, accessLevel: .hidden, isForwarded: false),
             ]
         )
 


### PR DESCRIPTION
Add type safety and unit test generation support for forwarded registrations using `.implements()`.

Also includes support for named forwards `.implements(Type.self, name: “bar”)`, as well as the `// @digen public` and `// @digen hidden` directives.