### PR TITLE
Mark generated files as readonly

### DIFF
--- a/Sources/KnitCodeGen/Configuration.swift
+++ b/Sources/KnitCodeGen/Configuration.swift
@@ -58,12 +58,15 @@ public extension Configuration {
 
 func write(text: String, to path: String) {
     let data = text.data(using: .utf8)!
-    let pathURL = URL(fileURLWithPath: path, isDirectory: false)
-
-    do {
-        try data.write(to: pathURL)
-    } catch {
-        fatalError("\(error)")
+    let fileManager = FileManager.default
+    // Write the file and mark as readonly
+    let result = fileManager.createFile(
+        atPath: path,
+        contents: data,
+        attributes: [.posixPermissions: 0o444]
+    )
+    if !result {
+        fatalError("Could not write to \(path)")
     }
 }
 


### PR DESCRIPTION
These files are marked `// Do not edit directly!` so setting them as readonly so Xcode will prompt to unlock the files. 

I used the example app to test that the files were generated correctly. Originally I marked the file as readonly as a separate operation which prevented the next `data.write` from succeeding.