### PR TITLE
Add support for imports wrapped in #if statements

### DIFF
--- a/Sources/KnitCodeGen/Configuration.swift
+++ b/Sources/KnitCodeGen/Configuration.swift
@@ -9,14 +9,14 @@ public struct Configuration: Encodable {
     public var registrations: [Registration]
     public var registrationsIntoCollections: [RegistrationIntoCollection]
 
-    public var imports: [ImportDeclSyntax] = []
+    public var imports: [ModuleImport] = []
     public var targetResolver: String
 
     public init(
         name: String,
         registrations: [Registration],
         registrationsIntoCollections: [RegistrationIntoCollection],
-        imports: [ImportDeclSyntax] = [],
+        imports: [ModuleImport] = [],
         targetResolver: String
     ) {
         self.name = name
@@ -45,8 +45,8 @@ public extension Configuration {
 
     func makeUnitTestSourceFile() throws -> SourceFileSyntax {
         var allImports = imports
-        allImports.append(try ImportDeclSyntax("@testable import \(raw: self.name)"))
-        allImports.append(try ImportDeclSyntax("import XCTest"))
+        allImports.append(try .testable(name: name))
+        allImports.append(try .named("XCTest"))
 
         return try UnitTestSourceFile.make(
             configuration: self

--- a/Sources/KnitCodeGen/FunctionCallRegistrationParsing.swift
+++ b/Sources/KnitCodeGen/FunctionCallRegistrationParsing.swift
@@ -296,7 +296,7 @@ enum RegistrationParsingError: LocalizedError, SyntaxError {
         case let .nonStaticString(_, name):
             return "Service name must be a static string. Found: \(name)"
         case let .invalidIfConfig(_, text):
-            return "Invalid IfConfig expression around container registration: \(text)"
+            return "Invalid IfConfig expression: \(text)"
         case .nestedIfConfig:
             return "Nested #if statements are not supported"
         }

--- a/Sources/KnitCodeGen/ModuleImport.swift
+++ b/Sources/KnitCodeGen/ModuleImport.swift
@@ -1,0 +1,28 @@
+// Copyright © Square, Inc. All rights reserved.
+
+import Foundation
+import SwiftSyntax
+
+public struct ModuleImport {
+    let decl: ImportDeclSyntax
+    let ifConfigCondition: ExprSyntax?
+
+    init(decl: ImportDeclSyntax, ifConfigCondition: ExprSyntax? = nil) {
+        self.decl = decl
+        self.ifConfigCondition = ifConfigCondition
+    }
+
+    var description: String {
+        return decl.description
+    }
+
+    static func named(_ name: String) -> ModuleImport {
+        let decl = try! ImportDeclSyntax("import \(raw: name)")
+        return ModuleImport(decl: decl)
+    }
+
+    static func testable(name: String) -> ModuleImport {
+        let decl = try! ImportDeclSyntax("@testable import \(raw: name)")
+        return ModuleImport(decl: decl)
+    }
+}

--- a/Sources/KnitCodeGen/TypeSafetySourceFile.swift
+++ b/Sources/KnitCodeGen/TypeSafetySourceFile.swift
@@ -68,7 +68,7 @@ public enum TypeSafetySourceFile {
             "self.resolve(\(raw: usages))!"
         }
 
-        // Wrap the output an in #if where needed
+        // Wrap the output in an #if where needed
         guard let ifConfigCondition = registration.ifConfigCondition else {
             return function
         }

--- a/Sources/KnitCodeGen/UnitTestSourceFile.swift
+++ b/Sources/KnitCodeGen/UnitTestSourceFile.swift
@@ -91,7 +91,7 @@ public enum UnitTestSourceFile {
         let expression = makeAssertCallExpression(registration: registration)
         let codeBlock = CodeBlockItemListSyntax([.init(item: .init(expression))])
 
-        // Wrap the output an in #if where needed
+        // Wrap the output in an #if where needed
         guard let ifConfigCondition = registration.ifConfigCondition else {
             return codeBlock
         }

--- a/Tests/KnitCodeGenTests/ConfigurationSetTests.swift
+++ b/Tests/KnitCodeGenTests/ConfigurationSetTests.swift
@@ -14,9 +14,9 @@ final class ConfigurationSetTests: XCTestCase {
             // Generated using Knit
             // Do not edit directly!
 
-            import Swinject
             import Dependency1
             import Dependency2
+            import Swinject
 
             // The correct resolution of each of these types is enforced by a matching automated unit test
             // If a type registration is missing or broken then the automated tests will fail for that PR
@@ -54,10 +54,10 @@ final class ConfigurationSetTests: XCTestCase {
             // Generated using Knit
             // Do not edit directly!
 
-            @testable import Module1
-            import XCTest
             import Dependency1
             import Dependency2
+            @testable import Module1
+            import XCTest
             final class Module1RegistrationTests: XCTestCase {
                 func testRegistrations() {
                     // In the test target for your module, please provide a static method that creates a
@@ -146,7 +146,7 @@ private enum Factory {
             .init(service: "CollectionService")
         ],
         imports: [
-            .init(moduleName: "Dependency1")
+            .named("Dependency1")
         ],
         targetResolver: "Resolver"
     )
@@ -160,7 +160,7 @@ private enum Factory {
         ],
         registrationsIntoCollections: [],
         imports: [
-            .init(moduleName: "Dependency2")
+            .named("Dependency2")
         ],
         targetResolver: "Resolver"
     )
@@ -172,7 +172,7 @@ private enum Factory {
         ],
         registrationsIntoCollections: [],
         imports: [
-            .init(moduleName: "Dependency2")
+            .named("Dependency2")
         ],
         targetResolver: "Resolver"
     )

--- a/Tests/KnitCodeGenTests/HeaderSourceFileTests.swift
+++ b/Tests/KnitCodeGenTests/HeaderSourceFileTests.swift
@@ -1,0 +1,58 @@
+// Copyright © Square, Inc. All rights reserved.
+
+@testable import KnitCodeGen
+import SwiftSyntax
+import XCTest
+
+final class HeaderSourceFileTests: XCTestCase {
+
+    func testBasicImports() {
+        let imports: [ModuleImport] = [
+            .named("ModuleA"),
+            .named("ModuleB"),
+        ]
+        let header = HeaderSourceFile.make(
+            imports: imports,
+            comment: nil
+        )
+        let formattedResult = header.formatted().description
+
+        let expected = #"""
+        // Generated using Knit
+        // Do not edit directly!
+
+        import ModuleA
+        import ModuleB
+        """#
+        XCTAssertEqual(formattedResult, expected)
+    }
+
+    func testIfConfigImports() throws {
+        let imports: [ModuleImport] = [
+            .init(decl: try ImportDeclSyntax("import ModuleA"), ifConfigCondition: ExprSyntax("SOME_FLAG")),
+            .init(decl: try ImportDeclSyntax("import OtherModule"), ifConfigCondition: ExprSyntax("DEBUG")),
+        ]
+
+        let header = HeaderSourceFile.make(
+            imports: imports,
+            comment: nil
+        )
+        let formattedResult = header.formatted().description
+
+        let expected = #"""
+        // Generated using Knit
+        // Do not edit directly!
+        
+        #if SOME_FLAG
+        import ModuleA
+        #endif
+        #if DEBUG
+        import OtherModule
+        #endif
+        
+        """#
+        XCTAssertEqual(formattedResult, expected)
+    }
+
+}
+

--- a/Tests/KnitCodeGenTests/TypeNamerTests.swift
+++ b/Tests/KnitCodeGenTests/TypeNamerTests.swift
@@ -1,4 +1,3 @@
-// Created by Alexander skorulis on 6/7/2023.
 // Copyright © Square, Inc. All rights reserved. 
 
 import Foundation

--- a/Tests/KnitCodeGenTests/UnitTestSourceFileTests.swift
+++ b/Tests/KnitCodeGenTests/UnitTestSourceFileTests.swift
@@ -10,7 +10,7 @@ final class UnitTestSourceFileTests: XCTestCase {
     func test_generation() throws {
         let result = try UnitTestSourceFile.make(
             name: "MyModule",
-            importDecls: [try ImportDeclSyntax("import Swinject")],
+            importDecls: [.named("Swinject")],
             registrations: [
                 .init(service: "ServiceA", name: nil, accessLevel: .internal, isForwarded: false),
                 .init(service: "ServiceB", name: "name", accessLevel: .internal, isForwarded: false),
@@ -56,7 +56,7 @@ final class UnitTestSourceFileTests: XCTestCase {
     func test_generation_emptyRegistrations() throws {
         let result = try UnitTestSourceFile.make(
             name: "MyModule",
-            importDecls: [try ImportDeclSyntax("import Swinject")],
+            importDecls: [.named("Swinject")],
             registrations: [],
             registrationsIntoCollections: []
         )
@@ -81,7 +81,7 @@ final class UnitTestSourceFileTests: XCTestCase {
     func test_generation_onlySingleRegistrations() throws {
         let result = try UnitTestSourceFile.make(
             name: "MyModule",
-            importDecls: [try ImportDeclSyntax("import Swinject")],
+            importDecls: [.named("Swinject")],
             registrations: [
                 .init(service: "ServiceA", name: nil, accessLevel: .internal, isForwarded: false),
             ],
@@ -109,7 +109,7 @@ final class UnitTestSourceFileTests: XCTestCase {
     func test_generation_onlyRegistrationsIntoCollections() throws {
         let result = try UnitTestSourceFile.make(
             name: "MyModule",
-            importDecls: [try ImportDeclSyntax("import Swinject")],
+            importDecls: [.named("Swinject")],
             registrations: [],
             registrationsIntoCollections: [
                 .init(service: "ServiceA"),
@@ -220,7 +220,7 @@ private extension UnitTestSourceFile {
 
     static func make(
         name: String,
-        importDecls: [ImportDeclSyntax],
+        importDecls: [ModuleImport],
         registrations: [Registration],
         registrationsIntoCollections: [RegistrationIntoCollection]
     ) throws -> SourceFileSyntax {


### PR DESCRIPTION
I hit an issue working on https://github.com/squareup/cash-ios/pull/43516 where the #if wrapped imports failed for prod builds. This had already been done for registrations, but I didn't think about imports.