### PR TITLE
Remove Duplicate Imports in Type Safety Source File Generation

### DIFF
--- a/Sources/KnitCodeGen/ConfigurationSet.swift
+++ b/Sources/KnitCodeGen/ConfigurationSet.swift
@@ -33,8 +33,9 @@ public struct ConfigurationSet {
     }
 
     var allImports: [ImportDeclSyntax] {
-        let all = assemblies.flatMap { $0.imports }
-        return Array(Set(all))
+        assemblies
+            .flatMap { $0.imports }
+            .uniqued(by: \.description)
     }
 }
 
@@ -83,4 +84,13 @@ public extension ConfigurationSet {
                 // If a type registration is missing or broken then the automated tests will fail for that PR
                 """
 
+}
+
+// MARK: - Private Extensions
+
+private extension Sequence {
+    func uniqued<T: Hashable>(by keyPath: KeyPath<Element, T>) -> [Element] {
+        var set = Set<T>()
+        return filter { set.insert($0[keyPath: keyPath]).inserted }
+    }
 }

--- a/Tests/KnitCodeGenTests/ConfigurationSetTests.swift
+++ b/Tests/KnitCodeGenTests/ConfigurationSetTests.swift
@@ -6,7 +6,7 @@ import XCTest
 final class ConfigurationSetTests: XCTestCase {
 
     func testTypeSafetyOutput() {
-        let configSet = ConfigurationSet(assemblies: [Factory.config1, Factory.config2])
+        let configSet = ConfigurationSet(assemblies: [Factory.config1, Factory.config2, Factory.config3])
 
         XCTAssertEqual(
             configSet.makeTypeSafetySourceFile(),
@@ -36,6 +36,13 @@ final class ConfigurationSetTests: XCTestCase {
                 }
                 func argumentService(string: String) -> ArgumentService {
                     self.resolve(ArgumentService.self, argument: string)!
+                }
+            }
+
+            // Generated from Module3Assembly
+            extension Resolver {
+                public func service3() -> Service3 {
+                    self.resolve(Service3.self)!
                 }
             }
             """
@@ -164,4 +171,14 @@ private enum Factory {
         ]
     )
 
+    static let config3 = Configuration(
+        name: "Module3",
+        registrations: [
+            .init(service: "Service3", accessLevel: .public),
+        ],
+        registrationsIntoCollections: [],
+        imports: [
+            .init(moduleName: "Dependency2")
+        ]
+    )
 }


### PR DESCRIPTION
This pull request addresses the issue of duplicate imports in the type safety source files generation process.