### PR TITLE
Add support for parsing registrations wrapped in #if conditions

### DIFF
--- a/Example/KnitExample/KnitExampleAssembly.swift
+++ b/Example/KnitExample/KnitExampleAssembly.swift
@@ -32,6 +32,10 @@ final class KnitExampleAssembly: Assembly {
         }
 
         container.autoregisterIntoCollection(ExampleService.self, initializer: ExampleService.init)
+
+        #if DEBUG
+        container.autoregister(DebugService.self, initializer: DebugService.init)
+        #endif
     }
 
 }
@@ -59,3 +63,5 @@ final class ClosureService {
 
     init(closure: @escaping (() -> Void)) { }
 }
+
+struct DebugService { }

--- a/Example/KnitExample/KnitExampleUserAssembly.swift
+++ b/Example/KnitExample/KnitExampleUserAssembly.swift
@@ -1,7 +1,7 @@
 // Copyright © Square, Inc. All rights reserved.
 
 import Foundation
-import Knit
+import KnitLib
 
 // @knit internal getter-named
 /// An assembly expected to be registered at the user level rather than at the app level

--- a/Sources/KnitCodeGen/FunctionCallRegistrationParsing.swift
+++ b/Sources/KnitCodeGen/FunctionCallRegistrationParsing.swift
@@ -282,6 +282,8 @@ enum RegistrationParsingError: LocalizedError, SyntaxError {
     case unwrappedClosureParams(syntax: SyntaxProtocol)
     case chainedRegistrations(syntax: SyntaxProtocol)
     case nonStaticString(syntax: SyntaxProtocol, name: String)
+    case invalidIfConfig(syntax: SyntaxProtocol, text: String)
+    case nestedIfConfig(syntax: SyntaxProtocol)
 
     var errorDescription: String? {
         switch self {
@@ -293,6 +295,10 @@ enum RegistrationParsingError: LocalizedError, SyntaxError {
             return "Chained registration calls are not supported"
         case let .nonStaticString(_, name):
             return "Service name must be a static string. Found: \(name)"
+        case let .invalidIfConfig(_, text):
+            return "Invalid IfConfig expression around container registration: \(text)"
+        case .nestedIfConfig:
+            return "Nested #if statements are not supported"
         }
     }
 
@@ -301,7 +307,9 @@ enum RegistrationParsingError: LocalizedError, SyntaxError {
         case let .missingArgumentType(syntax, _),
             let .chainedRegistrations(syntax),
             let .nonStaticString(syntax, _),
-            let .unwrappedClosureParams(syntax):
+            let .unwrappedClosureParams(syntax),
+            let .invalidIfConfig(syntax, _),
+            let .nestedIfConfig(syntax):
             return syntax
         }
     }

--- a/Sources/KnitCodeGen/Registration.swift
+++ b/Sources/KnitCodeGen/Registration.swift
@@ -1,3 +1,5 @@
+import SwiftSyntax
+
 public struct Registration: Equatable, Codable {
 
     public var service: String
@@ -16,6 +18,8 @@ public struct Registration: Equatable, Codable {
     /// This registration's getter setting.
     public var getterConfig: Set<GetterConfig>
 
+    public var ifConfigCondition: ExprSyntax?
+
     public init(
         service: String,
         name: String? = nil,
@@ -30,6 +34,11 @@ public struct Registration: Equatable, Codable {
         self.arguments = arguments
         self.isForwarded = isForwarded
         self.getterConfig = getterConfig
+    }
+
+    private enum CodingKeys: CodingKey {
+        // ifConfigCondition is not encoded since ExprSyntax does not conform to codable
+        case service, name, accessLevel, arguments, isForwarded, getterConfig
     }
 
 }

--- a/Sources/KnitCodeGen/UnitTestSourceFile.swift
+++ b/Sources/KnitCodeGen/UnitTestSourceFile.swift
@@ -87,8 +87,25 @@ public enum UnitTestSourceFile {
         }
     }
 
+    static func makeAssertCall(registration: Registration) -> CodeBlockItemListSyntax {
+        let expression = makeAssertCallExpression(registration: registration)
+        let codeBlock = CodeBlockItemListSyntax([.init(item: .init(expression))])
+
+        // Wrap the output an in #if where needed
+        guard let ifConfigCondition = registration.ifConfigCondition else {
+            return codeBlock
+        }
+        let clause = IfConfigClauseSyntax(
+            poundKeyword: .poundIfToken(),
+            condition: ifConfigCondition,
+            elements: .statements(codeBlock)
+        )
+        let ifConfig = IfConfigDeclSyntax(clauses: [clause])
+        return CodeBlockItemListSyntax([.init(item: .init(ifConfig))])
+    }
+
     /// Generate a function call to test a single registration resolves
-    static func makeAssertCall(registration: Registration) -> ExprSyntax {
+    private static func makeAssertCallExpression(registration: Registration) -> ExprSyntax {
         if !registration.arguments.isEmpty {
             let argParams = argumentParams(registration: registration)
             let nameParam = registration.name.map { "name: \"\($0)\""}

--- a/Tests/KnitCodeGenTests/TypeSafetySourceFileTests.swift
+++ b/Tests/KnitCodeGenTests/TypeSafetySourceFileTests.swift
@@ -134,6 +134,24 @@ final class TypeSafetySourceFileTests: XCTestCase {
         )
     }
 
+    func testRegistrationWithIfConfig() {
+        var registration = Registration(service: "A", accessLevel: .public)
+        registration.ifConfigCondition = ExprSyntax("SOME_FLAG")
+        XCTAssertEqual(
+            try TypeSafetySourceFile.makeResolver(
+                registration: registration,
+                enumName: nil
+            ).formatted().description,
+            """
+            #if SOME_FLAG
+            public func callAsFunction() -> A {
+                self.resolve(A.self)!
+            }
+            #endif
+            """
+        )
+    }
+
     func testArgumentNames() {
         let registration1 = Registration(service: "A", accessLevel: .public, arguments: [.init(type: "String?")])
         XCTAssertEqual(

--- a/Tests/KnitCodeGenTests/UnitTestSourceFileTests.swift
+++ b/Tests/KnitCodeGenTests/UnitTestSourceFileTests.swift
@@ -170,6 +170,21 @@ final class UnitTestSourceFileTests: XCTestCase {
         XCTAssertEqual(formattedResult, expected)
     }
 
+    func test_registrationAssertIfConfig() {
+        var registration = Registration(service: "A", accessLevel: .hidden)
+        registration.ifConfigCondition = ExprSyntax("SOME_FLAG && !DEBUG")
+        let result = UnitTestSourceFile.makeAssertCall(registration: registration)
+        let formattedResult = result.formatted().description
+        XCTAssertEqual(
+            formattedResult,
+            """
+            #if SOME_FLAG && !DEBUG
+            resolver.assertTypeResolves(A.self)
+            #endif
+            """
+        )
+    }
+
     func test_registrationAssertArgument() {
         let registration = Registration(
             service: "A",


### PR DESCRIPTION
This resolves an issue I found where a type I registered was only available behind a conditional build flag. References to this type were being put into the type safety and unit tests which would fail depending on the build configuration.

This change identifies `#if` statements, stores the condition and then wraps any generated code related to the registration with the original `#if`.

**Limitations**
* `#else` is not supported to prevent creating relationships between registrations.
* Nested `#if` statements are not supported only due to the extra parsing complexity. This can be added in the future.