### PR TITLE
Add handling for Swinject registrations using closures as arguments

### DIFF
--- a/Example/KnitExample/KnitExampleAssembly.swift
+++ b/Example/KnitExample/KnitExampleAssembly.swift
@@ -22,6 +22,8 @@ final class KnitExampleAssembly: Assembly {
 
         container.autoregister(NamedService.self, name: "name", initializer: NamedService.init)
 
+        container.autoregister(ClosureService.self, argument: (() -> Void).self, initializer: ClosureService.init)
+
         container.autoregisterIntoCollection(ExampleService.self, initializer: ExampleService.init)
     }
 
@@ -44,4 +46,9 @@ final class ExampleArgumentService {
     convenience init(arg: Argument) {
         self.init(string: arg.string)
     }
+}
+
+final class ClosureService {
+
+    init(closure: @escaping (() -> Void)) { }
 }

--- a/Example/KnitExampleTests/TestModuleAssembler.swift
+++ b/Example/KnitExampleTests/TestModuleAssembler.swift
@@ -11,6 +11,7 @@ func makeAssemblerForTests() -> Assembler {
 func makeArgumentsForTests() -> KnitRegistrationTestArguments {
     return .init(
         exampleArgumentServiceArg: "Test",
-        exampleArgumentServiceArgument: .init(string: "Test")
+        exampleArgumentServiceArgument: .init(string: "Test"),
+        closureServiceClosure: {}
     )
 }

--- a/Sources/KnitCodeGen/Registration.swift
+++ b/Sources/KnitCodeGen/Registration.swift
@@ -30,12 +30,28 @@ public struct Registration: Equatable, Codable {
 
 extension Registration {
     public struct Argument: Equatable, Codable {
-        let name: String?
+        let name: Name
         let type: String
 
         init(name: String? = nil, type: String) {
-            self.name = name
+            if let name {
+                self.name = .fixed(name)
+            } else {
+                self.name = .computed
+            }
             self.type = type
+        }
+    }
+
+    public enum Name: Codable, Equatable {
+        case fixed(String)
+        case computed
+
+        var string: String {
+            switch self {
+            case let .fixed(value): return value
+            case .computed: fatalError("Argument must be resolved to a fixed name")
+            }
         }
     }
 }

--- a/Sources/KnitCodeGen/UnitTestSourceFile.swift
+++ b/Sources/KnitCodeGen/UnitTestSourceFile.swift
@@ -171,7 +171,7 @@ public enum UnitTestSourceFile {
         var seen: Set<String> = []
         // Make sure duplicate parameters don't get created
         let uniqueFields = fields.filter {
-            let key = "\($0.0)-\($0.1)"
+            let key = "\($0.name.string)-\($0.type)"
             if seen.contains(key) {
                 return false
             }
@@ -181,7 +181,7 @@ public enum UnitTestSourceFile {
 
         return StructDeclSyntax("struct KnitRegistrationTestArguments") {
             for field in uniqueFields {
-                DeclSyntax("let \(raw: field.0): \(raw: field.1)")
+                DeclSyntax("let \(raw: field.name.string): \(raw: field.type)")
             }
         }
     }
@@ -191,7 +191,7 @@ public enum UnitTestSourceFile {
             fatalError("Should only be called for registrations with arguments")
         }
         let prefix = registration.arguments.count == 1 ? "argument:" : "arguments:"
-        let params = registration.serviceNamedArguments().map { "args.\($0.name)" }.joined(separator: ", ")
+        let params = registration.serviceNamedArguments().map { "args.\($0.name.string)" }.joined(separator: ", ")
         return "\(prefix) \(params)"
     }
 
@@ -200,11 +200,11 @@ public enum UnitTestSourceFile {
 private extension Registration {
 
     /// Argument names prefixed with the service name. Provides additional collision safety.
-    func serviceNamedArguments() -> [(name: String, type: String)] {
-        return namedArguments().map { (name, type) in
+    func serviceNamedArguments() -> [Argument] {
+        return namedArguments().map { arg in
             let serviceName = self.service.prefix(1).lowercased() + self.service.dropFirst()
-            let capitalizedName = name.prefix(1).uppercased() + name.dropFirst()
-            return (serviceName + capitalizedName, type)
+            let capitalizedName = arg.name.string.prefix(1).uppercased() + arg.name.string.dropFirst()
+            return Argument(name: serviceName + capitalizedName, type: arg.type)
         }
     }
 

--- a/Tests/KnitCodeGenTests/RegistrationParsingTests.swift
+++ b/Tests/KnitCodeGenTests/RegistrationParsingTests.swift
@@ -368,6 +368,15 @@ final class RegistrationParsingTests: XCTestCase {
         )
     }
 
+    func testClosureArgument() {
+        assertMultipleRegistrationsString(
+            "container.autoregister(A.self, argument: (() -> Void).self, initializer: A.init)",
+            registrations: [
+                Registration(service: "A", accessLevel: .internal, arguments: [.init(type: "(() -> Void)")]),
+            ]
+        )
+    }
+
     func testArgumentMissingType() {
         // Type of arg can be inferred at build time but cannot be parsed
         let string = """

--- a/Tests/KnitCodeGenTests/TypeSafetySourceFileTests.swift
+++ b/Tests/KnitCodeGenTests/TypeSafetySourceFileTests.swift
@@ -18,6 +18,7 @@ final class TypeSafetySourceFileTests: XCTestCase {
                 .init(service: "ServiceB", name: "otherName", accessLevel: .internal, isForwarded: false),
                 .init(service: "ServiceC", name: nil, accessLevel: .hidden, isForwarded: false), // No resolver is created
                 .init(service: "ServiceD", name: nil, accessLevel: .public, isForwarded: true),
+                .init(service: "ServiceE", name: nil, accessLevel: .public, arguments: [.init(type: "() -> Void")]),
             ]
         )
 
@@ -35,6 +36,9 @@ final class TypeSafetySourceFileTests: XCTestCase {
             }
             public func callAsFunction() -> ServiceD {
                 self.resolve(ServiceD.self)!
+            }
+            public func callAsFunction(closure: @escaping () -> Void) -> ServiceE {
+                self.resolve(ServiceE.self, argument: closure)!
             }
             func callAsFunction(name: ModuleAssembly.ServiceB_ResolutionKey) -> ServiceB {
                 self.resolve(ServiceB.self, name: name.rawValue)!
@@ -129,19 +133,19 @@ final class TypeSafetySourceFileTests: XCTestCase {
     func testArgumentNames() {
         let registration1 = Registration(service: "A", accessLevel: .public, arguments: [.init(type: "String?")])
         XCTAssertEqual(
-            registration1.namedArguments().map { $0.name },
+            registration1.namedArguments().map { $0.name.string },
             ["string"]
         )
 
         let registration2 = Registration(service: "A", accessLevel: .public, arguments: [.init(type: "Service.Argument")])
         XCTAssertEqual(
-            registration2.namedArguments().map { $0.name },
+            registration2.namedArguments().map { $0.name.string },
             ["argument"]
         )
 
         let registration3 = Registration(service: "A", accessLevel: .public, arguments: [.init(type: "Result<String, Error>")])
         XCTAssertEqual(
-            registration3.namedArguments().map { $0.name },
+            registration3.namedArguments().map { $0.name.string },
             ["result"]
         )
 
@@ -151,7 +155,7 @@ final class TypeSafetySourceFileTests: XCTestCase {
             arguments: [.init(type: "[Result<ServerResponse<Any>, Swift.Error>]")]
         )
         XCTAssertEqual(
-            registration4.namedArguments().map { $0.name },
+            registration4.namedArguments().map { $0.name.string },
             ["result"]
         )
 


### PR DESCRIPTION
This requirement came up for a presenter that has a completion closure. I've stuck to just naming the variable `closure` as it's hard to come up with good names based just on a closure type. ie: `() -> Void`, `(String) -> Void`, `() -> Bool`.

The biggest structural change here is that `Registration.Argument` is used in more places because it encapsulates whether the type is a closure.

For now this doesn't handle escaping closures which I think is ok as it will keep consistency that arguments shouldn't be marked as @escaping.