### PR TITLE
Standardise source file headers

### DIFF
--- a/Example/KnitExample/ContentView.swift
+++ b/Example/KnitExample/ContentView.swift
@@ -1,4 +1,6 @@
-// Copyright © Square, Inc. All rights reserved.
+//
+// Copyright © Block, Inc. All rights reserved.
+//
 
 import SwiftUI
 

--- a/Example/KnitExample/KnitExampleApp.swift
+++ b/Example/KnitExample/KnitExampleApp.swift
@@ -1,4 +1,6 @@
-// Copyright © Square, Inc. All rights reserved.
+//
+// Copyright © Block, Inc. All rights reserved.
+//
 
 import SwiftUI
 import Knit

--- a/Example/KnitExample/KnitExampleAssembly.swift
+++ b/Example/KnitExample/KnitExampleAssembly.swift
@@ -1,4 +1,6 @@
-// Copyright © Square, Inc. All rights reserved.
+//
+// Copyright © Block, Inc. All rights reserved.
+//
 
 import Foundation
 import Knit

--- a/Example/KnitExample/KnitExampleUserAssembly.swift
+++ b/Example/KnitExample/KnitExampleUserAssembly.swift
@@ -1,4 +1,6 @@
-// Copyright © Square, Inc. All rights reserved.
+//
+// Copyright © Block, Inc. All rights reserved.
+//
 
 import Foundation
 import Knit

--- a/Example/KnitExampleTests/TestModuleAssembler.swift
+++ b/Example/KnitExampleTests/TestModuleAssembler.swift
@@ -1,4 +1,6 @@
-// Copyright © Square, Inc. All rights reserved.
+//
+// Copyright © Block, Inc. All rights reserved.
+//
 
 import Foundation
 import Knit

--- a/Sources/Knit/Module/DependencyBuilder.swift
+++ b/Sources/Knit/Module/DependencyBuilder.swift
@@ -1,5 +1,5 @@
 //
-// Copyright © Square, Inc. All rights reserved.
+// Copyright © Block, Inc. All rights reserved.
 //
 
 import Foundation

--- a/Sources/Knit/Module/ModuleAssembler.swift
+++ b/Sources/Knit/Module/ModuleAssembler.swift
@@ -1,5 +1,5 @@
 //
-// Copyright © Square, Inc. All rights reserved.
+// Copyright © Block, Inc. All rights reserved.
 //
 
 /// ModuleAssembler wraps the Swinject Assembler to resolves the full tree of module dependencies.

--- a/Sources/Knit/Module/ModuleAssembly.swift
+++ b/Sources/Knit/Module/ModuleAssembly.swift
@@ -1,5 +1,5 @@
 //
-// Copyright © Square, Inc. All rights reserved.
+// Copyright © Block, Inc. All rights reserved.
 //
 
 import Foundation

--- a/Sources/Knit/ServiceCollection/Resolver+ServiceCollection.swift
+++ b/Sources/Knit/ServiceCollection/Resolver+ServiceCollection.swift
@@ -1,3 +1,6 @@
+//
+// Copyright © Block, Inc. All rights reserved.
+//
 
 extension Resolver {
 

--- a/Sources/Knit/ServiceCollection/ServiceCollection.swift
+++ b/Sources/Knit/ServiceCollection/ServiceCollection.swift
@@ -1,3 +1,6 @@
+//
+// Copyright © Block, Inc. All rights reserved.
+//
 
 /// Represents the aggregate of all services registered using ``Container/registerIntoCollection(_:factory:)``
 /// or ``Container/autoregisterIntoCollection(_:initializer:)``.

--- a/Sources/Knit/ServiceCollection/ServiceCollector.swift
+++ b/Sources/Knit/ServiceCollection/ServiceCollector.swift
@@ -1,3 +1,7 @@
+//
+// Copyright © Block, Inc. All rights reserved.
+//
+
 import Foundation
 import Swinject
 

--- a/Sources/Knit/WeakResolver.swift
+++ b/Sources/Knit/WeakResolver.swift
@@ -1,5 +1,5 @@
 //
-// Copyright © Square, Inc. All rights reserved.
+// Copyright © Block, Inc. All rights reserved.
 //
 
 import Swinject

--- a/Sources/KnitCodeGen/AssemblyParsing.swift
+++ b/Sources/KnitCodeGen/AssemblyParsing.swift
@@ -1,3 +1,7 @@
+//
+// Copyright © Block, Inc. All rights reserved.
+//
+
 import Foundation
 import SwiftSyntax
 import SwiftParser

--- a/Sources/KnitCodeGen/Configuration.swift
+++ b/Sources/KnitCodeGen/Configuration.swift
@@ -1,3 +1,7 @@
+//
+// Copyright © Block, Inc. All rights reserved.
+//
+
 import Foundation
 import SwiftSyntax
 

--- a/Sources/KnitCodeGen/ConfigurationSet.swift
+++ b/Sources/KnitCodeGen/ConfigurationSet.swift
@@ -1,3 +1,7 @@
+//
+// Copyright © Block, Inc. All rights reserved.
+//
+
 import Foundation
 import SwiftSyntax
 import SwiftSyntaxBuilder

--- a/Sources/KnitCodeGen/FunctionCallRegistrationParsing.swift
+++ b/Sources/KnitCodeGen/FunctionCallRegistrationParsing.swift
@@ -1,5 +1,5 @@
 //
-// Copyright © Square, Inc. All rights reserved.
+// Copyright © Block, Inc. All rights reserved.
 //
 
 import Foundation

--- a/Sources/KnitCodeGen/HeaderSourceFile.swift
+++ b/Sources/KnitCodeGen/HeaderSourceFile.swift
@@ -1,4 +1,6 @@
-// Copyright © Square, Inc. All rights reserved.
+//
+// Copyright © Block, Inc. All rights reserved.
+//
 
 import Foundation
 import SwiftSyntax

--- a/Sources/KnitCodeGen/KnitDirectives.swift
+++ b/Sources/KnitCodeGen/KnitDirectives.swift
@@ -1,4 +1,6 @@
-// Copyright © Square, Inc. All rights reserved.
+//
+// Copyright © Block, Inc. All rights reserved.
+//
 
 import Foundation
 import SwiftSyntax

--- a/Sources/KnitCodeGen/ModuleAssemblyExtensionSourceFile.swift
+++ b/Sources/KnitCodeGen/ModuleAssemblyExtensionSourceFile.swift
@@ -1,8 +1,5 @@
 //
-//  ModuleAssemblyExtensionSourceFile.swift
-//  
-//
-//  Created by Brad Fol on 8/4/23.
+// Copyright © Block, Inc. All rights reserved.
 //
 
 import SwiftSyntax

--- a/Sources/KnitCodeGen/ModuleImport.swift
+++ b/Sources/KnitCodeGen/ModuleImport.swift
@@ -1,4 +1,6 @@
-// Copyright © Square, Inc. All rights reserved.
+//
+// Copyright © Block, Inc. All rights reserved.
+//
 
 import Foundation
 import SwiftSyntax

--- a/Sources/KnitCodeGen/NamedRegistrationGroup.swift
+++ b/Sources/KnitCodeGen/NamedRegistrationGroup.swift
@@ -1,4 +1,6 @@
-// Copyright © Square, Inc. All rights reserved.
+//
+// Copyright © Block, Inc. All rights reserved.
+//
 
 import Foundation
 

--- a/Sources/KnitCodeGen/Registration.swift
+++ b/Sources/KnitCodeGen/Registration.swift
@@ -1,3 +1,7 @@
+//
+// Copyright © Block, Inc. All rights reserved.
+//
+
 import SwiftSyntax
 
 public struct Registration: Equatable, Codable {

--- a/Sources/KnitCodeGen/RegistrationIntoCollection.swift
+++ b/Sources/KnitCodeGen/RegistrationIntoCollection.swift
@@ -1,3 +1,6 @@
+//
+// Copyright © Block, Inc. All rights reserved.
+//
 
 /// Represents a single concrete factory registered into a collection
 /// A separate instance will be created for each call to `{auto}registerIntoCollection`

--- a/Sources/KnitCodeGen/SourceFileSyntax+Write.swift
+++ b/Sources/KnitCodeGen/SourceFileSyntax+Write.swift
@@ -1,8 +1,5 @@
 //
-//  SourceFileSyntax+Write.swift
-//  
-//
-//  Created by Brad Fol on 8/4/23.
+// Copyright © Block, Inc. All rights reserved.
 //
 
 import Foundation

--- a/Sources/KnitCodeGen/SyntaxError.swift
+++ b/Sources/KnitCodeGen/SyntaxError.swift
@@ -1,4 +1,6 @@
-// Copyright © Square, Inc. All rights reserved.
+//
+// Copyright © Block, Inc. All rights reserved.
+//
 
 import Foundation
 import SwiftSyntax

--- a/Sources/KnitCodeGen/TriviaProvider.swift
+++ b/Sources/KnitCodeGen/TriviaProvider.swift
@@ -1,5 +1,5 @@
 //
-// Copyright © Square, Inc. All rights reserved.
+// Copyright © Block, Inc. All rights reserved.
 //
 
 import Foundation

--- a/Sources/KnitCodeGen/TypeNamer.swift
+++ b/Sources/KnitCodeGen/TypeNamer.swift
@@ -1,5 +1,6 @@
-// Created by Alexander skorulis on 6/7/2023.
-// Copyright © Square, Inc. All rights reserved. 
+//
+// Copyright © Block, Inc. All rights reserved.
+//
 
 import Foundation
 

--- a/Sources/KnitCodeGen/TypeSafetySourceFile.swift
+++ b/Sources/KnitCodeGen/TypeSafetySourceFile.swift
@@ -1,3 +1,7 @@
+//
+// Copyright © Block, Inc. All rights reserved.
+//
+
 import Foundation
 import SwiftSyntax
 import SwiftSyntaxBuilder

--- a/Sources/KnitCodeGen/UnitTestSourceFile.swift
+++ b/Sources/KnitCodeGen/UnitTestSourceFile.swift
@@ -1,3 +1,7 @@
+//
+// Copyright © Block, Inc. All rights reserved.
+//
+
 import SwiftSyntax
 import SwiftSyntaxBuilder
 

--- a/Sources/KnitCommand/GenCommand.swift
+++ b/Sources/KnitCommand/GenCommand.swift
@@ -1,8 +1,5 @@
 //
-//  GenCommand.swift
-//  
-//
-//  Created by Brad Fol on 8/4/23.
+// Copyright © Block, Inc. All rights reserved.
 //
 
 import ArgumentParser

--- a/Sources/KnitCommand/KnitCommand.swift
+++ b/Sources/KnitCommand/KnitCommand.swift
@@ -1,3 +1,7 @@
+//
+// Copyright © Block, Inc. All rights reserved.
+//
+
 import ArgumentParser
 
 @main

--- a/Sources/KnitCommand/ModuleDependenciesCommand.swift
+++ b/Sources/KnitCommand/ModuleDependenciesCommand.swift
@@ -1,8 +1,5 @@
 //
-//  ModuleDependenciesCommand.swift
-//  
-//
-//  Created by Brad Fol on 8/4/23.
+// Copyright © Block, Inc. All rights reserved.
 //
 
 import ArgumentParser

--- a/Tests/KnitCodeGenTests/AssemblyParsingTests.swift
+++ b/Tests/KnitCodeGenTests/AssemblyParsingTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright © Square, Inc. All rights reserved.
+// Copyright © Block, Inc. All rights reserved.
 //
 
 @testable import KnitCodeGen

--- a/Tests/KnitCodeGenTests/ConfigurationSetTests.swift
+++ b/Tests/KnitCodeGenTests/ConfigurationSetTests.swift
@@ -1,4 +1,6 @@
-//  Created by Alexander skorulis on 8/8/2023.
+//
+// Copyright © Block, Inc. All rights reserved.
+//
 
 @testable import KnitCodeGen
 import XCTest

--- a/Tests/KnitCodeGenTests/HeaderSourceFileTests.swift
+++ b/Tests/KnitCodeGenTests/HeaderSourceFileTests.swift
@@ -1,4 +1,6 @@
-// Copyright © Square, Inc. All rights reserved.
+//
+// Copyright © Block, Inc. All rights reserved.
+//
 
 @testable import KnitCodeGen
 import SwiftSyntax

--- a/Tests/KnitCodeGenTests/KnitDirectivesTests.swift
+++ b/Tests/KnitCodeGenTests/KnitDirectivesTests.swift
@@ -1,4 +1,6 @@
-//  Created by Alexander skorulis on 28/7/2023.
+//
+// Copyright © Block, Inc. All rights reserved.
+//
 
 @testable import KnitCodeGen
 import SwiftSyntax

--- a/Tests/KnitCodeGenTests/ModuleAssemblyExtensionSourceFileTests.swift
+++ b/Tests/KnitCodeGenTests/ModuleAssemblyExtensionSourceFileTests.swift
@@ -1,8 +1,5 @@
 //
-//  ModuleAssemblyExtensionSourceFileTests.swift
-//  
-//
-//  Created by Brad Fol on 8/7/23.
+// Copyright © Block, Inc. All rights reserved.
 //
 
 @testable import KnitCodeGen

--- a/Tests/KnitCodeGenTests/NamedRegistrationGroupTests.swift
+++ b/Tests/KnitCodeGenTests/NamedRegistrationGroupTests.swift
@@ -1,4 +1,6 @@
-// Copyright © Square, Inc. All rights reserved.
+//
+// Copyright © Block, Inc. All rights reserved.
+//
 
 @testable import KnitCodeGen
 import Foundation

--- a/Tests/KnitCodeGenTests/RegistrationParsingTests.swift
+++ b/Tests/KnitCodeGenTests/RegistrationParsingTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright © Square, Inc. All rights reserved.
+// Copyright © Block, Inc. All rights reserved.
 //
 
 @testable import KnitCodeGen

--- a/Tests/KnitCodeGenTests/TypeNamerTests.swift
+++ b/Tests/KnitCodeGenTests/TypeNamerTests.swift
@@ -1,4 +1,6 @@
-// Copyright © Square, Inc. All rights reserved. 
+//
+// Copyright © Block, Inc. All rights reserved.
+//
 
 import Foundation
 @testable import KnitCodeGen

--- a/Tests/KnitCodeGenTests/TypeSafetySourceFileTests.swift
+++ b/Tests/KnitCodeGenTests/TypeSafetySourceFileTests.swift
@@ -1,4 +1,6 @@
-// Copyright © Square, Inc. All rights reserved.
+//
+// Copyright © Block, Inc. All rights reserved.
+//
 
 @testable import KnitCodeGen
 import Foundation

--- a/Tests/KnitCodeGenTests/UnitTestSourceFileTests.swift
+++ b/Tests/KnitCodeGenTests/UnitTestSourceFileTests.swift
@@ -1,4 +1,6 @@
-// Copyright © Square, Inc. All rights reserved.
+//
+// Copyright © Block, Inc. All rights reserved.
+//
 
 @testable import KnitCodeGen
 import Foundation

--- a/Tests/KnitTests/DependencyBuilderTests.swift
+++ b/Tests/KnitTests/DependencyBuilderTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright © Square, Inc. All rights reserved.
+// Copyright © Block, Inc. All rights reserved.
 //
 
 @testable import Knit

--- a/Tests/KnitTests/ModuleAssemblerTests.swift
+++ b/Tests/KnitTests/ModuleAssemblerTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright © Square, Inc. All rights reserved.
+// Copyright © Block, Inc. All rights reserved.
 //
 
 @testable import Knit

--- a/Tests/KnitTests/ModuleAssemblyOverrideTests.swift
+++ b/Tests/KnitTests/ModuleAssemblyOverrideTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright © Square, Inc. All rights reserved.
+// Copyright © Block, Inc. All rights reserved.
 //
 
 @testable import Knit

--- a/Tests/KnitTests/ServiceCollectorTests.swift
+++ b/Tests/KnitTests/ServiceCollectorTests.swift
@@ -1,3 +1,7 @@
+//
+// Copyright © Block, Inc. All rights reserved.
+//
+
 import Knit
 import XCTest
 

--- a/Tests/KnitTests/TestResolver.swift
+++ b/Tests/KnitTests/TestResolver.swift
@@ -1,5 +1,5 @@
 //
-// Copyright © Square, Inc. All rights reserved.
+// Copyright © Block, Inc. All rights reserved.
 //
 
 @testable import Knit

--- a/Tests/KnitTests/WeakResolverTests.swift
+++ b/Tests/KnitTests/WeakResolverTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright © Square, Inc. All rights reserved.
+// Copyright © Block, Inc. All rights reserved.
 //
 
 import Knit


### PR DESCRIPTION
Update all source file headers to be consistent. All files now use the following header.
```
//
// Copyright © Block, Inc. All rights reserved.
//
```