### PR TITLE
Generate unit tests for registrations with arguments

### DIFF
--- a/Sources/KnitCodeGen/Registration.swift
+++ b/Sources/KnitCodeGen/Registration.swift
@@ -26,31 +26,6 @@ public struct Registration: Equatable {
         self.isForwarded = isForwarded
     }
 
-    /// Generate names for each argument based on the type
-    public var namedArguments: [(name: String, type: String)] {
-        var result: [(name: String, type: String)] = []
-        for argument in arguments {
-            let indexID: String
-            if (arguments.filter { $0.resolvedName == argument.resolvedName }).count > 1 {
-                indexID = (result.filter { $0.type == argument.type }.count + 1).description
-            } else {
-                indexID = ""
-            }
-            let name = argument.resolvedName + indexID
-            result.append((name, argument.type))
-        }
-        return result
-    }
-
-    /// Argument names prefixed with the service name. Provides additional collision safety.
-    public var serviceNamedArguments: [(name: String, type: String)] {
-        return namedArguments.map { (name, type) in
-            let serviceName = self.service.prefix(1).lowercased() + self.service.dropFirst()
-            let capitalizedName = name.prefix(1).uppercased() + name.dropFirst()
-            return (serviceName + capitalizedName, type)
-        }
-    }
-
 }
 
 extension Registration {
@@ -61,16 +36,6 @@ extension Registration {
         init(name: String? = nil, type: String) {
             self.name = name
             self.type = type
-        }
-
-        var resolvedName: String {
-            if let name {
-                return name
-            }
-            if type.uppercased() == type {
-                return type.lowercased()
-            }
-            return type.prefix(1).lowercased() + type.dropFirst()
         }
     }
 }

--- a/Sources/KnitCodeGen/TypeSafetySourceFile.swift
+++ b/Sources/KnitCodeGen/TypeSafetySourceFile.swift
@@ -78,7 +78,7 @@ public enum TypeSafetySourceFile {
 
 }
 
-private extension Registration {
+extension Registration {
 
     /// Generate names for each argument based on the type
     func namedArguments() -> [(name: String, type: String)] {

--- a/Sources/KnitCodeGen/UnitTestSourceFile.swift
+++ b/Sources/KnitCodeGen/UnitTestSourceFile.swift
@@ -6,7 +6,8 @@ public enum UnitTestSourceFile {
     public static func make(
         importDecls: [ImportDeclSyntax],
         setupCodeBlock: CodeBlockItemListSyntax?,
-        registrations: [Registration]
+        registrations: [Registration],
+        registrationsIntoCollections: [RegistrationIntoCollection]
     ) -> SourceFileSyntax {
         let withArguments = registrations.filter { !$0.arguments.isEmpty }
         let hasArguments = !withArguments.isEmpty
@@ -45,6 +46,12 @@ public enum UnitTestSourceFile {
                     for registration in registrations {
                         makeAssertCall(registration: registration)
                     }
+
+                    for (service, count) in groupByService(registrationsIntoCollections) {
+                        FunctionCallExprSyntax(
+                            "resolver.assertCollectionResolves(\(raw: service).self, count: \(raw: count))"
+                        )
+                    }
                 }
             }
 
@@ -63,8 +70,21 @@ public enum UnitTestSourceFile {
                 if hasArguments {
                     makeResultAssert()
                 }
+
+                if !groupByService(registrationsIntoCollections).isEmpty {
+                    makeCollectionAssert()
+                }
             }
             // swiftlint:enable line_length
+        }
+    }
+
+    /// Groups the provided registrations by service
+    /// - Returns: A dictionary mapping each service to the number of times it was registered
+    private static func groupByService(_ registrations: [RegistrationIntoCollection]) -> [String: Int] {
+        registrations.reduce(into: [:]) { result, registration in
+            let existingCount = result[registration.service] ?? 0
+            result[registration.service] = existingCount + 1
         }
     }
 
@@ -84,6 +104,30 @@ public enum UnitTestSourceFile {
         } else {
             return FunctionCallExprSyntax("resolver.assertTypeResolves(\(raw: registration.service).self)")
         }
+    }
+
+    private static func makeCollectionAssert() -> FunctionDeclSyntax {
+        let string = #"""
+        func assertCollectionResolves <T> (
+            _ type: T.Type,
+            count expectedCount: Int,
+            file: StaticString = #filePath,
+            line: UInt = #line
+        ) {
+            let actualCount = resolveCollection(type).entries.count
+            XCTAssert(
+                actualCount >= expectedCount,
+                """
+                The resolved ServiceCollection<\(type)> did not contain the expected number of services \
+                (resolved \(actualCount), expected \(expectedCount)).
+                Make sure your assembler contains a ServiceCollector behavior.
+                """,
+                file: file,
+                line: line
+            )
+        }
+        """#
+        return FunctionDeclSyntax(stringLiteral: string)
     }
 
     /// Generate a function to assert that a type can be resolved
@@ -127,7 +171,7 @@ public enum UnitTestSourceFile {
 
     /// Generate code for a struct that contains all of the parameters used to resolve services
     static func makeArgumentStruct(registrations: [Registration]) -> StructDeclSyntax {
-        let fields = registrations.flatMap { $0.serviceNamedArguments }
+        let fields = registrations.flatMap { $0.serviceNamedArguments() }
         var seen: Set<String> = []
         // Make sure duplicate parameters don't get created
         let uniqueFields = fields.filter {
@@ -151,8 +195,21 @@ public enum UnitTestSourceFile {
             fatalError("Should only be called for registrations with arguments")
         }
         let prefix = registration.arguments.count == 1 ? "argument:" : "arguments:"
-        let params = registration.serviceNamedArguments.map { "args.\($0.name)" }.joined(separator: ", ")
+        let params = registration.serviceNamedArguments().map { "args.\($0.name)" }.joined(separator: ", ")
         return "\(prefix) \(params)"
+    }
+
+}
+
+private extension Registration {
+
+    /// Argument names prefixed with the service name. Provides additional collision safety.
+    func serviceNamedArguments() -> [(name: String, type: String)] {
+        return namedArguments().map { (name, type) in
+            let serviceName = self.service.prefix(1).lowercased() + self.service.dropFirst()
+            let capitalizedName = name.prefix(1).uppercased() + name.dropFirst()
+            return (serviceName + capitalizedName, type)
+        }
     }
 
 }


### PR DESCRIPTION
Follow on from https://github.com/squareup/knit/pull/23. Registrations with arguments now generate the required unit tests. When a module contains registrations that include arguments it requires another function `makeArgumentsForTests()` to be implemented alongside `makeAssemblerForTests()`. The return type of this function is a struct containing all the required arguments. This ensures that arguments cannot be missed or forgotten.

I used the code from the example PR to test that the code functioned as expected.