### PR TITLE
Use a synchronized resolver when using a ScopedModuleAssembler

### DIFF
--- a/Sources/Knit/Module/ScopedModuleAssembler.swift
+++ b/Sources/Knit/Module/ScopedModuleAssembler.swift
@@ -11,7 +11,7 @@ public final class ScopedModuleAssembler<ScopedResolver> {
 
     public var resolver: ScopedResolver {
         // swiftlint:disable:next force_cast
-        internalAssembler.container as! ScopedResolver
+        internalAssembler.resolver as! ScopedResolver
     }
 
     public init(


### PR DESCRIPTION
ModuleAssembler was correct (as demonstrated by tests) but `ScopedModuleAssembler` was accessing the container directly and thus not using `.synchronize()`