### PR TITLE
Fix syntax issue in release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,12 +12,12 @@ jobs:
   create-release:
     runs-on: macos-latest
     steps:
+      - uses: swift-actions/setup-swift@v1.25.0
+        with:
+          swift-version: "5.9"
       - name: Checkout
         uses: actions/checkout@v3
       - name: Create Release
-        uses: swift-actions/setup-swift@v1.25.0
-          with:
-            swift-version: "5.9"
         run: |
           set -euo pipefail
 


### PR DESCRIPTION
Issues I hit on other branches. I'm not sure how to validate that the release workflow is still correct.

https://github.com/squareup/knit/actions/runs/6809724774/workflow
https://github.com/squareup/knit/actions/runs/6809878044