### PR TITLE
Handle named registrations using complex types

### DIFF
--- a/Sources/KnitCodeGen/NamedRegistrationGroup.swift
+++ b/Sources/KnitCodeGen/NamedRegistrationGroup.swift
@@ -25,7 +25,8 @@ struct NamedRegistrationGroup {
     }
 
     var enumName: String {
-        return "\(service)_ResolutionKey"
+        let sanitizedType = TypeNamer.sanitizeType(type: service, keepGenerics: true)
+        return "\(sanitizedType)_ResolutionKey"
     }
 
 }

--- a/Tests/KnitCodeGenTests/NamedRegistrationGroupTests.swift
+++ b/Tests/KnitCodeGenTests/NamedRegistrationGroupTests.swift
@@ -28,4 +28,17 @@ final class NamedRegistrationGroupTests: XCTestCase {
 
     }
 
+    func testComplexEnumNaming() throws {
+        let registrations: [Registration] = [
+            .init(service: "AnyProfileValueProvider<BalanceSnapshot?>", name: "name1", accessLevel: .internal)
+        ]
+
+        let namedGroup = NamedRegistrationGroup.make(from: registrations)[0]
+
+        XCTAssertEqual(
+            namedGroup.enumName,
+            "AnyProfileValueProvider_BalanceSnapshot_ResolutionKey"
+        )
+    }
+
 }

--- a/Tests/KnitCodeGenTests/TypeNamerTests.swift
+++ b/Tests/KnitCodeGenTests/TypeNamerTests.swift
@@ -55,6 +55,23 @@ final class TypeNamerTests: XCTestCase {
         XCTAssertFalse(TypeNamer.isClosure(type: "String"))
     }
 
+    func testSanitizeWithGenerics() {
+        XCTAssertEqual(
+            TypeNamer.sanitizeType(type: "Array<String>", keepGenerics: true),
+            "Array_String"
+        )
+
+        XCTAssertEqual(
+            TypeNamer.sanitizeType(type: "Result<String, Error>", keepGenerics: true),
+            "Result_String_Error"
+        )
+
+        XCTAssertEqual(
+            TypeNamer.sanitizeType(type: "Array<String>", keepGenerics: false),
+            "Array"
+        )
+    }
+
 }
 
 private func assertComputedIdentifier(


### PR DESCRIPTION
Removes invalid characters from types like `AnyProfileValueProvider<BalanceSnapshot?>`