### PR TITLE
Prevent infinite loops when generating source paths

### DIFF
--- a/Tests/KnitLibTests/ModuleCycleTests.swift
+++ b/Tests/KnitLibTests/ModuleCycleTests.swift
@@ -24,6 +24,20 @@ final class ModuleCycleTests: XCTestCase {
             ["\(Assembly1.self)", "\(Assembly3.self)"]
         )
     }
+
+    func test_sourceCycle() {
+        let assembler = ModuleAssembler([Assembly5()])
+        XCTAssertEqual(
+            assembler.builder.sourcePath(moduleType: Assembly5.self),
+            ["\(Assembly5.self)"]
+        )
+
+        XCTAssertEqual(
+            assembler.builder.sourcePath(moduleType: Assembly7.self),
+            ["\(Assembly5.self)", "\(Assembly6.self)", "\(Assembly7.self)"]
+        )
+    }
+
 }
 
 // Assembly1 depends on Assembly2
@@ -50,5 +64,22 @@ private struct Assembly3: AutoInitModuleAssembly {
 
 private struct Assembly4: AutoInitModuleAssembly {
     static var dependencies: [any ModuleAssembly.Type] { [] }
+    func assemble(container: Container) {}
+}
+
+// Assembly 5-6-7 form a dependency circle
+
+private struct Assembly5: AutoInitModuleAssembly {
+    static var dependencies: [any ModuleAssembly.Type] { [Assembly6.self] }
+    func assemble(container: Container) {}
+}
+
+private struct Assembly6: AutoInitModuleAssembly {
+    static var dependencies: [any ModuleAssembly.Type] { [Assembly7.self] }
+    func assemble(container: Container) {}
+}
+
+private struct Assembly7: AutoInitModuleAssembly {
+    static var dependencies: [any ModuleAssembly.Type] { [Assembly5.self] }
     func assemble(container: Container) {}
 }


### PR DESCRIPTION
I found that it was possible for loops to be created in our dependency trees. This isn't an issue for the graph building as it can break the loops but when there is a failure and we try to print the path to the problematic dependency we end up in an infinite loop.

This breaks the loop and also prevents adding a source for a dependency which came from the input.