### PR TITLE
Add parameter to name-getters to allow customisation

### DIFF
--- a/Example/KnitExample/KnitExampleAssembly.swift
+++ b/Example/KnitExample/KnitExampleAssembly.swift
@@ -9,10 +9,10 @@ final class KnitExampleAssembly: Assembly {
     func assemble(container: Container) {
         container.addBehavior(ServiceCollector())
 
-        // @knit named-getter
+        // @knit getter-named
         container.autoregister(ExampleService.self, initializer: ExampleService.init)
 
-        // @knit named-getter
+        // @knit getter-named("example")
         container.register(ExampleArgumentService.self) { (_, arg: String) in
             ExampleArgumentService.init(string: arg)
         }

--- a/Sources/KnitCodeGen/FunctionCallRegistrationParsing.swift
+++ b/Sources/KnitCodeGen/FunctionCallRegistrationParsing.swift
@@ -151,7 +151,14 @@ private func makeRegistrationFor(
 
     let registrationText = firstParam.base!.withoutTrivia().description
     let name = try getName(arguments: arguments)
-    let directives = KnitDirectives.parse(leadingTrivia: leadingTrivia)
+    let directives = try KnitDirectives.parse(leadingTrivia: leadingTrivia)
+
+    var getterConfig: Set<GetterConfig> = GetterConfig.default
+    if !directives.getterConfig.isEmpty {
+        getterConfig = directives.getterConfig
+    } else if !defaultDirectives.getterConfig.isEmpty {
+        getterConfig = defaultDirectives.getterConfig
+    }
 
     return Registration(
         service: registrationText,
@@ -159,7 +166,7 @@ private func makeRegistrationFor(
         accessLevel: directives.accessLevel ?? defaultDirectives.accessLevel ?? .default,
         arguments: registrationArguments,
         isForwarded: isForwarded,
-        getterConfig: directives.getterConfig ?? defaultDirectives.getterConfig ?? .default
+        getterConfig: getterConfig
     )
 }
 

--- a/Sources/KnitCodeGen/Registration.swift
+++ b/Sources/KnitCodeGen/Registration.swift
@@ -14,7 +14,7 @@ public struct Registration: Equatable, Codable {
     public var isForwarded: Bool
 
     /// This registration's getter setting.
-    public var getterConfig: GetterConfig
+    public var getterConfig: Set<GetterConfig>
 
     public init(
         service: String,
@@ -22,7 +22,7 @@ public struct Registration: Equatable, Codable {
         accessLevel: AccessLevel,
         arguments: [Argument] = [],
         isForwarded: Bool = false,
-        getterConfig: GetterConfig = .default
+        getterConfig: Set<GetterConfig> = GetterConfig.default
     ) {
         self.service = service
         self.name = name

--- a/Tests/KnitCodeGenTests/AssemblyParsingTests.swift
+++ b/Tests/KnitCodeGenTests/AssemblyParsingTests.swift
@@ -103,8 +103,8 @@ final class AssemblyParsingTests: XCTestCase {
         XCTAssertEqual(
             config.registrations,
             [
-                .init(service: "A", accessLevel: .public, getterConfig: .identifiedGetter),
-                .init(service: "B", accessLevel: .internal, getterConfig: .callAsFunction)
+                .init(service: "A", accessLevel: .public, getterConfig: [.identifiedGetter(nil)]),
+                .init(service: "B", accessLevel: .internal, getterConfig: [.callAsFunction])
             ]
         )
     }

--- a/Tests/KnitCodeGenTests/KnitDirectivesTests.swift
+++ b/Tests/KnitCodeGenTests/KnitDirectivesTests.swift
@@ -1,0 +1,80 @@
+//  Created by Alexander skorulis on 28/7/2023.
+
+@testable import KnitCodeGen
+import SwiftSyntax
+import XCTest
+
+final class KnitDirectivesTests: XCTestCase {
+
+    func testAccessLevel() throws {
+        XCTAssertEqual(
+            try parse(" @knit public"),
+            .init(accessLevel: .public, getterConfig: [])
+        )
+
+        XCTAssertEqual(
+            try parse("@knit internal"),
+            .init(accessLevel: .internal, getterConfig: [])
+        )
+
+        XCTAssertEqual(
+            try parse("@knit hidden"),
+            .init(accessLevel: .hidden, getterConfig: [])
+        )
+    }
+
+    func testKnitPrefix() {
+        XCTAssertEqual(
+            try parse("// @knit public"),
+            .init(accessLevel: .public, getterConfig: [])
+        )
+
+        XCTAssertEqual(
+            try parse("knit public"),
+            .empty
+        )
+
+        XCTAssertEqual(
+            try parse("public @knit"),
+            .empty
+        )
+
+        XCTAssertEqual(
+            try parse("informational comment"),
+            .empty
+        )
+    }
+
+    func testGetterConfig() {
+        XCTAssertEqual(
+            try parse("// @knit getter-named"),
+            .init(accessLevel: nil, getterConfig: [.identifiedGetter(nil)])
+        )
+
+        XCTAssertEqual(
+            try parse("// @knit getter-named(\"customName\")"),
+            .init(accessLevel: nil, getterConfig: [.identifiedGetter("customName")])
+        )
+
+        XCTAssertEqual(
+            try parse("// @knit getter-callAsFunction"),
+            .init(accessLevel: nil, getterConfig: [.callAsFunction])
+        )
+
+        XCTAssertEqual(
+            try parse("// @knit getter-callAsFunction getter-named"),
+            .init(accessLevel: nil, getterConfig: [.identifiedGetter(nil), .callAsFunction])
+        )
+
+        XCTAssertEqual(
+            try parse("// @knit getter-callAsFunction getter-named"),
+            .init(accessLevel: nil, getterConfig: [.identifiedGetter(nil), .callAsFunction])
+        )
+    }
+
+    private func parse(_ comment: String) throws -> KnitDirectives {
+        let trivia = Trivia(pieces: [.lineComment(comment)])
+        return try KnitDirectives.parse(leadingTrivia: trivia)
+    }
+
+}

--- a/Tests/KnitCodeGenTests/RegistrationParsingTests.swift
+++ b/Tests/KnitCodeGenTests/RegistrationParsingTests.swift
@@ -93,7 +93,7 @@ final class RegistrationParsingTests: XCTestCase {
             container.register(A.self) { }
             """,
             registrations: [
-                .init(service: "A", accessLevel: .public, getterConfig: .identifiedGetter)
+                .init(service: "A", accessLevel: .public, getterConfig: [.identifiedGetter(nil)])
             ]
         )
 
@@ -103,7 +103,7 @@ final class RegistrationParsingTests: XCTestCase {
             container.register(A.self) { }
             """,
             registrations: [
-                .init(service: "A", accessLevel: .public, getterConfig: .callAsFunction)
+                .init(service: "A", accessLevel: .public, getterConfig: [.callAsFunction])
             ]
         )
 
@@ -113,7 +113,7 @@ final class RegistrationParsingTests: XCTestCase {
             container.register(A.self) { }
             """,
             registrations: [
-                .init(service: "A", accessLevel: .public, getterConfig: .both)
+                .init(service: "A", accessLevel: .public, getterConfig: GetterConfig.both)
             ]
         )
     }

--- a/Tests/KnitCodeGenTests/TypeSafetySourceFileTests.swift
+++ b/Tests/KnitCodeGenTests/TypeSafetySourceFileTests.swift
@@ -17,9 +17,9 @@ final class TypeSafetySourceFileTests: XCTestCase {
                 .init(service: "ServiceB", name: "name", accessLevel: .internal, isForwarded: false),
                 .init(service: "ServiceB", name: "otherName", accessLevel: .internal, isForwarded: false),
                 .init(service: "ServiceC", name: nil, accessLevel: .hidden, isForwarded: false), // No resolver is created
-                .init(service: "ServiceD", name: nil, accessLevel: .public, isForwarded: true, getterConfig: .both),
+                .init(service: "ServiceD", name: nil, accessLevel: .public, isForwarded: true, getterConfig: GetterConfig.both),
                 .init(service: "ServiceE", name: nil, accessLevel: .public, arguments: [.init(type: "() -> Void")]),
-                .init(service: "ServiceF", name: nil, accessLevel: .public, getterConfig: .identifiedGetter),
+                .init(service: "ServiceF", name: nil, accessLevel: .public, getterConfig: [GetterConfig.identifiedGetter(nil)]),
             ]
         )
 
@@ -32,20 +32,20 @@ final class TypeSafetySourceFileTests: XCTestCase {
         // The correct resolution of each of these types is enforced by a matching automated unit test
         // If a type registration is missing or broken then the automated tests will fail for that PR
         extension Resolve {
-            public func serviceD() -> ServiceD {
-                self.resolve(ServiceD.self)!
-            }
-            public func serviceF() -> ServiceF {
-                self.resolve(ServiceF.self)!
-            }
             func callAsFunction() -> ServiceA {
                 self.resolve(ServiceA.self)!
             }
             public func callAsFunction() -> ServiceD {
                 self.resolve(ServiceD.self)!
             }
+            public func serviceD() -> ServiceD {
+                self.resolve(ServiceD.self)!
+            }
             public func callAsFunction(closure: @escaping () -> Void) -> ServiceE {
                 self.resolve(ServiceE.self, argument: closure)!
+            }
+            public func serviceF() -> ServiceF {
+                self.resolve(ServiceF.self)!
             }
             func callAsFunction(name: ModuleAssembly.ServiceB_ResolutionKey) -> ServiceB {
                 self.resolve(ServiceB.self, name: name.rawValue)!


### PR DESCRIPTION
This does a few things all at once.

1. Allows `getter-named("myService")` comment syntax to customise the name. 
2. Enforces that comments start with `@knit` instead of containing `@knit`
3. Enforces that all parts of our comments are parseable. Any spelling mistakes will be raised as errors.
4. Adds direct tests for KnitDirectives.

I couldn't get the errors to have exact line numbers because Trivia doesn't conform to SyntaxProtocol.