### PR TITLE
Add `ignore` access level modifier

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ The following commands are available:
 * `public`: Make the type safe function(s) public (default is internal).
 * `internal`: Make the type safe function(s) internal. This is a useful override when the assembly is set to `public`.
 * `hidden`: Do not generate any type safe function.
+* `ignore`: Completely ignore this assembly or registration
 
 #### Examples:
 

--- a/Sources/KnitCodeGen/KnitDirectives.swift
+++ b/Sources/KnitCodeGen/KnitDirectives.swift
@@ -111,6 +111,7 @@ public enum AccessLevel: String, CaseIterable, Codable {
     case `public`
     case `internal`
     case hidden
+    case ignore
 
     /// Centralized control of the default behavior.
     public static var `default`: AccessLevel = .internal

--- a/Sources/KnitCodeGen/TypeSafetySourceFile.swift
+++ b/Sources/KnitCodeGen/TypeSafetySourceFile.swift
@@ -15,7 +15,7 @@ public enum TypeSafetySourceFile {
     ) throws -> SourceFileSyntax {
         let visibleRegistrations = allRegistrations.filter {
             // Exclude hidden registrations always
-            $0.accessLevel != .hidden
+            $0.accessLevel != .hidden && $0.accessLevel != .ignore
         }
         let unnamedRegistrations = visibleRegistrations.filter { $0.name == nil }
         let namedGroups = NamedRegistrationGroup.make(from: visibleRegistrations)

--- a/Tests/KnitCodeGenTests/AssemblyParsingTests.swift
+++ b/Tests/KnitCodeGenTests/AssemblyParsingTests.swift
@@ -426,6 +426,40 @@ final class AssemblyParsingTests: XCTestCase {
         )
     }
 
+    func testIgnoredConfiguration() throws {
+        let sourceFile: SourceFileSyntax = """
+            // @knit ignore
+            class MyAssembly: Assembly {
+                typealias TargetResolver = TestResolver
+            }
+        """
+        var errorsToPrint = [Error]()
+
+        let configuration = try parseSyntaxTree(
+            sourceFile,
+            errorsToPrint: &errorsToPrint,
+            defaultTargetResolver: "Resolver",
+            useTargetResolver: true
+        )
+
+        XCTAssertEqual(errorsToPrint.count, 0)
+        XCTAssertNil(configuration)
+    }
+
+    func testIgnoredRegistration() throws {
+        let sourceFile: SourceFileSyntax = """
+            class MyAssembly: Assembly {
+                func assemble(container: Container) {
+                    // @knit ignore
+                    container.register(A.self) { }
+                }
+            }
+        """
+        
+        let config = try assertParsesSyntaxTree(sourceFile)
+        XCTAssertEqual(config.registrations.count, 0)
+    }
+
 }
 
 private func assertParsesSyntaxTree(
@@ -450,5 +484,5 @@ private func assertParsesSyntaxTree(
         XCTAssertEqual(errorsToPrint.count, 0, file: file, line: line)
     }
 
-    return configuration
+    return try XCTUnwrap(configuration)
 }

--- a/Tests/KnitCodeGenTests/KnitDirectivesTests.swift
+++ b/Tests/KnitCodeGenTests/KnitDirectivesTests.swift
@@ -23,6 +23,11 @@ final class KnitDirectivesTests: XCTestCase {
             try parse("@knit hidden"),
             .init(accessLevel: .hidden, getterConfig: [])
         )
+
+        XCTAssertEqual(
+            try parse("@knit ignore"),
+            .init(accessLevel: .ignore, getterConfig: [])
+        )
     }
 
     func testKnitPrefix() {


### PR DESCRIPTION
This allows tagging an entire assembly with `// @knit ignore` to prevent parsing from continuing. The purpose of this is to allow wildcard specification of assemblies (like `Sources/DI/*Assembly.swift`) but still being able to ignore individual files.

The ignore directive works for registrations as well and drops them from the array. A further improvement could completely skip parsing allowing for non parsable registrations to be included and handled manually.

This was driven from https://github.com/squareup/knit/pull/114 which required this option.
