### PR TITLE
Remove the direct force unwrap from generated functions

### DIFF
--- a/Example/KnitExample/ContentView.swift
+++ b/Example/KnitExample/ContentView.swift
@@ -2,15 +2,20 @@
 // Copyright © Block, Inc. All rights reserved.
 //
 
+import Knit
+import Swinject
 import SwiftUI
 
 struct ContentView: View {
+
+    let resolver: Resolver
+
     var body: some View {
         VStack {
             Image(systemName: "globe")
                 .imageScale(.large)
                 .foregroundColor(.accentColor)
-            Text("Hello, world!")
+            Text(resolver.exampleService().title)
         }
         .padding()
     }
@@ -18,6 +23,7 @@ struct ContentView: View {
 
 struct ContentView_Previews: PreviewProvider {
     static var previews: some View {
-        ContentView()
+        let resolver = ModuleAssembler([KnitExampleAssembly()]).resolver
+        return ContentView(resolver: resolver)
     }
 }

--- a/Example/KnitExample/KnitExampleApp.swift
+++ b/Example/KnitExample/KnitExampleApp.swift
@@ -12,7 +12,7 @@ struct KnitExampleApp: App {
 
     var body: some Scene {
         WindowGroup {
-            ContentView()
+            ContentView(resolver: resolver)
         }
     }
 }

--- a/Example/KnitExample/KnitExampleAssembly.swift
+++ b/Example/KnitExample/KnitExampleAssembly.swift
@@ -57,6 +57,8 @@ final class NamedService {}
 
 final class ExampleService {
     init() { }
+
+    var title: String { "Example String" }
 }
 
 final class ExampleArgumentService {

--- a/Example/KnitExample/KnitExampleUserAssembly.swift
+++ b/Example/KnitExample/KnitExampleUserAssembly.swift
@@ -14,4 +14,7 @@ final class KnitExampleUserAssembly: Assembly {
     }
 }
 
-final class UserService {}
+final class UserService {
+
+    var username: String = "John"
+}

--- a/Sources/Knit/Resolver+Additions.swift
+++ b/Sources/Knit/Resolver+Additions.swift
@@ -1,0 +1,22 @@
+//
+// Copyright © Block, Inc. All rights reserved.
+//
+
+import Swinject
+
+public extension Resolver {
+
+    /// Force unwrap that improves single line error logging to help track test failures
+    /// This is used in knit generated type safe functions
+    func knitUnwrap<T>(
+        _ value: T?,
+        file: StaticString = #fileID,
+        function: StaticString = #function,
+        line: Int = #line
+    ) -> T {
+        guard let unwrapped = value else {
+            fatalError("Knit resolver failure for \(function) -> \(T.self) from \(file):\(line)")
+        }
+        return unwrapped
+    }
+}

--- a/Sources/KnitCodeGen/TypeSafetySourceFile.swift
+++ b/Sources/KnitCodeGen/TypeSafetySourceFile.swift
@@ -69,7 +69,7 @@ public enum TypeSafetySourceFile {
         }
 
         let function = try FunctionDeclSyntax("\(raw: modifier)func \(raw: funcName)(\(raw: inputs)) -> \(raw: registration.service)") {
-            "self.resolve(\(raw: usages))!"
+            "knitUnwrap(resolve(\(raw: usages)))"
         }
 
         // Wrap the output in an #if where needed

--- a/Tests/KnitCodeGenTests/ConfigurationSetTests.swift
+++ b/Tests/KnitCodeGenTests/ConfigurationSetTests.swift
@@ -25,22 +25,22 @@ final class ConfigurationSetTests: XCTestCase {
             // Generated from Module1Assembly
             extension Resolver {
                 public func service1() -> Service1 {
-                    self.resolve(Service1.self)!
+                    knitUnwrap(resolve(Service1.self))
                 }
             }
             // Generated from Module2Assembly
             extension Resolver {
                 func callAsFunction() -> Service2 {
-                    self.resolve(Service2.self)!
+                    knitUnwrap(resolve(Service2.self))
                 }
                 func argumentService(string: String) -> ArgumentService {
-                    self.resolve(ArgumentService.self, argument: string)!
+                    knitUnwrap(resolve(ArgumentService.self, argument: string))
                 }
             }
             // Generated from Module3Assembly
             extension Resolver {
                 public func service3() -> Service3 {
-                    self.resolve(Service3.self)!
+                    knitUnwrap(resolve(Service3.self))
                 }
             }
             """

--- a/Tests/KnitCodeGenTests/TypeSafetySourceFileTests.swift
+++ b/Tests/KnitCodeGenTests/TypeSafetySourceFileTests.swift
@@ -29,25 +29,25 @@ final class TypeSafetySourceFileTests: XCTestCase {
         // Generated from ModuleAssembly
         extension Resolve {
             func serviceA() -> ServiceA {
-                self.resolve(ServiceA.self)!
+                knitUnwrap(resolve(ServiceA.self))
             }
             public func callAsFunction() -> ServiceD {
-                self.resolve(ServiceD.self)!
+                knitUnwrap(resolve(ServiceD.self))
             }
             public func serviceD() -> ServiceD {
-                self.resolve(ServiceD.self)!
+                knitUnwrap(resolve(ServiceD.self))
             }
             public func serviceE(closure: @escaping () -> Void) -> ServiceE {
-                self.resolve(ServiceE.self, argument: closure)!
+                knitUnwrap(resolve(ServiceE.self, argument: closure))
             }
             public func serviceF() -> ServiceF {
-                self.resolve(ServiceF.self)!
+                knitUnwrap(resolve(ServiceF.self))
             }
             public func stringInt() -> (String, Int?) {
-                self.resolve((String, Int?).self)!
+                knitUnwrap(resolve((String, Int?).self))
             }
             func serviceB(name: ModuleAssembly.ServiceB_ResolutionKey) -> ServiceB {
-                self.resolve(ServiceB.self, name: name.rawValue)!
+                knitUnwrap(resolve(ServiceB.self, name: name.rawValue))
             }
         }
         extension ModuleAssembly {
@@ -70,7 +70,7 @@ final class TypeSafetySourceFileTests: XCTestCase {
             ).formatted().description,
             """
             public func callAsFunction(string: String, url: URL) -> A {
-                self.resolve(A.self, arguments: string, url)!
+                knitUnwrap(resolve(A.self, arguments: string, url))
             }
             """
         )
@@ -85,7 +85,7 @@ final class TypeSafetySourceFileTests: XCTestCase {
             ).formatted().description,
             """
             public func callAsFunction(string: String) -> A {
-                self.resolve(A.self, argument: string)!
+                knitUnwrap(resolve(A.self, argument: string))
             }
             """
         )
@@ -100,7 +100,7 @@ final class TypeSafetySourceFileTests: XCTestCase {
             ).formatted().description,
             """
             public func callAsFunction(string1: String, string2: String) -> A {
-                self.resolve(A.self, arguments: string1, string2)!
+                knitUnwrap(resolve(A.self, arguments: string1, string2))
             }
             """
         )
@@ -115,7 +115,7 @@ final class TypeSafetySourceFileTests: XCTestCase {
             ).formatted().description,
             """
             public func callAsFunction(name: MyAssembly.A_ResolutionKey, string: String) -> A {
-                self.resolve(A.self, name: name.rawValue, argument: string)!
+                knitUnwrap(resolve(A.self, name: name.rawValue, argument: string))
             }
             """
         )
@@ -130,7 +130,7 @@ final class TypeSafetySourceFileTests: XCTestCase {
             ).formatted().description,
             """
             public func callAsFunction(arg: String) -> A {
-                self.resolve(A.self, argument: arg)!
+                knitUnwrap(resolve(A.self, argument: arg))
             }
             """
         )
@@ -147,7 +147,7 @@ final class TypeSafetySourceFileTests: XCTestCase {
             """
             #if SOME_FLAG
             public func callAsFunction() -> A {
-                self.resolve(A.self)!
+                knitUnwrap(resolve(A.self))
             }
             #endif
             """


### PR DESCRIPTION
This helps with issues seem in https://github.com/squareup/cash-ios/pull/43486. In cases where the stack trace is unavailable the error message doesn't give any information about what service failed to resolve. This requires manual investigation which can now be avoided.

Before:
`KnitExample/KnitDITypeSafety.swift:47: Fatal error: Unexpectedly found nil while unwrapping an Optional value` 

After:
`Knit/Resolver+Additions.swift:18: Fatal error: Knit resolver failure for userService() -> UserService from KnitExample/KnitDITypeSafety.swift:47`