### PR TITLE
Consolidate Argument Name logic

### DIFF
--- a/Sources/KnitCodeGen/Registration.swift
+++ b/Sources/KnitCodeGen/Registration.swift
@@ -41,19 +41,14 @@ extension Registration {
             }
             self.type = type
         }
-    }
 
-    public enum Name: Codable, Equatable {
-        case fixed(String)
-        case computed
-
-        var string: String {
-            switch self {
-            case let .fixed(value): return value
-            case .computed: fatalError("Argument must be resolved to a fixed name")
-            }
+        public enum Name: Codable, Equatable {
+            case fixed(String)
+            case computed
         }
+
     }
+
 }
 
 public enum AccessLevel: String, Codable {

--- a/Sources/KnitCodeGen/TypeSafetySourceFile.swift
+++ b/Sources/KnitCodeGen/TypeSafetySourceFile.swift
@@ -56,7 +56,7 @@ public enum TypeSafetySourceFile {
             return (nil, nil)
         }
         let prefix = registration.arguments.count == 1 ? "argument:" : "arguments:"
-        let input = registration.namedArguments().map { "\($0.name.string): \($0.functionType)" }.joined(separator: ", ")
+        let input = registration.namedArguments().map { "\($0.resolvedName()): \($0.functionType)" }.joined(separator: ", ")
         let usages = registration.namedArguments().map { $0.resolvedName() }.joined(separator: ", ")
         return (input, "\(prefix) \(usages)")
     }
@@ -99,8 +99,9 @@ extension Registration {
 
 }
 
-private extension Registration.Argument {
+extension Registration.Argument {
 
+    /// Determine the name for the Registration Argument.
     func resolvedName() -> String {
         switch name {
         case let .fixed(value):

--- a/Sources/KnitCodeGen/UnitTestSourceFile.swift
+++ b/Sources/KnitCodeGen/UnitTestSourceFile.swift
@@ -171,7 +171,7 @@ public enum UnitTestSourceFile {
         var seen: Set<String> = []
         // Make sure duplicate parameters don't get created
         let uniqueFields = fields.filter {
-            let key = "\($0.name.string)-\($0.type)"
+            let key = "\($0.resolvedName())-\($0.type)"
             if seen.contains(key) {
                 return false
             }
@@ -181,7 +181,7 @@ public enum UnitTestSourceFile {
 
         return StructDeclSyntax("struct KnitRegistrationTestArguments") {
             for field in uniqueFields {
-                DeclSyntax("let \(raw: field.name.string): \(raw: field.type)")
+                DeclSyntax("let \(raw: field.resolvedName()): \(raw: field.type)")
             }
         }
     }
@@ -191,7 +191,7 @@ public enum UnitTestSourceFile {
             fatalError("Should only be called for registrations with arguments")
         }
         let prefix = registration.arguments.count == 1 ? "argument:" : "arguments:"
-        let params = registration.serviceNamedArguments().map { "args.\($0.name.string)" }.joined(separator: ", ")
+        let params = registration.serviceNamedArguments().map { "args.\($0.resolvedName())" }.joined(separator: ", ")
         return "\(prefix) \(params)"
     }
 
@@ -203,7 +203,7 @@ private extension Registration {
     func serviceNamedArguments() -> [Argument] {
         return namedArguments().map { arg in
             let serviceName = self.service.prefix(1).lowercased() + self.service.dropFirst()
-            let capitalizedName = arg.name.string.prefix(1).uppercased() + arg.name.string.dropFirst()
+            let capitalizedName = arg.resolvedName().prefix(1).uppercased() + arg.resolvedName().dropFirst()
             return Argument(name: serviceName + capitalizedName, type: arg.type)
         }
     }

--- a/Tests/KnitCodeGenTests/TypeSafetySourceFileTests.swift
+++ b/Tests/KnitCodeGenTests/TypeSafetySourceFileTests.swift
@@ -133,19 +133,19 @@ final class TypeSafetySourceFileTests: XCTestCase {
     func testArgumentNames() {
         let registration1 = Registration(service: "A", accessLevel: .public, arguments: [.init(type: "String?")])
         XCTAssertEqual(
-            registration1.namedArguments().map { $0.name.string },
+            registration1.namedArguments().map { $0.resolvedName() },
             ["string"]
         )
 
         let registration2 = Registration(service: "A", accessLevel: .public, arguments: [.init(type: "Service.Argument")])
         XCTAssertEqual(
-            registration2.namedArguments().map { $0.name.string },
+            registration2.namedArguments().map { $0.resolvedName() },
             ["argument"]
         )
 
         let registration3 = Registration(service: "A", accessLevel: .public, arguments: [.init(type: "Result<String, Error>")])
         XCTAssertEqual(
-            registration3.namedArguments().map { $0.name.string },
+            registration3.namedArguments().map { $0.resolvedName() },
             ["result"]
         )
 
@@ -155,7 +155,7 @@ final class TypeSafetySourceFileTests: XCTestCase {
             arguments: [.init(type: "[Result<ServerResponse<Any>, Swift.Error>]")]
         )
         XCTAssertEqual(
-            registration4.namedArguments().map { $0.name.string },
+            registration4.namedArguments().map { $0.resolvedName() },
             ["result"]
         )
 


### PR DESCRIPTION
Now we always use the resolved name for the Argument so there is a single way to retrieve the name.