### PR TITLE
Nest `makeAssemblerForTests` under the scope of the Assembly

### DIFF
--- a/Example/KnitExampleTests/TestModuleAssembler.swift
+++ b/Example/KnitExampleTests/TestModuleAssembler.swift
@@ -4,15 +4,18 @@ import Foundation
 import Knit
 @testable import KnitExample
 
-func makeAssemblerForTests() -> Assembler {
-    Assembler([KnitExampleAssembly()])
-}
+extension KnitExampleAssembly {
+    static func makeAssemblerForTests() -> Assembler {
+        Assembler([KnitExampleAssembly()])
+    }
 
-func makeArgumentsForTests() -> KnitRegistrationTestArguments {
-    return .init(
-        exampleArgumentServiceArg: "Test",
-        exampleArgumentServiceArgument: .init(string: "Test"),
-        closureServiceClosure: {},
-        closureServiceArg1: {}
-    )
+    static func makeArgumentsForTests() -> KnitRegistrationTestArguments {
+        return .init(
+            exampleArgumentServiceArg: "Test",
+            exampleArgumentServiceArgument: .init(string: "Test"),
+            closureServiceClosure: {},
+            closureServiceArg1: {}
+        )
+    }
+
 }

--- a/Sources/KnitCodeGen/Configuration.swift
+++ b/Sources/KnitCodeGen/Configuration.swift
@@ -49,6 +49,7 @@ public extension Configuration {
         allImports.append("import XCTest")
 
         return UnitTestSourceFile.make(
+            assemblyName: "\(name)Assembly",
             importDecls: sortImports(allImports),
             registrations: registrations,
             registrationsIntoCollections: registrationsIntoCollections

--- a/Sources/KnitCodeGen/UnitTestSourceFile.swift
+++ b/Sources/KnitCodeGen/UnitTestSourceFile.swift
@@ -4,6 +4,7 @@ import SwiftSyntaxBuilder
 public enum UnitTestSourceFile {
 
     public static func make(
+        assemblyName: String,
         importDecls: [ImportDeclSyntax],
         registrations: [Registration],
         registrationsIntoCollections: [RegistrationIntoCollection]
@@ -22,14 +23,14 @@ public enum UnitTestSourceFile {
                     DeclSyntax("""
                         // In the test target for your module, please provide a static method that creates a
                         // ModuleAssembler instance for testing.
-                        let assembler = makeAssemblerForTests()
+                        let assembler = \(raw: assemblyName).makeAssemblerForTests()
                         """)
 
                     if hasArguments {
                         DeclSyntax("""
                             // In the test target for your module, please provide a static method that provides
                             // an instance of KnitRegistrationTestArguments
-                            let args: KnitRegistrationTestArguments = makeArgumentsForTests()
+                            let args: KnitRegistrationTestArguments = \(raw: assemblyName).makeArgumentsForTests()
                             """)
                     }
 

--- a/Tests/KnitCodeGenTests/UnitTestSourceFileTests.swift
+++ b/Tests/KnitCodeGenTests/UnitTestSourceFileTests.swift
@@ -9,6 +9,7 @@ final class UnitTestSourceFileTests: XCTestCase {
 
     func test_generation() {
         let result = UnitTestSourceFile.make(
+            assemblyName: "MyModuleAssembly",
             importDecls: [ImportDeclSyntax("import Swinject")],
             registrations: [
                 .init(service: "ServiceA", name: nil, accessLevel: .internal, isForwarded: false),
@@ -36,10 +37,10 @@ final class UnitTestSourceFileTests: XCTestCase {
             func testRegistrations() {
                 // In the test target for your module, please provide a static method that creates a
                 // ModuleAssembler instance for testing.
-                let assembler = makeAssemblerForTests()
+                let assembler = MyModuleAssembly.makeAssemblerForTests()
                 // In the test target for your module, please provide a static method that provides
                 // an instance of KnitRegistrationTestArguments
-                let args: KnitRegistrationTestArguments = makeArgumentsForTests()
+                let args: KnitRegistrationTestArguments = MyModuleAssembly.makeArgumentsForTests()
                 let resolver = assembler.resolver
                 resolver.assertTypeResolves(ServiceA.self)
                 resolver.assertTypeResolves(ServiceB.self, name: "name")
@@ -104,6 +105,7 @@ final class UnitTestSourceFileTests: XCTestCase {
 
     func test_generation_emptyRegistrations() {
         let result = UnitTestSourceFile.make(
+            assemblyName: "MyModuleAssembly",
             importDecls: [ImportDeclSyntax("import Swinject")],
             registrations: [],
             registrationsIntoCollections: []
@@ -122,7 +124,7 @@ final class UnitTestSourceFileTests: XCTestCase {
             func testRegistrations() {
                 // In the test target for your module, please provide a static method that creates a
                 // ModuleAssembler instance for testing.
-                let assembler = makeAssemblerForTests()
+                let assembler = MyModuleAssembly.makeAssemblerForTests()
                 let _ = assembler.resolver
             }
         }
@@ -135,6 +137,7 @@ final class UnitTestSourceFileTests: XCTestCase {
 
     func test_generation_onlySingleRegistrations() {
         let result = UnitTestSourceFile.make(
+            assemblyName: "MyModuleAssembly",
             importDecls: [ImportDeclSyntax("import Swinject")],
             registrations: [
                 .init(service: "ServiceA", name: nil, accessLevel: .internal, isForwarded: false),
@@ -155,7 +158,7 @@ final class UnitTestSourceFileTests: XCTestCase {
             func testRegistrations() {
                 // In the test target for your module, please provide a static method that creates a
                 // ModuleAssembler instance for testing.
-                let assembler = makeAssemblerForTests()
+                let assembler = MyModuleAssembly.makeAssemblerForTests()
                 let resolver = assembler.resolver
                 resolver.assertTypeResolves(ServiceA.self)
             }
@@ -182,6 +185,7 @@ final class UnitTestSourceFileTests: XCTestCase {
 
     func test_generation_onlyRegistrationsIntoCollections() {
         let result = UnitTestSourceFile.make(
+            assemblyName: "MyModuleAssembly",
             importDecls: [ImportDeclSyntax("import Swinject")],
             registrations: [],
             registrationsIntoCollections: [
@@ -202,7 +206,7 @@ final class UnitTestSourceFileTests: XCTestCase {
             func testRegistrations() {
                 // In the test target for your module, please provide a static method that creates a
                 // ModuleAssembler instance for testing.
-                let assembler = makeAssemblerForTests()
+                let assembler = MyModuleAssembly.makeAssemblerForTests()
                 let resolver = assembler.resolver
                 resolver.assertCollectionResolves(ServiceA.self, count: 1)
             }


### PR DESCRIPTION
This unblocks a single module using multiple assemblies.