### PR TITLE
Fix parsing computed properties inside Assemblies

### DIFF
--- a/Sources/KnitCodeGen/AssemblyParsing.swift
+++ b/Sources/KnitCodeGen/AssemblyParsing.swift
@@ -132,6 +132,11 @@ private class ClassDeclVisitor: SyntaxVisitor {
         return .skipChildren
     }
 
+    override func visit(_ node: VariableDeclSyntax) -> SyntaxVisitorContinueKind {
+        // There could be computed properties that contain other function calls we don't want to parse
+        return .skipChildren
+    }
+
 }
 
 extension IdentifiedDeclSyntax {

--- a/Tests/KnitCodeGenTests/AssemblyParsingTests.swift
+++ b/Tests/KnitCodeGenTests/AssemblyParsingTests.swift
@@ -163,6 +163,29 @@ final class AssemblyParsingTests: XCTestCase {
         )
     }
 
+    func testAdditionalFunctionsInComputedPropertyAreNotParsed() throws {
+        let sourceFile: SourceFile = """
+                class ExampleAssembly: Assembly {
+                    func assemble(container: Container) {
+                        container.register(MyService.self) { }
+                    }
+                    static var dependencies: [any ModuleAssembly.Type] {
+                        return ExampleAssembly.generatedDependencies.filter { $0.resolverType == AppResolver.self }
+                    }
+                }
+            """
+
+        let config = try assertParsesSyntaxTree(sourceFile)
+        XCTAssertEqual(config.name, "Example")
+        XCTAssertEqual(
+            config.registrations,
+            [
+                .init(service: "MyService", accessLevel: .internal),
+            ],
+            "The `dependencies` computed property should be ignored"
+        )
+    }
+
     // MARK: - ClassDecl Extension
 
     func testClassDeclExtension() {


### PR DESCRIPTION
Previously if there was a computed property that had a function call within its body then the visitor would attempt to parse that function call.