### PR TITLE
Parse the assembly type based on the inheritance clause

### DIFF
--- a/Sources/Knit/Module/AbstractAssembly.swift
+++ b/Sources/Knit/Module/AbstractAssembly.swift
@@ -1,0 +1,8 @@
+//
+// Copyright © Block, Inc. All rights reserved.
+//
+
+import Foundation
+
+/// An AbstractAssembly can only contain abstract registrations and should not be initialised.
+protocol AbstractAssembly: ModuleAssembly { }

--- a/Sources/KnitCodeGen/Configuration.swift
+++ b/Sources/KnitCodeGen/Configuration.swift
@@ -9,6 +9,7 @@ public struct Configuration: Encodable {
 
     /// Name of the module for this configuration.
     public var name: String
+    public var assemblyType: String
 
     public var registrations: [Registration]
     public var registrationsIntoCollections: [RegistrationIntoCollection]
@@ -18,12 +19,14 @@ public struct Configuration: Encodable {
 
     public init(
         name: String,
+        assemblyType: String = "Assembly",
         registrations: [Registration],
         registrationsIntoCollections: [RegistrationIntoCollection],
         imports: [ModuleImport] = [],
         targetResolver: String
     ) {
         self.name = name
+        self.assemblyType = assemblyType
         self.registrations = registrations
         self.registrationsIntoCollections = registrationsIntoCollections
         self.imports = imports
@@ -32,6 +35,7 @@ public struct Configuration: Encodable {
 
     public enum CodingKeys: CodingKey {
         case name
+        case assemblyType
         case registrations
     }
 
@@ -48,10 +52,6 @@ public extension Configuration {
     }
 
     func makeUnitTestSourceFile() throws -> SourceFileSyntax {
-        var allImports = imports
-        allImports.append(try .testable(name: name))
-        allImports.append(try .named("XCTest"))
-
         return try UnitTestSourceFile.make(
             configuration: self
         )

--- a/Tests/KnitCodeGenTests/AssemblyParsingTests.swift
+++ b/Tests/KnitCodeGenTests/AssemblyParsingTests.swift
@@ -13,7 +13,7 @@ final class AssemblyParsingTests: XCTestCase {
         let sourceFile: SourceFileSyntax = """
             import A
             import B // Comment after import should be stripped
-            class FooTestAssembly: Assembly { }
+            class FooTestAssembly: ModuleAssembly { }
             """
 
         let config = try assertParsesSyntaxTree(sourceFile)
@@ -25,6 +25,7 @@ final class AssemblyParsingTests: XCTestCase {
             ]
         )
         XCTAssertEqual(config.registrations.count, 0, "No registrations")
+        XCTAssertEqual(config.assemblyType, "ModuleAssembly")
     }
 
     func testDebugWrappedAssemblyImports() throws {
@@ -108,6 +109,7 @@ final class AssemblyParsingTests: XCTestCase {
 
         let config = try assertParsesSyntaxTree(sourceFile)
         XCTAssertEqual(config.name, "FooTest")
+        XCTAssertEqual(config.assemblyType, "Assembly")
     }
 
     func testAssemblyStructModuleName() throws {


### PR DESCRIPTION
This opens up the possibility of enforcing that only  classes implementing `AbstractAssembly` use abstract registrations. It will also be useful from an analysis perspective to know which assemblies are using AutoInitModuleAssembly