### PR TITLE
Support ServiceCollections in KnitCodeGen

### DIFF
--- a/Sources/KnitCodeGen/AssemblyParsing.swift
+++ b/Sources/KnitCodeGen/AssemblyParsing.swift
@@ -29,6 +29,7 @@ func parseSyntaxTree(_ syntaxTree: SyntaxProtocol, filePath: String? = nil) thro
         syntaxTree: syntaxTree,
         name: name,
         registrations: assemblyFileVisitor.registrations,
+        registrationsIntoCollections: assemblyFileVisitor.registrationsIntoCollections,
         errors: assemblyFileVisitor.registrationErrors,
         imports: assemblyFileVisitor.imports
     )
@@ -45,6 +46,10 @@ private class AssemblyFileVisitor: SyntaxVisitor {
 
     var registrations: [Registration] {
         return classDeclVisitor?.registrations ?? []
+    }
+
+    var registrationsIntoCollections: [RegistrationIntoCollection] {
+        return classDeclVisitor?.registrationsIntoCollections ?? []
     }
 
     var registrationErrors: [Error] {
@@ -85,11 +90,17 @@ private class ClassDeclVisitor: SyntaxVisitor {
 
     /// The registrations that were found in the tree.
     private(set) var registrations = [Registration]()
+
+    /// The registrations into collections that were found in the tree
+    private(set) var registrationsIntoCollections = [RegistrationIntoCollection]()
+
     private(set) var registrationErrors = [Error]()
 
     override func visit(_ node: FunctionCallExprSyntax) -> SyntaxVisitorContinueKind {
         do {
-            registrations.append(contentsOf: try node.getRegistrations())
+            let (registrations, registrationsIntoCollections) = try node.getRegistrations()
+            self.registrations.append(contentsOf: registrations)
+            self.registrationsIntoCollections.append(contentsOf: registrationsIntoCollections)
         } catch {
             registrationErrors.append(error)
         }

--- a/Sources/KnitCodeGen/Configuration.swift
+++ b/Sources/KnitCodeGen/Configuration.swift
@@ -11,6 +11,7 @@ public struct Configuration {
     public var name: String
 
     public var registrations: [Registration]
+    public var registrationsIntoCollections: [RegistrationIntoCollection]
 
     public var errors: [Error]
 
@@ -23,6 +24,7 @@ public struct Configuration {
         syntaxTree: SyntaxProtocol,
         name: String,
         registrations: [Registration],
+        registrationsIntoCollections: [RegistrationIntoCollection],
         errors: [Error],
         imports: [ImportDeclSyntax] = [],
         testConfiguration: TestConfiguration? = nil
@@ -31,6 +33,7 @@ public struct Configuration {
         self.syntaxTree = syntaxTree
         self.name = name
         self.registrations = registrations
+        self.registrationsIntoCollections = registrationsIntoCollections
         self.errors = errors
         self.imports = imports
         self.testConfiguration = testConfiguration
@@ -63,7 +66,8 @@ public extension Configuration {
         return UnitTestSourceFile.make(
             importDecls: sortImports(allImports),
             setupCodeBlock: testConfiguration?.testSetupCodeBlock,
-            registrations: registrations
+            registrations: registrations,
+            registrationsIntoCollections: registrationsIntoCollections
         )
     }
 

--- a/Sources/KnitCodeGen/RegistrationIntoCollection.swift
+++ b/Sources/KnitCodeGen/RegistrationIntoCollection.swift
@@ -1,0 +1,12 @@
+
+/// Represents a single concrete factory registered into a collection
+/// A separate instance will be created for each call to `{auto}registerIntoCollection`
+public struct RegistrationIntoCollection: Equatable {
+
+    public var service: String
+
+    public init(service: String) {
+        self.service = service
+    }
+
+}

--- a/Tests/KnitCodeGenTests/UnitTestSourceFileTests.swift
+++ b/Tests/KnitCodeGenTests/UnitTestSourceFileTests.swift
@@ -18,13 +18,17 @@ final class UnitTestSourceFileTests: XCTestCase {
                 .init(service: "ServiceC", name: nil, accessLevel: .hidden, isForwarded: false),
                 // TODO: Generate test for types with arguments
                 .init(service: "ServiceD", accessLevel: .hidden, arguments: [.init(type: "String")]),
+            ],
+            registrationsIntoCollections: [
+                .init(service: "ServiceD"),
+                .init(service: "ServiceD"),
             ]
         )
 
         //Remote trailing line spaces
         let formattedResult = result.formatted().description.replacingOccurrences(of: ", \n", with: ",\n")
 
-        let expected = """
+        let expected = #"""
 
         // Generated using Knit
         // Do not edit directly!
@@ -40,6 +44,7 @@ final class UnitTestSourceFileTests: XCTestCase {
                 resolver.assertTypeResolves(ServiceB.self, name: "name")
                 resolver.assertTypeResolves(ServiceB.self, name: "otherName")
                 resolver.assertTypeResolves(ServiceC.self)
+                resolver.assertCollectionResolves(ServiceD.self, count: 2)
             }
         }
         private extension Resolver {
@@ -58,8 +63,27 @@ final class UnitTestSourceFileTests: XCTestCase {
                 )
             }
 
+            func assertCollectionResolves < T > (
+                _ type: T.Type,
+                count expectedCount: Int,
+                file: StaticString = #filePath,
+                line: UInt = #line
+            ) {
+                let actualCount = resolveCollection(type).entries.count
+                XCTAssert(
+                    actualCount >= expectedCount,
+                    """
+                    The resolved ServiceCollection<\(type)> did not contain the expected number of services \
+                    (resolved \(actualCount), expected \(expectedCount)).
+                    Make sure your assembler contains a ServiceCollector behavior.
+                    """,
+                    file: file,
+                    line: line
+                )
+            }
+
         }
-        """
+        """#
 
         XCTAssertEqual(formattedResult, expected)
     }


### PR DESCRIPTION
This change updates the unit test codegen to assert on services registered into collections. This guarantees that services registered into collections are able to be resolved. It also updates the type safety codegen to ignore registrations that use `registerIntoCollection` and `autoregisterIntoCollection` since we don't need to generate resolvers for service collections (`resolveCollection(SomeType.self)` is always available).

- [x] rebase after https://github.com/squareup/knit/pull/16/ merges
- [x] point to main