### PR TITLE
Improve handling of tuple registrations

### DIFF
--- a/Sources/KnitCodeGen/FunctionCallRegistrationParsing.swift
+++ b/Sources/KnitCodeGen/FunctionCallRegistrationParsing.swift
@@ -251,7 +251,11 @@ private func getArguments(
             guard let identifier = element.firstName?.text, let type = getArgumentType(arg: element)  else {
                 throw RegistrationParsingError.missingArgumentType(syntax: element, name: element.firstName?.text ?? "_")
             }
-            return .init(identifier: identifier, type: type)
+            if identifier == "_" {
+                return .init(identifier: nil, type: type)
+            } else {
+                return .init(identifier: identifier, type: type)
+            }
         }
     }
 

--- a/Sources/KnitCodeGen/TypeNamer.swift
+++ b/Sources/KnitCodeGen/TypeNamer.swift
@@ -26,7 +26,7 @@ enum TypeNamer {
             // The naming doesn't work for function types, just return closure
             return "closure"
         }
-        let removedCharacters = CharacterSet(charactersIn: "?[]:& ")
+        let removedCharacters = CharacterSet(charactersIn: "?[]():&, ")
         var type = type.components(separatedBy: removedCharacters).joined(separator: "")
         let regex = try! NSRegularExpression(pattern: "<.*>")
         let nsString = type as NSString

--- a/Tests/KnitCodeGenTests/RegistrationParsingTests.swift
+++ b/Tests/KnitCodeGenTests/RegistrationParsingTests.swift
@@ -242,6 +242,24 @@ final class RegistrationParsingTests: XCTestCase {
                 )
             ]
         )
+
+        // Unused arguments (for test/abstract usages)
+        assertMultipleRegistrationsString(
+            """
+            container.register(A.self, factory: { (_: Resolver, _: String) in
+                A()
+            })
+            """,
+            registrations: [
+                Registration(
+                    service: "A",
+                    accessLevel: .internal,
+                    arguments: [
+                        .init(identifier: nil, type: "String"),
+                    ]
+                )
+            ]
+        )
     }
 
     func testAutoregisterWithArguments() {
@@ -396,6 +414,16 @@ final class RegistrationParsingTests: XCTestCase {
                         .init(type: "Result<Int, Error>"),
                         .init(type: "Optional<Int>"),
                     ]),
+            ]
+        )
+
+        assertMultipleRegistrationsString(
+            """
+            // @knit getter-named
+            container.autoregister((String, Int?).self, initializer: Factory.make)
+            """,
+            registrations: [
+                .init(service: "(String, Int?)", accessLevel: .internal, getterConfig: [.identifiedGetter(nil)])
             ]
         )
     }

--- a/Tests/KnitCodeGenTests/TypeNamerTests.swift
+++ b/Tests/KnitCodeGenTests/TypeNamerTests.swift
@@ -58,6 +58,10 @@ final class TypeNamerTests: XCTestCase {
             expectedIdentifier: "protocolAProtocolB"
         )
 
+        assertComputedIdentifier(
+            type: "(String, Int?)",
+            expectedIdentifier: "stringInt"
+        )
     }
 
     func testClosureDetection() {
@@ -73,7 +77,7 @@ final class TypeNamerTests: XCTestCase {
 
         XCTAssertEqual(
             TypeNamer.sanitizeType(type: "Result<String, Error>", keepGenerics: true),
-            "Result_String_Error"
+            "Result_StringError"
         )
 
         XCTAssertEqual(

--- a/Tests/KnitCodeGenTests/TypeSafetySourceFileTests.swift
+++ b/Tests/KnitCodeGenTests/TypeSafetySourceFileTests.swift
@@ -19,6 +19,7 @@ final class TypeSafetySourceFileTests: XCTestCase {
                 .init(service: "ServiceD", name: nil, accessLevel: .public, isForwarded: true, getterConfig: GetterConfig.both),
                 .init(service: "ServiceE", name: nil, accessLevel: .public, arguments: [.init(type: "() -> Void")]),
                 .init(service: "ServiceF", name: nil, accessLevel: .public, getterConfig: [GetterConfig.identifiedGetter(nil)]),
+                .init(service: "(String, Int?)", name: nil, accessLevel: .public, getterConfig: [GetterConfig.identifiedGetter(nil)]),
             ]
         )
 
@@ -40,6 +41,9 @@ final class TypeSafetySourceFileTests: XCTestCase {
             }
             public func serviceF() -> ServiceF {
                 self.resolve(ServiceF.self)!
+            }
+            public func stringInt() -> (String, Int?) {
+                self.resolve((String, Int?).self)!
             }
             func callAsFunction(name: ModuleAssembly.ServiceB_ResolutionKey) -> ServiceB {
                 self.resolve(ServiceB.self, name: name.rawValue)!


### PR DESCRIPTION
This fixes 2 issues I found today.

1. Tuples did not get named correctly. It now removes characters we don't want.
2. Registration arguments which were unused and using `_` were getting given a name of `_` which caused compile issues