### PR TITLE
Overhaul Getters configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,17 +3,65 @@
 A tool for adding safety features to Swinject.
 Knit parses Swinject code and generates Swift files for type safety and unit testing.
 
-## Registration modifiers
+## `@knit` Comment Commands
 
-For any registration in an assembly it is possible to give knit additional information about how to generate the type safe functions. <br/>
-This is accomplished by adding a comment directly above the registration starting with `// @knit`.
+Knit is designed to consume the Swinject syntax in your Assembly file. However there are some important aspects of
+a registration that are not represented in the Swinject syntax. `@knit` comment commands allow you to configure
+your registrations with that additional information.
 
-The following modifiers are available:
+This is accomplished by adding a comment directly above the registration starting with `// @knit` and then
+followed with the configuration command.
 
-* `public` -> Make the type safe function public (default is internal)
-* `hidden` -> Do not generate any type safe function
-* `named-getter` -> Generate a named function in addition to `callAsFunction`.
+### Registration Visibility
+
+Knit can change the visibility of the generated type-safe accessors.
+The following commands are available:
+
+* `public`: Make the type safe function public (default is internal)
+* `hidden`: Do not generate any type safe function
+
+#### Examples:
+
+Make the generated type-safe accessor `public`:
+```
+// @knit public
+container.register(MyType.self, factory: { /*...*/ })
+```
+
+### Type Safe Getters
+
+One of the core capabilities of Knit is to generate type safe getters/accessors for your registrations.
+There are some additional options to control and configure this behavior.
+
+#### Call as Function Getter
+
+This allows the call site to simply use `resolver()` and 
+Swift will use type inference to match the appropriate registration.
+
+#### Named Getter
+
+In some situations it is helpful to have more control at the call site to specify the registration you would like to
+resolve. 
+For example, this can happen in unit test situations where there might be an alternate "testing" or "fake"
+version of an existing protocol registration.
+Named Getters allow you to write `resolver.myType()` or `resolver.myTypeFake()` to specifically resolve the 
+registration for `MyType` or `MyTypeFake`.
+
+In both situations the method call is type-safe.
+
+#### Commands
+
+The following commands are available:
+* `getter-named`: Generate a named accessor function.
+* `getter-callAsFunction`: Generate `callAsFunction` accessor.
+* Both commands can be included to specify that both accessors should be generated. `// @knit getter-named getter-callAsFunction`
+
+#### Default Setting
+
+By default Knit generates named getters for its type safety. 
 
 ---
 
-[Release guide](Release.md)
+## Release Guide
+
+Located in the [Release.md](Release.md) file.

--- a/Sources/KnitCodeGen/FunctionCallRegistrationParsing.swift
+++ b/Sources/KnitCodeGen/FunctionCallRegistrationParsing.swift
@@ -154,20 +154,21 @@ private func makeRegistrationFor(
     } else {
         accessLevel = .internal
     }
-    let identifiedGetterBoth = leadingTriviaText.contains("@knit") && leadingTriviaText.contains("named-getter")
-    let identifiedGetterOnly = leadingTriviaText.contains("@knit") && leadingTriviaText.contains("named-getter-only")
+    let identifiedGetterOnly = leadingTriviaText.contains("@knit") && leadingTriviaText.contains("getter-named")
+    let callAsFuncOnly =       leadingTriviaText.contains("@knit") && leadingTriviaText.contains("getter-callAsFunction")
     let name = try getName(arguments: arguments)
 
-    let identifiedGetter: Registration.IdentifiedGetter
-    switch (identifiedGetterBoth, identifiedGetterOnly) {
+    let getterConfig: Registration.GetterConfig
+    switch (identifiedGetterOnly, callAsFuncOnly) {
     case (false, false):
-        identifiedGetter = .off
+        // Use the default
+        getterConfig = .default
     case (true, false):
-        identifiedGetter = .both
+        getterConfig = .identifiedGetter
     case (false, true):
-        fatalError("This case never hit because the string 'named-getter-only' matches both")
+        getterConfig = .callAsFunction
     case (true, true):
-        identifiedGetter = .identifiedGetterOnly
+        getterConfig = .both
     }
 
     return Registration(
@@ -176,7 +177,7 @@ private func makeRegistrationFor(
         accessLevel: accessLevel,
         arguments: registrationArguments,
         isForwarded: isForwarded,
-        identifiedGetter: identifiedGetter
+        getterConfig: getterConfig
     )
 }
 

--- a/Sources/KnitCodeGen/Registration.swift
+++ b/Sources/KnitCodeGen/Registration.swift
@@ -13,8 +13,8 @@ public struct Registration: Equatable, Codable {
     /// This registration is forwarded to another service entry.
     public var isForwarded: Bool
 
-    /// This registration's identified getter setting.
-    public var identifiedGetter: IdentifiedGetter
+    /// This registration's getter setting.
+    public var getterConfig: GetterConfig
 
     public init(
         service: String,
@@ -22,14 +22,14 @@ public struct Registration: Equatable, Codable {
         accessLevel: AccessLevel,
         arguments: [Argument] = [],
         isForwarded: Bool = false,
-        identifiedGetter: IdentifiedGetter = .off
+        getterConfig: GetterConfig = .default
     ) {
         self.service = service
         self.name = name
         self.accessLevel = accessLevel
         self.arguments = arguments
         self.isForwarded = isForwarded
-        self.identifiedGetter = identifiedGetter
+        self.getterConfig = getterConfig
     }
 
 }
@@ -57,13 +57,16 @@ extension Registration {
 
     }
 
-    public enum IdentifiedGetter: Codable {
-        /// No identified getter, only the `callAsFunction()` accessor is generated.
-        case off
+    public enum GetterConfig: Codable {
+        /// Only the `callAsFunction()` accessor is generated.
+        case callAsFunction
+        /// Only the identified getter is generated.
+        case identifiedGetter
         /// Both the identified getter and the `callAsFunction()` accessors are generated.
         case both
-        /// Only the identified getter is generated.
-        case identifiedGetterOnly
+
+        /// Centralized control of the default behavior.
+        public static var `default`: GetterConfig = .identifiedGetter
     }
 
 }

--- a/Tests/KnitCodeGenTests/RegistrationParsingTests.swift
+++ b/Tests/KnitCodeGenTests/RegistrationParsingTests.swift
@@ -86,24 +86,34 @@ final class RegistrationParsingTests: XCTestCase {
         )
     }
 
-    func testIdentifiedGetterRegistrations() throws {
+    func testGetterConfigRegistrations() throws {
         assertMultipleRegistrationsString(
             """
-            // @knit public named-getter
+            // @knit public getter-named
             container.register(A.self) { }
             """,
             registrations: [
-                .init(service: "A", accessLevel: .public, identifiedGetter: .both)
+                .init(service: "A", accessLevel: .public, getterConfig: .identifiedGetter)
             ]
         )
 
         assertMultipleRegistrationsString(
             """
-            // @knit public named-getter-only
+            // @knit public getter-callAsFunction
             container.register(A.self) { }
             """,
             registrations: [
-                .init(service: "A", accessLevel: .public, identifiedGetter: .identifiedGetterOnly)
+                .init(service: "A", accessLevel: .public, getterConfig: .callAsFunction)
+            ]
+        )
+
+        assertMultipleRegistrationsString(
+            """
+            // @knit public getter-named getter-callAsFunction
+            container.register(A.self) { }
+            """,
+            registrations: [
+                .init(service: "A", accessLevel: .public, getterConfig: .both)
             ]
         )
     }

--- a/Tests/KnitCodeGenTests/TypeSafetySourceFileTests.swift
+++ b/Tests/KnitCodeGenTests/TypeSafetySourceFileTests.swift
@@ -17,9 +17,9 @@ final class TypeSafetySourceFileTests: XCTestCase {
                 .init(service: "ServiceB", name: "name", accessLevel: .internal, isForwarded: false),
                 .init(service: "ServiceB", name: "otherName", accessLevel: .internal, isForwarded: false),
                 .init(service: "ServiceC", name: nil, accessLevel: .hidden, isForwarded: false), // No resolver is created
-                .init(service: "ServiceD", name: nil, accessLevel: .public, isForwarded: true, identifiedGetter: .both),
+                .init(service: "ServiceD", name: nil, accessLevel: .public, isForwarded: true, getterConfig: .both),
                 .init(service: "ServiceE", name: nil, accessLevel: .public, arguments: [.init(type: "() -> Void")]),
-                .init(service: "ServiceF", name: nil, accessLevel: .public, identifiedGetter: .identifiedGetterOnly),
+                .init(service: "ServiceF", name: nil, accessLevel: .public, getterConfig: .callAsFunction),
             ]
         )
 
@@ -32,23 +32,23 @@ final class TypeSafetySourceFileTests: XCTestCase {
         // The correct resolution of each of these types is enforced by a matching automated unit test
         // If a type registration is missing or broken then the automated tests will fail for that PR
         extension Resolve {
-            func callAsFunction() -> ServiceA {
+            func serviceA() -> ServiceA {
                 self.resolve(ServiceA.self)!
-            }
-            public func callAsFunction() -> ServiceD {
-                self.resolve(ServiceD.self)!
-            }
-            public func callAsFunction(closure: @escaping () -> Void) -> ServiceE {
-                self.resolve(ServiceE.self, argument: closure)!
-            }
-            func callAsFunction(name: ModuleAssembly.ServiceB_ResolutionKey) -> ServiceB {
-                self.resolve(ServiceB.self, name: name.rawValue)!
             }
             public func serviceD() -> ServiceD {
                 self.resolve(ServiceD.self)!
             }
-            public func serviceF() -> ServiceF {
+            public func serviceE(closure: @escaping () -> Void) -> ServiceE {
+                self.resolve(ServiceE.self, argument: closure)!
+            }
+            public func callAsFunction() -> ServiceD {
+                self.resolve(ServiceD.self)!
+            }
+            public func callAsFunction() -> ServiceF {
                 self.resolve(ServiceF.self)!
+            }
+            func serviceB(name: ModuleAssembly.ServiceB_ResolutionKey) -> ServiceB {
+                self.resolve(ServiceB.self, name: name.rawValue)!
             }
         }
         extension ModuleAssembly {


### PR DESCRIPTION
This changes the default behavior to generate identified getters, and also updates the command names to be more clear.