### PR TITLE
Allow assemblies with only collection registrations

### DIFF
--- a/Sources/KnitCodeGen/UnitTestSourceFile.swift
+++ b/Sources/KnitCodeGen/UnitTestSourceFile.swift
@@ -33,7 +33,7 @@ public enum UnitTestSourceFile {
                             """)
                     }
 
-                    if registrations.isEmpty {
+                    if registrations.isEmpty && registrationsIntoCollections.isEmpty {
                         DeclSyntax("let _ = assembler.resolver")
                     } else {
                         DeclSyntax("let resolver = assembler.resolver")


### PR DESCRIPTION
Currently assemblies that only contain registrations into collections don't compile:
```swift
final class KnitDIRegistrationTests: XCTestCase {
    func testRegistrations() {
        // In the test target for your module, please provide a static method that creates a
        // ModuleAssembler instance for testing.
        let assembler = makeAssemblerForTests()
        let _ = assembler.resolver
        resolver.assertCollectionResolves(ClientRouteHandler.self, count: 2)
    }
}
```