### PR TITLE
Add the Assembly path to the abstract registration into the error output

### DIFF
--- a/Example/KnitExample.xcodeproj/project.pbxproj
+++ b/Example/KnitExample.xcodeproj/project.pbxproj
@@ -239,7 +239,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "/usr/bin/xcrun --sdk macosx swift run knit \\\n--assembly-input-path KnitExample/KnitExampleAssembly.swift \\\n--assembly-input-path KnitExample/KnitExampleUserAssembly.swift \\\n--type-safety-extensions-output-path KnitExample/KnitDITypeSafety.swift \\\n--unit-test-output-path KnitExampleTests/KnitDIRegistrationTests.swift\n";
+			shellScript = "/usr/bin/xcrun --sdk macosx swift run knit gen \\\n--assembly-input-path KnitExample/KnitExampleAssembly.swift \\\n--assembly-input-path KnitExample/KnitExampleUserAssembly.swift \\\n--type-safety-extensions-output-path KnitExample/KnitDITypeSafety.swift \\\n--unit-test-output-path KnitExampleTests/KnitDIRegistrationTests.swift\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 

--- a/Example/KnitExample/KnitExampleApp.swift
+++ b/Example/KnitExample/KnitExampleApp.swift
@@ -1,9 +1,13 @@
 // Copyright © Square, Inc. All rights reserved.
 
 import SwiftUI
+import Knit
 
 @main
 struct KnitExampleApp: App {
+
+    let resolver = ModuleAssembler([KnitExampleAssembly()]).resolver
+
     var body: some Scene {
         WindowGroup {
             ContentView()

--- a/Sources/Knit/Module/DependencyBuilder.swift
+++ b/Sources/Knit/Module/DependencyBuilder.swift
@@ -123,17 +123,24 @@ final class DependencyBuilder {
         return type
     }
 
-    func sourcePath(moduleType: any ModuleAssembly.Type) -> [any ModuleAssembly.Type] {
-        let name = String(describing: moduleType)
-        guard let source = moduleSources[name] else {
-            return [moduleType]
+    func sourcePath(moduleType: any ModuleAssembly.Type) -> [String] {
+        return sourcePath(moduleName: String(describing: moduleType))
+    }
+
+    func sourcePath(moduleName: String) -> [String] {
+        guard let source = moduleSources[moduleName] else {
+            return [moduleName]
         }
-        return sourcePath(moduleType: source) + [moduleType]
+        return sourcePath(moduleType: source) + [moduleName]
+    }
+
+    func sourcePathString(moduleName: String) -> String {
+        let modules = sourcePath(moduleName: moduleName).joined(separator: " -> ")
+        return "Dependency path: \(modules)"
     }
 
     func sourcePathString(moduleType: any ModuleAssembly.Type) -> String {
-        let modules = sourcePath(moduleType: moduleType).map { "\($0)"}.joined(separator: " -> ")
-        return "Dependency path: \(modules)"
+        return sourcePathString(moduleName: String(describing: moduleType))
     }
 
 }

--- a/Tests/KnitTests/AbstractRegistrationTests.swift
+++ b/Tests/KnitTests/AbstractRegistrationTests.swift
@@ -57,4 +57,31 @@ final class AbstractRegistrationTests: XCTestCase {
         XCTAssertNoThrow(try abstractRegistrations.validate())
     }
 
+    func testAbstractErrorFormatting() throws {
+        let builder = try DependencyBuilder(modules: [Assembly1()])
+        let error = Container.AbstractRegistrationError(serviceType: "String", file: "Assembly2.swift", name: nil)
+        let errors = Container.AbstractRegistrationErrors(errors: [error])
+        let result = ModuleAssembler.formatErrors(dependencyBuilder: builder, error: errors)
+        XCTAssertEqual(
+            result,
+            """
+            Unsatisfied abstract registration. Service: String, File: Assembly2.swift
+            Dependency path: Assembly1 -> Assembly2
+            Error creating ModuleAssembler. Please make sure all necessary assemblies are provided.
+            """
+        )
+    }
+
+}
+
+private struct Assembly1: AutoInitModuleAssembly {
+    static var dependencies: [any ModuleAssembly.Type] { [ Assembly2.self] }
+    func assemble(container: Container) {}
+}
+
+private struct Assembly2: AutoInitModuleAssembly {
+    static var dependencies: [any ModuleAssembly.Type] { [] }
+    func assemble(container: Container) {
+        container.registerAbstract(String.self)
+    }
 }

--- a/Tests/KnitTests/ModuleCycleTests.swift
+++ b/Tests/KnitTests/ModuleCycleTests.swift
@@ -15,12 +15,12 @@ final class ModuleCycleTests: XCTestCase {
         XCTAssertTrue(assembler.isRegistered(Assembly4.self))
 
         XCTAssertEqual(
-            assembler.builder.sourcePath(moduleType: Assembly1.self).map { "\($0)"},
+            assembler.builder.sourcePath(moduleType: Assembly1.self),
             ["\(Assembly1.self)"]
         )
 
         XCTAssertEqual(
-            assembler.builder.sourcePath(moduleType: Assembly3.self).map { "\($0)"},
+            assembler.builder.sourcePath(moduleType: Assembly3.self),
             ["\(Assembly1.self)", "\(Assembly3.self)"]
         )
     }


### PR DESCRIPTION
We currently output the file that defines an abstract registration but not the path that imported it. I hit some issues where I had errors cause by abstract registrations but I couldn't tell where how the assembly was being pulled into the dependency graph.

I also reorganised the error output so the more generic info is on later lines. This will help when CI truncates the error message.