### PR TITLE
Create WeakResolver

### DIFF
--- a/Sources/KnitLib/WeakResolver.swift
+++ b/Sources/KnitLib/WeakResolver.swift
@@ -1,0 +1,122 @@
+//
+// Copyright © Square, Inc. All rights reserved.
+//
+
+import Swinject
+
+/// A resolver that weakly holds onto the container. This allows keeping a reference without the risk of leaking the container
+/// Classes holding onto a WeakResolver do not take ownership of the DI graph
+/// This allows the container to be deallocated even if services still have references to it
+public final class WeakResolver {
+
+    private weak var container: Container?
+
+    public init(container: Container) {
+        self.container = container
+    }
+
+    public var isAvailable: Bool { return container != nil }
+    public var optionalResolver: Resolver? { container }
+
+    // Force unwrap the weak Container
+    private var unwrapped: Resolver {
+        guard let container else {
+            fatalError("Attempting to resolve using a container which is out of scope")
+        }
+        return container
+    }
+
+    private var resolver: Resolver? { container }
+}
+
+extension Resolver {
+    /// Check if a Resolver is still able to resolve services
+    public var isAvailable: Bool { true }
+
+    /// optionalResolver allows optionally resolving a service without a crash
+    public var optionalResolver: Resolver? { self }
+}
+
+// MARK: - Resolver conformance
+
+extension WeakResolver: Resolver {
+    public func resolve<Service>(_ serviceType: Service.Type) -> Service? {
+        unwrapped.resolve(serviceType)
+    }
+
+    public func resolve<Service>(_ serviceType: Service.Type, name: String?) -> Service? {
+        unwrapped.resolve(serviceType, name: name)
+    }
+
+    public func resolve<Service, Arg1>(_ serviceType: Service.Type, argument: Arg1) -> Service? {
+        unwrapped.resolve(serviceType, argument: argument)
+    }
+
+    public func resolve<Service, Arg1>(_ serviceType: Service.Type, name: String?, argument: Arg1) -> Service? {
+        unwrapped.resolve(serviceType, name: name, argument: argument)
+    }
+
+    public func resolve<Service, Arg1, Arg2>(_ serviceType: Service.Type, arguments arg1: Arg1, _ arg2: Arg2) -> Service? {
+        unwrapped.resolve(serviceType, arguments: arg1, arg2)
+    }
+
+    public func resolve<Service, Arg1, Arg2>(_ serviceType: Service.Type, name: String?, arguments arg1: Arg1, _ arg2: Arg2) -> Service? {
+        unwrapped.resolve(serviceType, name: name, arguments: arg1, arg2)
+    }
+
+    public func resolve<Service, Arg1, Arg2, Arg3>(_ serviceType: Service.Type, arguments arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3) -> Service? {
+        unwrapped.resolve(serviceType, arguments: arg1, arg2, arg3)
+    }
+
+    public func resolve<Service, Arg1, Arg2, Arg3>(_ serviceType: Service.Type, name: String?, arguments arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3) -> Service? {
+        unwrapped.resolve(serviceType, name: name, arguments: arg1, arg2, arg3)
+    }
+
+    public func resolve<Service, Arg1, Arg2, Arg3, Arg4>(_ serviceType: Service.Type, arguments arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3, _ arg4: Arg4) -> Service? {
+        unwrapped.resolve(serviceType, arguments: arg1, arg2, arg3, arg4)
+    }
+
+    public func resolve<Service, Arg1, Arg2, Arg3, Arg4>(_ serviceType: Service.Type, name: String?, arguments arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3, _ arg4: Arg4) -> Service? {
+        unwrapped.resolve(serviceType, name: name, arguments: arg1, arg2, arg3, arg4)
+    }
+
+    public func resolve<Service, Arg1, Arg2, Arg3, Arg4, Arg5>(_ serviceType: Service.Type, arguments arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3, _ arg4: Arg4, _ arg5: Arg5) -> Service? {
+        unwrapped.resolve(serviceType, arguments: arg1, arg2, arg3, arg4, arg5)
+    }
+
+    public func resolve<Service, Arg1, Arg2, Arg3, Arg4, Arg5>(_ serviceType: Service.Type, name: String?, arguments arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3, _ arg4: Arg4, _ arg5: Arg5) -> Service? {
+        unwrapped.resolve(serviceType, name: name, arguments: arg1, arg2, arg3, arg4, arg5)
+    }
+
+    public func resolve<Service, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6>(_ serviceType: Service.Type, arguments arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3, _ arg4: Arg4, _ arg5: Arg5, _ arg6: Arg6) -> Service? {
+        unwrapped.resolve(serviceType, arguments: arg1, arg2, arg3, arg4, arg5, arg6)
+    }
+
+    public func resolve<Service, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6>(_ serviceType: Service.Type, name: String?, arguments arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3, _ arg4: Arg4, _ arg5: Arg5, _ arg6: Arg6) -> Service? {
+        unwrapped.resolve(serviceType, name: name, arguments: arg1, arg2, arg3, arg4, arg5, arg6)
+    }
+
+    public func resolve<Service, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7>(_ serviceType: Service.Type, arguments arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3, _ arg4: Arg4, _ arg5: Arg5, _ arg6: Arg6, _ arg7: Arg7) -> Service? {
+        unwrapped.resolve(serviceType, arguments: arg1, arg2, arg3, arg4, arg5, arg6, arg7)
+    }
+
+    public func resolve<Service, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7>(_ serviceType: Service.Type, name: String?, arguments arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3, _ arg4: Arg4, _ arg5: Arg5, _ arg6: Arg6, _ arg7: Arg7) -> Service? {
+        unwrapped.resolve(serviceType, name: name, arguments: arg1, arg2, arg3, arg4, arg5, arg6, arg7)
+    }
+
+    public func resolve<Service, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8>(_ serviceType: Service.Type, arguments arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3, _ arg4: Arg4, _ arg5: Arg5, _ arg6: Arg6, _ arg7: Arg7, _ arg8: Arg8) -> Service? {
+        unwrapped.resolve(serviceType, arguments: arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8)
+    }
+
+    public func resolve<Service, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8>(_ serviceType: Service.Type, name: String?, arguments arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3, _ arg4: Arg4, _ arg5: Arg5, _ arg6: Arg6, _ arg7: Arg7, _ arg8: Arg8) -> Service? {
+        unwrapped.resolve(serviceType, name: name, arguments: arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8)
+    }
+
+    public func resolve<Service, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8, Arg9>(_ serviceType: Service.Type, arguments arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3, _ arg4: Arg4, _ arg5: Arg5, _ arg6: Arg6, _ arg7: Arg7, _ arg8: Arg8, _ arg9: Arg9) -> Service? {
+        unwrapped.resolve(serviceType, arguments: arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9)
+    }
+
+    public func resolve<Service, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8, Arg9>(_ serviceType: Service.Type, name: String?, arguments arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3, _ arg4: Arg4, _ arg5: Arg5, _ arg6: Arg6, _ arg7: Arg7, _ arg8: Arg8, _ arg9: Arg9) -> Service? {
+        unwrapped.resolve(serviceType, name: name, arguments: arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9)
+    }
+}

--- a/Tests/KnitLibTests/WeakResolverTests.swift
+++ b/Tests/KnitLibTests/WeakResolverTests.swift
@@ -1,0 +1,28 @@
+//
+// Copyright © Square, Inc. All rights reserved.
+//
+
+import KnitLib
+import XCTest
+
+final class WeakResolverTests: XCTestCase {
+
+    func test_weakResolver() {
+        var container: Container? = Container()
+        container?.register(String.self) { _ in "Test" }
+
+        let weakResolver = WeakResolver(container: container!)
+
+        XCTAssertEqual(weakResolver.resolve(String.self), "Test")
+        XCTAssertTrue(weakResolver.isAvailable)
+        XCTAssertNotNil(weakResolver.optionalResolver)
+        XCTAssertNotNil(container?.optionalResolver)
+
+        // Once the container is deallocated, the resolver is no longer available
+        container = nil
+        XCTAssertFalse(weakResolver.isAvailable)
+        XCTAssertNil(weakResolver.optionalResolver)
+    }
+
+}
+


### PR DESCRIPTION
## Background

It is expected that parts of the dependency graph will directly hold onto a `Resolver` as they need to resolve services after initialisation. (e.g. pushing a new view controller). This creates the potential that if the object holding the Resolver leaks then so does the Resolver. While this can be detected, it is difficult to pinpoint the cause of the issue without the aid of debug tooling.

## Solution

This PR adds the concept of a `WeakResolver` which holds a weak reference to the underlying `Container` which works as a Resolver until the Container has been deallocated at which point any attempt to resolve a service will cause a crash.
