### PR TITLE
Use “identifier” terminology to disambiguate with “name”

### DIFF
--- a/Sources/KnitCodeGen/FunctionCallRegistrationParsing.swift
+++ b/Sources/KnitCodeGen/FunctionCallRegistrationParsing.swift
@@ -154,7 +154,7 @@ private func makeRegistrationFor(
     } else {
         accessLevel = .internal
     }
-    let namedVar = leadingTriviaText.contains("@knit") && leadingTriviaText.contains("named-getter")
+    let identifiedGetter = leadingTriviaText.contains("@knit") && leadingTriviaText.contains("named-getter")
     let name = try getName(arguments: arguments)
 
     return Registration(
@@ -163,7 +163,7 @@ private func makeRegistrationFor(
         accessLevel: accessLevel,
         arguments: registrationArguments,
         isForwarded: isForwarded,
-        namedVar: namedVar
+        identifiedGetter: identifiedGetter
     )
 }
 
@@ -245,10 +245,10 @@ private func getArguments(
         let params = closureParameters.parameterList
         // The first param is the resolver, everything after that is an argument
         return try params[params.index(after: params.startIndex)..<params.endIndex].compactMap { element in
-            guard let name = element.firstName?.text, let type = getArgumentType(arg: element)  else {
+            guard let identifier = element.firstName?.text, let type = getArgumentType(arg: element)  else {
                 throw RegistrationParsingError.missingArgumentType(syntax: element, name: element.firstName?.text ?? "_")
             }
-            return .init(name: name, type: type)
+            return .init(identifier: identifier, type: type)
         }
     }
 

--- a/Sources/KnitCodeGen/Registration.swift
+++ b/Sources/KnitCodeGen/Registration.swift
@@ -2,6 +2,7 @@ public struct Registration: Equatable, Codable {
 
     public var service: String
 
+    /// The resolution name for this Registration, if specified.
     public var name: String?
 
     public var accessLevel: AccessLevel
@@ -12,8 +13,8 @@ public struct Registration: Equatable, Codable {
     /// This registration is forwarded to another service entry.
     public var isForwarded: Bool
 
-    /// This registration should have a named var generated
-    public var namedVar: Bool
+    /// This registration should have an identified getter generated.
+    public var identifiedGetter: Bool
 
     public init(
         service: String,
@@ -21,33 +22,35 @@ public struct Registration: Equatable, Codable {
         accessLevel: AccessLevel,
         arguments: [Argument] = [],
         isForwarded: Bool = false,
-        namedVar: Bool = false
+        identifiedGetter: Bool = false
     ) {
         self.service = service
         self.name = name
         self.accessLevel = accessLevel
         self.arguments = arguments
         self.isForwarded = isForwarded
-        self.namedVar = namedVar
+        self.identifiedGetter = identifiedGetter
     }
 
 }
 
 extension Registration {
+
     public struct Argument: Equatable, Codable {
-        let name: Name
+
+        let identifier: Identifier
         let type: String
 
-        init(name: String? = nil, type: String) {
-            if let name {
-                self.name = .fixed(name)
+        init(identifier: String? = nil, type: String) {
+            if let identifier {
+                self.identifier = .fixed(identifier)
             } else {
-                self.name = .computed
+                self.identifier = .computed
             }
             self.type = type
         }
 
-        public enum Name: Codable, Equatable {
+        public enum Identifier: Codable, Equatable {
             case fixed(String)
             case computed
         }

--- a/Sources/KnitCodeGen/TypeNamer.swift
+++ b/Sources/KnitCodeGen/TypeNamer.swift
@@ -5,7 +5,13 @@ import Foundation
 
 enum TypeNamer {
 
-    static func computedVariableName(type: String) -> String {
+    /**
+     Creates a name for a given Type signature.
+     The resulting name can be safely used as an identifier in Swift (does not use reserved characters).
+
+     See TypeNamerTests unit tests for examples.
+     */
+    static func computedIdentifierName(type: String) -> String {
         let type = sanitizeType(type: type)
         if type.uppercased() == type {
             return type.lowercased()
@@ -36,6 +42,5 @@ enum TypeNamer {
     static func isClosure(type: String) -> Bool {
         return type.contains("->")
     }
-
 
 }

--- a/Sources/KnitCodeGen/UnitTestSourceFile.swift
+++ b/Sources/KnitCodeGen/UnitTestSourceFile.swift
@@ -171,7 +171,7 @@ public enum UnitTestSourceFile {
         var seen: Set<String> = []
         // Make sure duplicate parameters don't get created
         let uniqueFields = fields.filter {
-            let key = "\($0.resolvedName())-\($0.type)"
+            let key = "\($0.resolvedIdentifier())-\($0.type)"
             if seen.contains(key) {
                 return false
             }
@@ -181,7 +181,7 @@ public enum UnitTestSourceFile {
 
         return StructDeclSyntax("struct KnitRegistrationTestArguments") {
             for field in uniqueFields {
-                DeclSyntax("let \(raw: field.resolvedName()): \(raw: field.type)")
+                DeclSyntax("let \(raw: field.resolvedIdentifier()): \(raw: field.type)")
             }
         }
     }
@@ -191,7 +191,7 @@ public enum UnitTestSourceFile {
             fatalError("Should only be called for registrations with arguments")
         }
         let prefix = registration.arguments.count == 1 ? "argument:" : "arguments:"
-        let params = registration.serviceNamedArguments().map { "args.\($0.resolvedName())" }.joined(separator: ", ")
+        let params = registration.serviceNamedArguments().map { "args.\($0.resolvedIdentifier())" }.joined(separator: ", ")
         return "\(prefix) \(params)"
     }
 
@@ -203,8 +203,8 @@ private extension Registration {
     func serviceNamedArguments() -> [Argument] {
         return namedArguments().map { arg in
             let serviceName = self.service.prefix(1).lowercased() + self.service.dropFirst()
-            let capitalizedName = arg.resolvedName().prefix(1).uppercased() + arg.resolvedName().dropFirst()
-            return Argument(name: serviceName + capitalizedName, type: arg.type)
+            let capitalizedName = arg.resolvedIdentifier().prefix(1).uppercased() + arg.resolvedIdentifier().dropFirst()
+            return Argument(identifier: serviceName + capitalizedName, type: arg.type)
         }
     }
 

--- a/Tests/KnitCodeGenTests/RegistrationParsingTests.swift
+++ b/Tests/KnitCodeGenTests/RegistrationParsingTests.swift
@@ -93,7 +93,7 @@ final class RegistrationParsingTests: XCTestCase {
             container.register(A.self) { }
             """,
             registrations: [
-                .init(service: "A", accessLevel: .public, namedVar: true)
+                .init(service: "A", accessLevel: .public, identifiedGetter: true)
             ]
         )
     }
@@ -169,7 +169,7 @@ final class RegistrationParsingTests: XCTestCase {
             }
             """,
             registrations: [
-                Registration(service: "A", accessLevel: .internal, arguments: [.init(name: "arg", type: "String")])
+                Registration(service: "A", accessLevel: .internal, arguments: [.init(identifier: "arg", type: "String")])
             ]
         )
 
@@ -181,7 +181,7 @@ final class RegistrationParsingTests: XCTestCase {
             })
             """,
             registrations: [
-                Registration(service: "A", accessLevel: .internal, arguments: [.init(name: "arg", type: "String")])
+                Registration(service: "A", accessLevel: .internal, arguments: [.init(identifier: "arg", type: "String")])
             ]
         )
 
@@ -197,8 +197,8 @@ final class RegistrationParsingTests: XCTestCase {
                     service: "A",
                     accessLevel: .internal,
                     arguments: [
-                        .init(name: "arg", type: "String"),
-                        .init(name: "arg2", type: "Int"),
+                        .init(identifier: "arg", type: "String"),
+                        .init(identifier: "arg2", type: "Int"),
                     ]
                 )
             ]
@@ -216,8 +216,8 @@ final class RegistrationParsingTests: XCTestCase {
                     service: "A",
                     accessLevel: .internal,
                     arguments: [
-                        .init(name: "arg", type: "String"),
-                        .init(name: "arg2", type: "Int"),
+                        .init(identifier: "arg", type: "String"),
+                        .init(identifier: "arg2", type: "Int"),
                     ]
                 )
             ]
@@ -324,8 +324,8 @@ final class RegistrationParsingTests: XCTestCase {
             .implements(B.self)
             """,
             registrations: [
-                Registration(service: "A", accessLevel: .internal, arguments: [.init(name: "arg", type: "String")]),
-                Registration(service: "B", accessLevel: .internal, arguments: [.init(name: "arg", type: "String")], isForwarded: true)
+                Registration(service: "A", accessLevel: .internal, arguments: [.init(identifier: "arg", type: "String")]),
+                Registration(service: "B", accessLevel: .internal, arguments: [.init(identifier: "arg", type: "String")], isForwarded: true)
             ]
         )
     }
@@ -338,7 +338,7 @@ final class RegistrationParsingTests: XCTestCase {
             }
             """,
             registrations: [
-                Registration(service: "A", accessLevel: .internal, arguments: [.init(name: "arg", type: "A.Argument")]),
+                Registration(service: "A", accessLevel: .internal, arguments: [.init(identifier: "arg", type: "A.Argument")]),
             ]
         )
 
@@ -349,7 +349,7 @@ final class RegistrationParsingTests: XCTestCase {
             }
             """,
             registrations: [
-                Registration(service: "A", accessLevel: .internal, arguments: [.init(name: "arg", type: "Result<String?, Error>")]),
+                Registration(service: "A", accessLevel: .internal, arguments: [.init(identifier: "arg", type: "Result<String?, Error>")]),
             ]
         )
     }
@@ -395,7 +395,7 @@ final class RegistrationParsingTests: XCTestCase {
             }
             """,
             registrations: [
-                Registration(service: "A", accessLevel: .internal, arguments: [.init(name: "arg1", type: "() -> Void")]),
+                Registration(service: "A", accessLevel: .internal, arguments: [.init(identifier: "arg1", type: "() -> Void")]),
             ]
         )
     }

--- a/Tests/KnitCodeGenTests/TypeNamerTests.swift
+++ b/Tests/KnitCodeGenTests/TypeNamerTests.swift
@@ -7,45 +7,45 @@ import XCTest
 
 final class TypeNamerTests: XCTestCase {
 
-    func testTypeNaming() {
-        XCTAssertEqual(
-            TypeNamer.computedVariableName(type: "String"),
-            "string"
+    func testTypeComputedIdentifiers() {
+        assertComputedIdentifier(
+            type: "String",
+            expectedIdentifier: "string"
         )
 
-        XCTAssertEqual(
-            TypeNamer.computedVariableName(type: "URL"),
-            "url"
+        assertComputedIdentifier(
+            type: "URL",
+            expectedIdentifier: "url"
         )
 
-        XCTAssertEqual(
-            TypeNamer.computedVariableName(type: "() -> URL"),
-            "closure"
+        assertComputedIdentifier(
+            type: "() -> URL",
+            expectedIdentifier: "closure"
         )
 
-        XCTAssertEqual(
-            TypeNamer.computedVariableName(type: "MyService"),
-            "myService"
+        assertComputedIdentifier(
+            type: "MyService",
+            expectedIdentifier: "myService"
         )
 
-        XCTAssertEqual(
-            TypeNamer.computedVariableName(type: "Result<String, Error>"),
-            "result"
+        assertComputedIdentifier(
+            type: "Result<String, Error>",
+            expectedIdentifier: "result"
         )
 
-        XCTAssertEqual(
-            TypeNamer.computedVariableName(type: "Result<String, Error>"),
-            "result"
+        assertComputedIdentifier(
+            type: "Result<String, Error>",
+            expectedIdentifier: "result"
         )
 
-        XCTAssertEqual(
-            TypeNamer.computedVariableName(type: "[ServiceA]"),
-            "serviceA"
+        assertComputedIdentifier(
+            type: "[ServiceA]",
+            expectedIdentifier: "serviceA"
         )
 
-        XCTAssertEqual(
-            TypeNamer.computedVariableName(type: "[ServiceA]?"),
-            "serviceA"
+        assertComputedIdentifier(
+            type: "[ServiceA]?",
+            expectedIdentifier: "serviceA"
         )
 
     }
@@ -55,4 +55,18 @@ final class TypeNamerTests: XCTestCase {
         XCTAssertFalse(TypeNamer.isClosure(type: "String"))
     }
 
+}
+
+private func assertComputedIdentifier(
+    type: String,
+    expectedIdentifier: String,
+    file: StaticString = #file,
+    line: UInt = #line
+) {
+    XCTAssertEqual(
+        TypeNamer.computedIdentifierName(type: type),
+        expectedIdentifier,
+        file: file,
+        line: line
+    )
 }

--- a/Tests/KnitCodeGenTests/TypeSafetySourceFileTests.swift
+++ b/Tests/KnitCodeGenTests/TypeSafetySourceFileTests.swift
@@ -17,7 +17,7 @@ final class TypeSafetySourceFileTests: XCTestCase {
                 .init(service: "ServiceB", name: "name", accessLevel: .internal, isForwarded: false),
                 .init(service: "ServiceB", name: "otherName", accessLevel: .internal, isForwarded: false),
                 .init(service: "ServiceC", name: nil, accessLevel: .hidden, isForwarded: false), // No resolver is created
-                .init(service: "ServiceD", name: nil, accessLevel: .public, isForwarded: true, namedVar: true),
+                .init(service: "ServiceD", name: nil, accessLevel: .public, isForwarded: true, identifiedGetter: true),
                 .init(service: "ServiceE", name: nil, accessLevel: .public, arguments: [.init(type: "() -> Void")]),
             ]
         )
@@ -119,7 +119,7 @@ final class TypeSafetySourceFileTests: XCTestCase {
     }
 
     func testRegistrationWithPrenamedArguments() {
-        let registration = Registration(service: "A", accessLevel: .public, arguments: [.init(name: "arg", type: "String")])
+        let registration = Registration(service: "A", accessLevel: .public, arguments: [.init(identifier: "arg", type: "String")])
         XCTAssertEqual(
             TypeSafetySourceFile.makeResolver(
                 registration: registration,
@@ -136,19 +136,19 @@ final class TypeSafetySourceFileTests: XCTestCase {
     func testArgumentNames() {
         let registration1 = Registration(service: "A", accessLevel: .public, arguments: [.init(type: "String?")])
         XCTAssertEqual(
-            registration1.namedArguments().map { $0.resolvedName() },
+            registration1.namedArguments().map { $0.resolvedIdentifier() },
             ["string"]
         )
 
         let registration2 = Registration(service: "A", accessLevel: .public, arguments: [.init(type: "Service.Argument")])
         XCTAssertEqual(
-            registration2.namedArguments().map { $0.resolvedName() },
+            registration2.namedArguments().map { $0.resolvedIdentifier() },
             ["argument"]
         )
 
         let registration3 = Registration(service: "A", accessLevel: .public, arguments: [.init(type: "Result<String, Error>")])
         XCTAssertEqual(
-            registration3.namedArguments().map { $0.resolvedName() },
+            registration3.namedArguments().map { $0.resolvedIdentifier() },
             ["result"]
         )
 
@@ -158,7 +158,7 @@ final class TypeSafetySourceFileTests: XCTestCase {
             arguments: [.init(type: "[Result<ServerResponse<Any>, Swift.Error>]")]
         )
         XCTAssertEqual(
-            registration4.namedArguments().map { $0.resolvedName() },
+            registration4.namedArguments().map { $0.resolvedIdentifier() },
             ["result"]
         )
 

--- a/Tests/KnitCodeGenTests/UnitTestSourceFileTests.swift
+++ b/Tests/KnitCodeGenTests/UnitTestSourceFileTests.swift
@@ -235,7 +235,7 @@ final class UnitTestSourceFileTests: XCTestCase {
     func test_argumentStruct() {
         let result = UnitTestSourceFile.makeArgumentStruct(registrations: [
             Registration(service: "A", accessLevel: .public, arguments: [.init(type: "String")]),
-            Registration(service: "B", accessLevel: .public, arguments: [.init(name: "field", type: "String"), .init(type: "String")]),
+            Registration(service: "B", accessLevel: .public, arguments: [.init(identifier: "field", type: "String"), .init(type: "String")]),
             Registration(service: "A", accessLevel: .public, arguments: [.init(type: "Int"), .init(type: "String")]),
         ])
 


### PR DESCRIPTION
It was confusing to keep track of the different meanings of “name” in our internal usage. I am leaving “name” to refer to Swinject named registrations. For the generated getters I am using the term “identifier” as that is what swift-syntax uses for function/property syntax.