### PR TITLE
Fix assemblyValidation not taking into account having a parent assembler

### DIFF
--- a/Knit.podspec
+++ b/Knit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'Knit'
-  s.version          = '0.2.3'
+  s.version          = '0.2.4'
   s.summary          = 'A tool for adding safety features to Swinject'
   s.description      = 'Knit parses Swinject code and generates Swift files for type safety and unit testing.'
   s.homepage         = 'https://github.com/squareup/knit'

--- a/Sources/KnitLib/Module/DependencyBuilder.swift
+++ b/Sources/KnitLib/Module/DependencyBuilder.swift
@@ -87,7 +87,7 @@ final class DependencyBuilder {
         // Assembly validation should be performed "up front"
         // For example if we are validating the assemblies' `TargetResolver`, we should not walk the tree
         // if the root assembly is targeting an incorrect resolver.
-        if let assemblyValidation {
+        if let assemblyValidation, !isRegisteredInParent(resolved) {
             do {
                 try assemblyValidation(resolved)
             } catch {

--- a/Tests/KnitLibTests/ScopedModuleAssemblerTests.swift
+++ b/Tests/KnitLibTests/ScopedModuleAssemblerTests.swift
@@ -14,6 +14,15 @@ final class ScopedModuleAssemblerTests: XCTestCase {
         XCTAssertEqual(assembler.internalAssembler.registeredModules.count, 1)
     }
 
+    func testParentExcluded() throws {
+        let parent = try ScopedModuleAssembler<TestResolver>(_modules: [Assembly1()])
+        let assembler = try ScopedModuleAssembler<OutsideResolver>(
+            parent: parent.internalAssembler,
+            _modules: [Assembly3()]
+        )
+        XCTAssertEqual(assembler.internalAssembler.registeredModules.count, 1)
+    }
+
     func testPostAssemble() throws {
         let assembler = try ScopedModuleAssembler<TestResolver>(_modules: [Assembly1()]) { container in
             container.register(String.self) { _ in "string" }
@@ -52,5 +61,11 @@ protocol OutsideResolver: Resolver { }
 private struct Assembly2: AutoInitModuleAssembly {
     typealias TargetResolver = OutsideResolver
     static var dependencies: [any ModuleAssembly.Type] { [] }
+    func assemble(container: Container) { }
+}
+
+private struct Assembly3: AutoInitModuleAssembly {
+    typealias TargetResolver = OutsideResolver
+    static var dependencies: [any ModuleAssembly.Type] { [Assembly1.self] }
     func assemble(container: Container) { }
 }


### PR DESCRIPTION
I noticed this issue when trying to upgrade. `assemblyValidation` now doesn't run if the type is already registered.

Added tests to prove that the fix works.

I've bumped the version to `0.2.4` as I want to try upgrading again once this is resolved.

One more PR to go in `0.2.4` https://github.com/squareup/knit/pull/101