### PR TITLE
Add an easy accessor for the weak resolver.

### DIFF
--- a/Sources/KnitLib/Module/ScopedModuleAssembler.swift
+++ b/Sources/KnitLib/Module/ScopedModuleAssembler.swift
@@ -8,10 +8,18 @@ import Foundation
 public final class ScopedModuleAssembler<ScopedResolver> {
 
     public let internalAssembler: ModuleAssembler
-
+    
+    /// Cast and return the swinject resolver to the expected type
     public var resolver: ScopedResolver {
         // swiftlint:disable:next force_cast
         internalAssembler.resolver as! ScopedResolver
+    }
+
+    /// Return a weakly wrapped version of the scoped resolver.
+    /// This resolver will only function while the ModuleAssembler remains in memory
+    public var weakResolver: ScopedResolver {
+        // swiftlint:disable:next force_cast
+        return WeakResolver(container: internalAssembler.container) as! ScopedResolver
     }
 
     public convenience init(


### PR DESCRIPTION
Prevents needing to force cast the Resolver as a Container since the Container is an internal variable