### PR TITLE
Make sure that `optionalResolver` property doesn’t leak container

### DIFF
--- a/Sources/KnitLib/WeakResolver.swift
+++ b/Sources/KnitLib/WeakResolver.swift
@@ -15,31 +15,30 @@ public final class WeakResolver {
         self.container = container
     }
 
+    /// Returns `true` if the backing container is still available in memory, otherwise `false`.
     public var isAvailable: Bool { return container != nil }
-    public var optionalResolver: Resolver? { container }
 
-    // Force unwrap the weak Container
-    private var unwrapped: Resolver {
-        guard let container else {
-            fatalError("Attempting to resolve using a container which is out of scope")
-        }
-        return container
+    /// Only provide a resolver if it is still available in memory, otherwise return `nil`.
+    /// Syntax sugar to allow optional chaining on the instance.
+    public var optionalResolver: Resolver? {
+        // We are returning `self` rather than the container to maintain weak semantics
+        isAvailable ? self : nil
     }
-
-    private var resolver: Resolver? { container }
-}
-
-extension Resolver {
-    /// Check if a Resolver is still able to resolve services
-    public var isAvailable: Bool { true }
-
-    /// optionalResolver allows optionally resolving a service without a crash
-    public var optionalResolver: Resolver? { self }
 }
 
 // MARK: - Resolver conformance
 
 extension WeakResolver: Resolver {
+
+    // Force unwraps the weak Container
+    // Convenience accessor for private implementation
+    private var unwrapped: Resolver {
+        guard let container else {
+            fatalError("Attempting to resolve using a container which has been released")
+        }
+        return container
+    }
+
     public func resolve<Service>(_ serviceType: Service.Type) -> Service? {
         unwrapped.resolve(serviceType)
     }

--- a/Tests/KnitLibTests/WeakResolverTests.swift
+++ b/Tests/KnitLibTests/WeakResolverTests.swift
@@ -9,6 +9,7 @@ final class WeakResolverTests: XCTestCase {
 
     func test_weakResolver() {
         var container: Container? = Container()
+        weak var weakContainer = container
         container?.register(String.self) { _ in "Test" }
 
         let weakResolver = WeakResolver(container: container!)
@@ -16,12 +17,32 @@ final class WeakResolverTests: XCTestCase {
         XCTAssertEqual(weakResolver.resolve(String.self), "Test")
         XCTAssertTrue(weakResolver.isAvailable)
         XCTAssertNotNil(weakResolver.optionalResolver)
-        XCTAssertNotNil(container?.optionalResolver)
+        XCTAssertNotNil(weakContainer)
 
         // Once the container is deallocated, the resolver is no longer available
         container = nil
+        XCTAssertNil(weakContainer)
         XCTAssertFalse(weakResolver.isAvailable)
         XCTAssertNil(weakResolver.optionalResolver)
+    }
+
+    func test_optionalResolver_property() {
+        // It is probably unusual if a consumer retains the result of the `optionalResolver` property,
+        // but in case that happens we don't want to accidentally leak the container.
+
+        var container: Container? = Container()
+        weak var weakConatiner = container
+        container?.register(String.self) { _ in "Test" }
+
+        let weakResolver = WeakResolver(container: container!)
+
+        // Holding the result of this property access should not retain the backing container
+        let optionalResolver = weakResolver.optionalResolver
+
+        container = nil
+        XCTAssertNil(weakConatiner, "The container should be released")
+        XCTAssertNotNil(optionalResolver)
+        XCTAssertEqual(weakResolver.isAvailable, false, "`isAvailable` should return false")
     }
 
 }


### PR DESCRIPTION
It is possible someone could retain the result of accessing the `optionalResolver` property and we don’t want that to leak the backing container. Add test case.