### PR TITLE
Add file and line numbers to knit parsing errors

### DIFF
--- a/Sources/KnitCodeGen/AssemblyParsing.swift
+++ b/Sources/KnitCodeGen/AssemblyParsing.swift
@@ -13,10 +13,10 @@ public func parseAssembly(at path: String) throws -> Configuration {
         throw AssemblyParsingError.syntaxParsingError(error, path: path)
     }
 
-    return try parseSyntaxTree(syntaxTree)
+    return try parseSyntaxTree(syntaxTree, filePath: path)
 }
 
-func parseSyntaxTree(_ syntaxTree: SyntaxProtocol) throws -> Configuration {
+func parseSyntaxTree(_ syntaxTree: SyntaxProtocol, filePath: String? = nil) throws -> Configuration {
     let assemblyFileVisitor = AssemblyFileVisitor()
     assemblyFileVisitor.walk(syntaxTree)
 
@@ -25,6 +25,8 @@ func parseSyntaxTree(_ syntaxTree: SyntaxProtocol) throws -> Configuration {
     }
 
     return Configuration(
+        filePath: filePath,
+        syntaxTree: syntaxTree,
         name: name,
         registrations: assemblyFileVisitor.registrations,
         errors: assemblyFileVisitor.registrationErrors,

--- a/Sources/KnitCodeGen/SyntaxError.swift
+++ b/Sources/KnitCodeGen/SyntaxError.swift
@@ -1,0 +1,9 @@
+// Copyright © Square, Inc. All rights reserved.
+
+import Foundation
+import SwiftSyntax
+
+// An error that is related to a piece of syntax
+protocol SyntaxError {
+    var syntax: SyntaxProtocol { get }
+}


### PR DESCRIPTION
Follow up from https://github.com/squareup/knit/pull/23 to make the warnings show at the correct line. I used the example project to test that it worked as expected. 

I haven't turned the warnings into errors yet, still mulling that one over.

<img width="1217" alt="Screenshot 2023-06-19 at 3 20 19 pm" src="https://github.com/squareup/knit/assets/77594448/97d2a790-060a-4120-84df-d544170da1ae">
