### PR TITLE
Handle parsing multiple assemblies simultaneously

### DIFF
--- a/Example/KnitExample.xcodeproj/project.pbxproj
+++ b/Example/KnitExample.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		C40D0D1F2A838D140095AC59 /* KnitExampleUserAssembly.swift in Sources */ = {isa = PBXBuildFile; fileRef = C40D0D1E2A838D140095AC59 /* KnitExampleUserAssembly.swift */; };
 		C43334F32A3FDD43003BA9E3 /* KnitExampleApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = C43334F22A3FDD43003BA9E3 /* KnitExampleApp.swift */; };
 		C43334F52A3FDD43003BA9E3 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C43334F42A3FDD43003BA9E3 /* ContentView.swift */; };
 		C43334F72A3FDD44003BA9E3 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = C43334F62A3FDD44003BA9E3 /* Assets.xcassets */; };
@@ -29,6 +30,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		C40D0D1E2A838D140095AC59 /* KnitExampleUserAssembly.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KnitExampleUserAssembly.swift; sourceTree = "<group>"; };
 		C43334EF2A3FDD43003BA9E3 /* KnitExample.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = KnitExample.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		C43334F22A3FDD43003BA9E3 /* KnitExampleApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KnitExampleApp.swift; sourceTree = "<group>"; };
 		C43334F42A3FDD43003BA9E3 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
@@ -90,6 +92,7 @@
 				C43334F62A3FDD44003BA9E3 /* Assets.xcassets */,
 				C43334F82A3FDD44003BA9E3 /* Preview Content */,
 				C43335052A3FDDD3003BA9E3 /* KnitExampleAssembly.swift */,
+				C40D0D1E2A838D140095AC59 /* KnitExampleUserAssembly.swift */,
 			);
 			path = KnitExample;
 			sourceTree = "<group>";
@@ -236,7 +239,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "/usr/bin/xcrun --sdk macosx swift run knit \\\n--assembly-input-path KnitExample/KnitExampleAssembly.swift \\\n--type-safety-extensions-output-path KnitExample/KnitDITypeSafety.swift \\\n--unit-test-output-path KnitExampleTests/KnitDIRegistrationTests.swift\n";
+			shellScript = "/usr/bin/xcrun --sdk macosx swift run knit \\\n--assembly-input-path KnitExample/KnitExampleAssembly.swift \\\n--assembly-input-path KnitExample/KnitExampleUserAssembly.swift \\\n--type-safety-extensions-output-path KnitExample/KnitDITypeSafety.swift \\\n--unit-test-output-path KnitExampleTests/KnitDIRegistrationTests.swift\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 
@@ -245,6 +248,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				C40D0D1F2A838D140095AC59 /* KnitExampleUserAssembly.swift in Sources */,
 				C43334F52A3FDD43003BA9E3 /* ContentView.swift in Sources */,
 				C43334F32A3FDD43003BA9E3 /* KnitExampleApp.swift in Sources */,
 				C44754F72A3FE7570072333A /* KnitDITypeSafety.swift in Sources */,

--- a/Example/KnitExample/KnitExampleUserAssembly.swift
+++ b/Example/KnitExample/KnitExampleUserAssembly.swift
@@ -1,0 +1,15 @@
+// Copyright © Square, Inc. All rights reserved.
+
+import Foundation
+import Knit
+
+// @knit internal getter-named
+/// An assembly expected to be registered at the user level rather than at the app level
+final class KnitExampleUserAssembly: Assembly {
+
+    func assemble(container: Container) {
+        container.autoregister(UserService.self, initializer: UserService.init)
+    }
+}
+
+final class UserService {}

--- a/Example/KnitExampleTests/TestModuleAssembler.swift
+++ b/Example/KnitExampleTests/TestModuleAssembler.swift
@@ -9,7 +9,7 @@ extension KnitExampleAssembly {
         Assembler([KnitExampleAssembly()])
     }
 
-    static func makeArgumentsForTests() -> KnitRegistrationTestArguments {
+    static func makeArgumentsForTests() -> KnitExampleRegistrationTestArguments {
         return .init(
             exampleArgumentServiceArg: "Test",
             exampleArgumentServiceArgument: .init(string: "Test"),
@@ -18,4 +18,10 @@ extension KnitExampleAssembly {
         )
     }
 
+}
+
+extension KnitExampleUserAssembly {
+    static func makeAssemblerForTests() -> Assembler {
+        Assembler([KnitExampleUserAssembly(), KnitExampleAssembly()])
+    }
 }

--- a/Sources/KnitCodeGen/AssemblyParsing.swift
+++ b/Sources/KnitCodeGen/AssemblyParsing.swift
@@ -2,23 +2,23 @@ import Foundation
 import SwiftSyntax
 import SwiftSyntaxParser
 
-public func parseAssembly(at path: String) throws -> Configuration {
-    let url = URL(fileURLWithPath: path, isDirectory: false)
+public func parseAssemblies(at paths: [String]) throws -> ConfigurationSet {
+    var configs = [Configuration]()
+    for path in paths {
+        let url = URL(fileURLWithPath: path, isDirectory: false)
+        var errorsToPrint = [Error]()
 
-    let syntaxTree: SourceFileSyntax
-    do {
-        syntaxTree = try SwiftSyntaxParser.SyntaxParser.parse(url)
-    } catch {
-        throw AssemblyParsingError.syntaxParsingError(error, path: path)
+        let syntaxTree: SourceFileSyntax
+        do {
+            syntaxTree = try SwiftSyntaxParser.SyntaxParser.parse(url)
+        } catch {
+            throw AssemblyParsingError.syntaxParsingError(error, path: path)
+        }
+        let configuration = try parseSyntaxTree(syntaxTree, errorsToPrint: &errorsToPrint)
+        configs.append(configuration)
+        printErrors(errorsToPrint, filePath: path, syntaxTree: syntaxTree)
     }
-
-    var errorsToPrint = [Error]()
-
-    let configuration = try parseSyntaxTree(syntaxTree, errorsToPrint: &errorsToPrint)
-
-    printErrors(errorsToPrint, filePath: path, syntaxTree: syntaxTree)
-
-    return configuration
+    return ConfigurationSet(assemblies: configs)
 }
 
 func parseSyntaxTree(

--- a/Sources/KnitCodeGen/Configuration.swift
+++ b/Sources/KnitCodeGen/Configuration.swift
@@ -33,11 +33,8 @@ public struct Configuration: Encodable {
 public extension Configuration {
 
     func makeTypeSafetySourceFile() -> SourceFileSyntax {
-        var allImports = imports
-        allImports.append("import Swinject")
         return TypeSafetySourceFile.make(
             assemblyName: "\(name)Assembly",
-            imports: sortImports(allImports),
             extensionTarget: "Resolver",
             registrations: registrations
         )
@@ -49,45 +46,18 @@ public extension Configuration {
         allImports.append("import XCTest")
 
         return UnitTestSourceFile.make(
-            assemblyName: "\(name)Assembly",
-            importDecls: sortImports(allImports),
-            registrations: registrations,
-            registrationsIntoCollections: registrationsIntoCollections
+            configuration: self
         )
     }
 
-    func sortImports(_ imports: [ImportDeclSyntax]) -> [ImportDeclSyntax] {
-        return imports.sorted { import1, import2 in
-            let i1Name = import1.description.replacingOccurrences(of: "@testable ", with: "")
-            let i2Name = import2.description.replacingOccurrences(of: "@testable ", with: "")
-            return i1Name < i2Name
-        }
-    }
-
-    func writeGeneratedFiles(
-        typeSafetyExtensionsOutputPath: String?,
-        unitTestOutputPath: String?
-    ) {
-        if let typeSafetyExtensionsOutputPath {
-            write(
-                sourceFile: makeTypeSafetySourceFile(),
-                to: typeSafetyExtensionsOutputPath
-            )
-        }
-
-        if let unitTestOutputPath {
-            write(
-                sourceFile: makeUnitTestSourceFile(),
-                to: unitTestOutputPath
-            )
-        }
+    var assemblyName: String {
+        "\(name)Assembly"
     }
 
 }
 
-func write(sourceFile: SourceFileSyntax, to path: String) {
-    let data = sourceFile.formatted().description.data(using: .utf8)!
-
+func write(text: String, to path: String) {
+    let data = text.data(using: .utf8)!
     let pathURL = URL(fileURLWithPath: path, isDirectory: false)
 
     do {

--- a/Sources/KnitCodeGen/ConfigurationSet.swift
+++ b/Sources/KnitCodeGen/ConfigurationSet.swift
@@ -1,0 +1,86 @@
+//  Created by Alexander skorulis on 4/8/2023.
+
+import Foundation
+import SwiftSyntax
+
+// Multiple assemblies that are grouped together
+public struct ConfigurationSet {
+
+    public let assemblies: [Configuration]
+
+    public var primaryAssembly: Configuration {
+        // There must be at least 1 assembly and the first is treated as primary
+        return assemblies[0]
+    }
+
+    public func writeGeneratedFiles(
+        typeSafetyExtensionsOutputPath: String?,
+        unitTestOutputPath: String?
+    ) {
+        if let typeSafetyExtensionsOutputPath {
+            write(
+                text: makeTypeSafetySourceFile(),
+                to: typeSafetyExtensionsOutputPath
+            )
+        }
+
+        if let unitTestOutputPath {
+            write(
+                text: makeUnitTestSourceFile(),
+                to: unitTestOutputPath
+            )
+        }
+    }
+
+    var allImports: [ImportDeclSyntax] {
+        let all = assemblies.flatMap { $0.imports }
+        return Array(Set(all))
+    }
+}
+
+public extension ConfigurationSet {
+
+    func makeTypeSafetySourceFile() -> String {
+        var allImports = allImports
+        allImports.append("import Swinject")
+        let header = HeaderSourceFile.make(importDecls: sortImports(allImports), comment: Self.typeSafetyIntro)
+        let body = assemblies.map { $0.makeTypeSafetySourceFile() }
+        let sourceFiles = [header] + body
+        return Self.join(sourceFiles: sourceFiles)
+    }
+
+    func makeUnitTestSourceFile() -> String {
+        var allImports = allImports
+        allImports.append("@testable import \(raw: primaryAssembly.name)")
+        allImports.append("import XCTest")
+        let header = HeaderSourceFile.make(importDecls: sortImports(allImports), comment: nil)
+        let body = assemblies.map { $0.makeUnitTestSourceFile() }
+        let allRegistrations = assemblies.flatMap { $0.registrations }
+        let allRegistrationsIntoCollections = assemblies.flatMap { $0.registrationsIntoCollections }
+        let resolverExtensions = UnitTestSourceFile.resolverExtensions(
+            registrations: allRegistrations,
+            registrationsIntoCollections: allRegistrationsIntoCollections
+        )
+        let sourceFiles = [header] + body + [resolverExtensions]
+        return Self.join(sourceFiles: sourceFiles)
+    }
+
+    private static func join(sourceFiles: [SourceFileSyntax]) -> String {
+        let result = sourceFiles.map { $0.formatted().description }.joined(separator: "\n")
+        return result.replacingOccurrences(of: ", \n", with: ",\n")
+    }
+
+    private func sortImports(_ imports: [ImportDeclSyntax]) -> [ImportDeclSyntax] {
+        return imports.sorted { import1, import2 in
+            let i1Name = import1.description.replacingOccurrences(of: "@testable ", with: "")
+            let i2Name = import2.description.replacingOccurrences(of: "@testable ", with: "")
+            return i1Name < i2Name
+        }
+    }
+
+    private static let typeSafetyIntro = """
+                // The correct resolution of each of these types is enforced by a matching automated unit test
+                // If a type registration is missing or broken then the automated tests will fail for that PR
+                """
+
+}

--- a/Sources/KnitCodeGen/HeaderSourceFile.swift
+++ b/Sources/KnitCodeGen/HeaderSourceFile.swift
@@ -1,0 +1,30 @@
+// Copyright © Square, Inc. All rights reserved.
+
+import Foundation
+import SwiftSyntax
+
+/// Generate the shared headers for source files
+public enum HeaderSourceFile {
+
+    public static func make(
+        importDecls: [ImportDeclSyntax],
+        comment: String?
+    ) -> SourceFileSyntax {
+        let trivia = comment.map {
+            Trivia(pieces: [
+                .newlines(2),
+                .blockComment($0)
+            ])
+        }
+
+        return SourceFileSyntax(
+            leadingTrivia: TriviaProvider.headerTrivia,
+            statementsBuilder:  {
+                for importDecl in importDecls {
+                    importDecl
+                }
+            },
+            trailingTrivia: trivia
+        )
+    }
+}

--- a/Sources/KnitCodeGen/TypeSafetySourceFile.swift
+++ b/Sources/KnitCodeGen/TypeSafetySourceFile.swift
@@ -6,7 +6,6 @@ public enum TypeSafetySourceFile {
 
     public static func make(
         assemblyName: String,
-        imports: [ImportDeclSyntax],
         extensionTarget: String,
         registrations allRegistrations: [Registration]
     ) -> SourceFileSyntax {
@@ -16,14 +15,9 @@ public enum TypeSafetySourceFile {
         }
         let unnamedRegistrations = visibleRegistrations.filter { $0.name == nil }
         let namedGroups = NamedRegistrationGroup.make(from: visibleRegistrations)
-        return SourceFileSyntax(leadingTrivia: TriviaProvider.headerTrivia) {
-            for importItem in imports {
-                importItem
-            }
-
+        return SourceFileSyntax() {
             ExtensionDeclSyntax("""
-                          // The correct resolution of each of these types is enforced by a matching automated unit test
-                          // If a type registration is missing or broken then the automated tests will fail for that PR
+                          // Generated from \(assemblyName)
                           extension \(extensionTarget)
                           """) {
 

--- a/Sources/KnitCommand/KnitCommand.swift
+++ b/Sources/KnitCommand/KnitCommand.swift
@@ -15,7 +15,7 @@ public struct KnitCommand: ParsableCommand {
                   Path to the file location in the current module where the Assembly source is located.
                   For example: `${PODS_TARGET_SRCROOT}/Sources/DI/ModuleNameAssembly.swift`
                   """)
-    var assemblyInputPath: String
+    var assemblyInputPath: [String]
 
     @Option(help: """
                   Path to the file location in the current module where the unit test source should be written.
@@ -37,11 +37,11 @@ public struct KnitCommand: ParsableCommand {
     public init() {}
 
     public func run() throws {
-        let parsedConfig: Configuration
+        let parsedConfig: ConfigurationSet
         do {
-            parsedConfig = try parseAssembly(at: assemblyInputPath)
+            parsedConfig = try parseAssemblies(at: assemblyInputPath)
             if let jsonDataOutputPath {
-                let data = try JSONEncoder().encode(parsedConfig)
+                let data = try JSONEncoder().encode(parsedConfig.assemblies)
                 try data.write(to: URL(fileURLWithPath: jsonDataOutputPath))
             }
         } catch {

--- a/Tests/KnitCodeGenTests/ConfigurationSetTests.swift
+++ b/Tests/KnitCodeGenTests/ConfigurationSetTests.swift
@@ -1,0 +1,167 @@
+//  Created by Alexander skorulis on 8/8/2023.
+
+@testable import KnitCodeGen
+import XCTest
+
+final class ConfigurationSetTests: XCTestCase {
+
+    func testTypeSafetyOutput() {
+        let configSet = ConfigurationSet(assemblies: [Factory.config1, Factory.config2])
+
+        XCTAssertEqual(
+            configSet.makeTypeSafetySourceFile(),
+            """
+
+            // Generated using Knit
+            // Do not edit directly!
+
+            import Swinject
+            import Dependency1
+            import Dependency2
+
+            // The correct resolution of each of these types is enforced by a matching automated unit test
+            // If a type registration is missing or broken then the automated tests will fail for that PR
+
+            // Generated from Module1Assembly
+            extension Resolver {
+                public func callAsFunction() -> Service1 {
+                    self.resolve(Service1.self)!
+                }
+            }
+
+            // Generated from Module2Assembly
+            extension Resolver {
+                func callAsFunction() -> Service2 {
+                    self.resolve(Service2.self)!
+                }
+                func callAsFunction(string: String) -> ArgumentService {
+                    self.resolve(ArgumentService.self, argument: string)!
+                }
+            }
+            """
+        )
+    }
+
+    func testUnitTestOutput() {
+        let configSet = ConfigurationSet(assemblies: [Factory.config1, Factory.config2])
+
+        XCTAssertEqual(
+            configSet.makeUnitTestSourceFile(),
+            #"""
+
+            // Generated using Knit
+            // Do not edit directly!
+
+            @testable import Module1
+            import XCTest
+            import Dependency1
+            import Dependency2
+
+            final class Module1RegistrationTests: XCTestCase {
+                func testRegistrations() {
+                    // In the test target for your module, please provide a static method that creates a
+                    // ModuleAssembler instance for testing.
+                    let assembler = Module1Assembly.makeAssemblerForTests()
+                    let resolver = assembler.resolver
+                    resolver.assertTypeResolves(Service1.self)
+                    resolver.assertCollectionResolves(CollectionService.self, count: 1)
+                }
+            }
+
+            final class Module2RegistrationTests: XCTestCase {
+                func testRegistrations() {
+                    // In the test target for your module, please provide a static method that creates a
+                    // ModuleAssembler instance for testing.
+                    let assembler = Module2Assembly.makeAssemblerForTests()
+                    // In the test target for your module, please provide a static method that provides
+                    // an instance of Module2RegistrationTestArguments
+                    let args: Module2RegistrationTestArguments = Module2Assembly.makeArgumentsForTests()
+                    let resolver = assembler.resolver
+                    resolver.assertTypeResolves(Service2.self)
+                    resolver.assertTypeResolved(resolver.resolve(ArgumentService.self, argument: args.argumentServiceString))
+                }
+            }
+            struct Module2RegistrationTestArguments {
+                let argumentServiceString: String
+            }
+
+            private extension Resolver {
+                func assertTypeResolves < T > (
+                    _ type: T.Type,
+                    name: String? = nil,
+                    file: StaticString = #filePath,
+                    line: UInt = #line
+                ) {
+                    XCTAssertNotNil(
+                        resolve(type, name: name),
+                        "The container did not resolve the type: \(type). Check that this type is registered correctly.",
+                        file: file,
+                        line: line
+                    )
+                }
+                func assertTypeResolved < T > (
+                    _ result: T?,
+                    file: StaticString = #filePath,
+                    line: UInt = #line
+                ) {
+                    XCTAssertNotNil(
+                        result,
+                        "The container did not resolve the type: \(T.self). Check that this type is registered correctly.",
+                        file: file,
+                        line: line
+                    )
+                }
+                func assertCollectionResolves < T > (
+                    _ type: T.Type,
+                    count expectedCount: Int,
+                    file: StaticString = #filePath,
+                    line: UInt = #line
+                ) {
+                    let actualCount = resolveCollection(type).entries.count
+                    XCTAssert(
+                        actualCount >= expectedCount,
+                        """
+                    The resolved ServiceCollection<\(type)> did not contain the expected number of services \
+                    (resolved \(actualCount), expected \(expectedCount)).
+                    Make sure your assembler contains a ServiceCollector behavior.
+                    """,
+                        file: file,
+                        line: line
+                    )
+                }
+            }
+            """#
+        )
+    }
+
+}
+
+private enum Factory {
+
+    static let config1 = Configuration(
+        name: "Module1",
+        registrations: [
+            .init(service: "Service1", accessLevel: .public)
+        ],
+        registrationsIntoCollections: [
+            .init(service: "CollectionService")
+        ],
+        imports: [
+            .init(moduleName: "Dependency1")
+        ]
+    )
+
+    static let config2 = Configuration(
+        name: "Module2",
+        registrations: [
+            .init(service: "Service2", accessLevel: .internal),
+            .init(service: "ArgumentService", accessLevel: .internal, arguments: [.init(type: "String")])
+
+        ],
+        registrationsIntoCollections: [],
+        imports: [
+            .init(moduleName: "Dependency2")
+        ]
+    )
+
+}

--- a/Tests/KnitCodeGenTests/TypeSafetySourceFileTests.swift
+++ b/Tests/KnitCodeGenTests/TypeSafetySourceFileTests.swift
@@ -10,7 +10,6 @@ final class TypeSafetySourceFileTests: XCTestCase {
     func test_generation() {
         let result = TypeSafetySourceFile.make(
             assemblyName: "ModuleAssembly",
-            imports: [ImportDeclSyntax("import Swinject")],
             extensionTarget: "Resolve",
             registrations: [
                 .init(service: "ServiceA", name: nil, accessLevel: .internal, isForwarded: false),
@@ -24,13 +23,8 @@ final class TypeSafetySourceFileTests: XCTestCase {
         )
 
         let expected = """
-
-        // Generated using Knit
-        // Do not edit directly!
-
-        import Swinject
-        // The correct resolution of each of these types is enforced by a matching automated unit test
-        // If a type registration is missing or broken then the automated tests will fail for that PR
+        
+        // Generated from ModuleAssembly
         extension Resolve {
             func callAsFunction() -> ServiceA {
                 self.resolve(ServiceA.self)!

--- a/Tests/KnitCodeGenTests/UnitTestSourceFileTests.swift
+++ b/Tests/KnitCodeGenTests/UnitTestSourceFileTests.swift
@@ -9,7 +9,7 @@ final class UnitTestSourceFileTests: XCTestCase {
 
     func test_generation() {
         let result = UnitTestSourceFile.make(
-            assemblyName: "MyModuleAssembly",
+            name: "MyModule",
             importDecls: [ImportDeclSyntax("import Swinject")],
             registrations: [
                 .init(service: "ServiceA", name: nil, accessLevel: .internal, isForwarded: false),
@@ -29,18 +29,14 @@ final class UnitTestSourceFileTests: XCTestCase {
 
         let expected = #"""
 
-        // Generated using Knit
-        // Do not edit directly!
-
-        import Swinject
-        final class KnitDIRegistrationTests: XCTestCase {
+        final class MyModuleRegistrationTests: XCTestCase {
             func testRegistrations() {
                 // In the test target for your module, please provide a static method that creates a
                 // ModuleAssembler instance for testing.
                 let assembler = MyModuleAssembly.makeAssemblerForTests()
                 // In the test target for your module, please provide a static method that provides
-                // an instance of KnitRegistrationTestArguments
-                let args: KnitRegistrationTestArguments = MyModuleAssembly.makeArgumentsForTests()
+                // an instance of MyModuleRegistrationTestArguments
+                let args: MyModuleRegistrationTestArguments = MyModuleAssembly.makeArgumentsForTests()
                 let resolver = assembler.resolver
                 resolver.assertTypeResolves(ServiceA.self)
                 resolver.assertTypeResolves(ServiceB.self, name: "name")
@@ -50,53 +46,8 @@ final class UnitTestSourceFileTests: XCTestCase {
                 resolver.assertCollectionResolves(ServiceD.self, count: 2)
             }
         }
-        struct KnitRegistrationTestArguments {
+        struct MyModuleRegistrationTestArguments {
             let serviceDString: String
-        }
-        private extension Resolver {
-            func assertTypeResolves < T > (
-                _ type: T.Type,
-                name: String? = nil,
-                file: StaticString = #filePath,
-                line: UInt = #line
-            ) {
-                XCTAssertNotNil(
-                    resolve(type, name: name),
-                    "The container did not resolve the type: \(type). Check that this type is registered correctly.",
-                    file: file,
-                    line: line
-                )
-            }
-            func assertTypeResolved < T > (
-                _ result: T?,
-                file: StaticString = #filePath,
-                line: UInt = #line
-            ) {
-                XCTAssertNotNil(
-                    result,
-                    "The container did not resolve the type: \(T.self). Check that this type is registered correctly.",
-                    file: file,
-                    line: line
-                )
-            }
-            func assertCollectionResolves < T > (
-                _ type: T.Type,
-                count expectedCount: Int,
-                file: StaticString = #filePath,
-                line: UInt = #line
-            ) {
-                let actualCount = resolveCollection(type).entries.count
-                XCTAssert(
-                    actualCount >= expectedCount,
-                    """
-                The resolved ServiceCollection<\(type)> did not contain the expected number of services \
-                (resolved \(actualCount), expected \(expectedCount)).
-                Make sure your assembler contains a ServiceCollector behavior.
-                """,
-                    file: file,
-                    line: line
-                )
-            }
         }
         """#
 
@@ -105,7 +56,7 @@ final class UnitTestSourceFileTests: XCTestCase {
 
     func test_generation_emptyRegistrations() {
         let result = UnitTestSourceFile.make(
-            assemblyName: "MyModuleAssembly",
+            name: "MyModule",
             importDecls: [ImportDeclSyntax("import Swinject")],
             registrations: [],
             registrationsIntoCollections: []
@@ -116,19 +67,13 @@ final class UnitTestSourceFileTests: XCTestCase {
 
         let expected = #"""
 
-        // Generated using Knit
-        // Do not edit directly!
-
-        import Swinject
-        final class KnitDIRegistrationTests: XCTestCase {
+        final class MyModuleRegistrationTests: XCTestCase {
             func testRegistrations() {
                 // In the test target for your module, please provide a static method that creates a
                 // ModuleAssembler instance for testing.
                 let assembler = MyModuleAssembly.makeAssemblerForTests()
                 let _ = assembler.resolver
             }
-        }
-        private extension Resolver {
         }
         """#
 
@@ -137,7 +82,7 @@ final class UnitTestSourceFileTests: XCTestCase {
 
     func test_generation_onlySingleRegistrations() {
         let result = UnitTestSourceFile.make(
-            assemblyName: "MyModuleAssembly",
+            name: "MyModule",
             importDecls: [ImportDeclSyntax("import Swinject")],
             registrations: [
                 .init(service: "ServiceA", name: nil, accessLevel: .internal, isForwarded: false),
@@ -150,32 +95,13 @@ final class UnitTestSourceFileTests: XCTestCase {
 
         let expected = #"""
 
-        // Generated using Knit
-        // Do not edit directly!
-
-        import Swinject
-        final class KnitDIRegistrationTests: XCTestCase {
+        final class MyModuleRegistrationTests: XCTestCase {
             func testRegistrations() {
                 // In the test target for your module, please provide a static method that creates a
                 // ModuleAssembler instance for testing.
                 let assembler = MyModuleAssembly.makeAssemblerForTests()
                 let resolver = assembler.resolver
                 resolver.assertTypeResolves(ServiceA.self)
-            }
-        }
-        private extension Resolver {
-            func assertTypeResolves < T > (
-                _ type: T.Type,
-                name: String? = nil,
-                file: StaticString = #filePath,
-                line: UInt = #line
-            ) {
-                XCTAssertNotNil(
-                    resolve(type, name: name),
-                    "The container did not resolve the type: \(type). Check that this type is registered correctly.",
-                    file: file,
-                    line: line
-                )
             }
         }
         """#
@@ -185,7 +111,7 @@ final class UnitTestSourceFileTests: XCTestCase {
 
     func test_generation_onlyRegistrationsIntoCollections() {
         let result = UnitTestSourceFile.make(
-            assemblyName: "MyModuleAssembly",
+            name: "MyModule",
             importDecls: [ImportDeclSyntax("import Swinject")],
             registrations: [],
             registrationsIntoCollections: [
@@ -198,11 +124,7 @@ final class UnitTestSourceFileTests: XCTestCase {
 
         let expected = #"""
 
-        // Generated using Knit
-        // Do not edit directly!
-
-        import Swinject
-        final class KnitDIRegistrationTests: XCTestCase {
+        final class MyModuleRegistrationTests: XCTestCase {
             func testRegistrations() {
                 // In the test target for your module, please provide a static method that creates a
                 // ModuleAssembler instance for testing.
@@ -211,42 +133,23 @@ final class UnitTestSourceFileTests: XCTestCase {
                 resolver.assertCollectionResolves(ServiceA.self, count: 1)
             }
         }
-        private extension Resolver {
-            func assertCollectionResolves < T > (
-                _ type: T.Type,
-                count expectedCount: Int,
-                file: StaticString = #filePath,
-                line: UInt = #line
-            ) {
-                let actualCount = resolveCollection(type).entries.count
-                XCTAssert(
-                    actualCount >= expectedCount,
-                    """
-                The resolved ServiceCollection<\(type)> did not contain the expected number of services \
-                (resolved \(actualCount), expected \(expectedCount)).
-                Make sure your assembler contains a ServiceCollector behavior.
-                """,
-                    file: file,
-                    line: line
-                )
-            }
-        }
         """#
 
         XCTAssertEqual(formattedResult, expected)
     }
 
     func test_argumentStruct() {
-        let result = UnitTestSourceFile.makeArgumentStruct(registrations: [
+        let registrations = [
             Registration(service: "A", accessLevel: .public, arguments: [.init(type: "String")]),
             Registration(service: "B", accessLevel: .public, arguments: [.init(identifier: "field", type: "String"), .init(type: "String")]),
             Registration(service: "A", accessLevel: .public, arguments: [.init(type: "Int"), .init(type: "String")]),
-        ])
+        ]
+        let result = UnitTestSourceFile.makeArgumentStruct(registrations: registrations, moduleName: "MyModule")
 
         let formattedResult = result.formatted().description.replacingOccurrences(of: ", \n", with: ",\n")
 
         let expected = """
-        struct KnitRegistrationTestArguments {
+        struct MyModuleRegistrationTestArguments {
             let aString: String
             let bField: String
             let bString: String
@@ -299,5 +202,23 @@ final class UnitTestSourceFileTests: XCTestCase {
         let formattedResult = result.formatted().description.replacingOccurrences(of: ", \n", with: ",\n")
         let expected = "resolver.assertTypeResolved(resolver.resolve(A.self, arguments: args.aString1, args.aString2))"
         XCTAssertEqual(formattedResult, expected)
+    }
+}
+
+private extension UnitTestSourceFile {
+
+    static func make(
+        name: String,
+        importDecls: [ImportDeclSyntax],
+        registrations: [Registration],
+        registrationsIntoCollections: [RegistrationIntoCollection]
+    ) -> SourceFileSyntax {
+        let configuration = Configuration(
+            name: name,
+            registrations: registrations,
+            registrationsIntoCollections: registrationsIntoCollections,
+            imports: importDecls
+        )
+        return UnitTestSourceFile.make(configuration: configuration)
     }
 }


### PR DESCRIPTION
This allows `--assembly-input-path` to be used multiple times to have assemblies all generated into single output files. 

This required a few extra places to be named spaced under the assembly they come from. `KnitRegistrationTests` -> `MyModuleRegistrationTests`. This should ultimately make it easier to find the cause when tests fail though it would have been nice to have a single class with multiple test functions.