### PR TITLE
Add unit test to check that synchronized access is working

### DIFF
--- a/Sources/Knit/Module/ModuleAssembler.swift
+++ b/Sources/Knit/Module/ModuleAssembler.swift
@@ -10,10 +10,7 @@ public final class ModuleAssembler {
     let parent: ModuleAssembler?
 
     /// The resolver for this ModuleAssemblers container
-    public var resolver: Resolver {
-        // https://github.com/Swinject/Swinject/blob/master/Documentation/ThreadSafety.md
-        container.synchronize()
-    }
+    public let resolver: Resolver
 
     // Module types that were registered into the container owned by this ModuleAssembler
     var registeredModules: [any ModuleAssembly.Type] {
@@ -73,6 +70,8 @@ public final class ModuleAssembler {
                 line: line
             )
         }
+        // https://github.com/Swinject/Swinject/blob/master/Documentation/ThreadSafety.md
+        self.resolver = container.synchronize()
     }
 
     static func formatErrors(dependencyBuilder: DependencyBuilder?, error: Error) -> String {

--- a/Tests/KnitTests/SynchronizationTests.swift
+++ b/Tests/KnitTests/SynchronizationTests.swift
@@ -1,0 +1,58 @@
+//
+// Copyright © Block, Inc. All rights reserved.
+//
+
+import Foundation
+@testable import Knit
+import XCTest
+
+final class SynchronizationTests: XCTestCase {
+
+    func testMultiThreadResolving() async throws {
+        // Use a parent/child relationship to test synchronization between containers
+        let parent = ModuleAssembler([Assembly1()])
+        let assembler = ModuleAssembler(parent: parent, [Assembly2()])
+
+        // Resolve the same service in 2 separate tasks
+        async let task1 = try Task {
+            return assembler.resolver.resolve(Service2.self)!
+        }.result.get()
+
+        async let task2 = try Task {
+            return assembler.resolver.resolve(Service2.self)!
+        }.result.get()
+
+        let result = try await (task1, task2)
+
+        // Make sure that the weak services correctly return the same value
+        XCTAssertEqual(result.0.service1.id, result.1.service1.id)
+    }
+
+}
+
+private struct Assembly1: ModuleAssembly {
+    static var dependencies: [any ModuleAssembly.Type] { [] }
+    func assemble(container: Container) {
+        container.autoregister(Service1.self, initializer: Service1.init)
+    }
+}
+
+private struct Assembly2: ModuleAssembly {
+    static var dependencies: [any ModuleAssembly.Type] { [Assembly1.self] }
+    func assemble(container: Container) {
+        container.autoregister(Service2.self, initializer: Service2.init)
+            .inObjectScope(.weak)
+    }
+}
+
+private final class Service1 {
+    let id: String = UUID().uuidString
+}
+
+private final class Service2 {
+    let service1: Service1
+
+    init(service1: Service1) {
+        self.service1 = service1
+    }
+}


### PR DESCRIPTION
This moves synchronize() from being a computed value to being stored. From my testing I couldn't generated a crash with either way but this seems slightly safer anyway.