### PR TITLE
Introduce primary and secondary assembly roles

### DIFF
--- a/Sources/KnitCodeGen/AssemblyParsing.swift
+++ b/Sources/KnitCodeGen/AssemblyParsing.swift
@@ -71,6 +71,7 @@ func parseSyntaxTree(
     return Configuration(
         name: name,
         assemblyType: assemblyType,
+        role: assemblyFileVisitor.directives.role ?? .primary,
         registrations: assemblyFileVisitor.registrations,
         registrationsIntoCollections: assemblyFileVisitor.registrationsIntoCollections,
         imports: assemblyFileVisitor.imports,
@@ -92,7 +93,9 @@ private class AssemblyFileVisitor: SyntaxVisitor, IfConfigVisitor {
     private var classDeclVisitor: ClassDeclVisitor?
 
     private(set) var assemblyErrors: [Error] = []
-    
+
+    private(set) var directives: KnitDirectives = .empty
+
     /// For any imports parsed, this #if condition should be applied when it is used
     var currentIfConfigCondition: IfConfigVisitorCondition?
 
@@ -147,7 +150,6 @@ private class AssemblyFileVisitor: SyntaxVisitor, IfConfigVisitor {
             // Only the first class declaration should be visited
             return .skipChildren
         }
-        var directives: KnitDirectives = .empty
         do {
             directives = try KnitDirectives.parse(leadingTrivia: node.leadingTrivia)
 

--- a/Sources/KnitCodeGen/Configuration.swift
+++ b/Sources/KnitCodeGen/Configuration.swift
@@ -10,6 +10,7 @@ public struct Configuration: Encodable {
     /// Name of the module for this configuration.
     public var name: String
     public var assemblyType: String
+    public var role: AssemblyRole
 
     public var registrations: [Registration]
     public var registrationsIntoCollections: [RegistrationIntoCollection]
@@ -20,12 +21,14 @@ public struct Configuration: Encodable {
     public init(
         name: String,
         assemblyType: String = "Assembly",
+        role: AssemblyRole = .primary,
         registrations: [Registration],
         registrationsIntoCollections: [RegistrationIntoCollection],
         imports: [ModuleImport] = [],
         targetResolver: String
     ) {
         self.name = name
+        self.role = role
         self.assemblyType = assemblyType
         self.registrations = registrations
         self.registrationsIntoCollections = registrationsIntoCollections
@@ -35,6 +38,7 @@ public struct Configuration: Encodable {
 
     public enum CodingKeys: CodingKey {
         case name
+        case role
         case assemblyType
         case registrations
     }

--- a/Sources/KnitCodeGen/ConfigurationSet.swift
+++ b/Sources/KnitCodeGen/ConfigurationSet.swift
@@ -12,8 +12,12 @@ public struct ConfigurationSet {
     public let assemblies: [Configuration]
 
     public var primaryAssembly: Configuration {
-        // There must be at least 1 assembly and the first is treated as primary
-        return assemblies[0]
+        let primaries = assemblies.filter({ $0.role == .primary })
+        if primaries.count != 1 {
+            fatalError("Found \(primaries.count) primary assemblies. Only 1 primary assembly is supported")
+        }
+        // There must be exactly 1 primary assembly
+        return primaries[0]
     }
 
     public func writeGeneratedFiles(

--- a/Sources/KnitCodeGen/KnitDirectives.swift
+++ b/Sources/KnitCodeGen/KnitDirectives.swift
@@ -8,6 +8,17 @@ import SwiftSyntax
 struct KnitDirectives: Codable, Equatable {
     let accessLevel: AccessLevel?
     let getterConfig: Set<GetterConfig>
+    let role: AssemblyRole?
+
+    public init(
+        accessLevel: AccessLevel? = nil,
+        getterConfig: Set<GetterConfig> = [],
+        role: AssemblyRole? = nil
+    ) {
+        self.accessLevel = accessLevel
+        self.getterConfig = getterConfig
+        self.role = role
+    }
 
     private static let directiveMarker = "@knit"
 
@@ -34,42 +45,49 @@ struct KnitDirectives: Codable, Equatable {
 
         var accessLevel: AccessLevel?
         var getterConfigs: Set<GetterConfig> = []
+        var assemblyRole: AssemblyRole?
 
         for token in tokens {
             let parsed = try parse(token: token)
             if let level = parsed.accessLevel {
                 accessLevel = level
             }
+            if let role = parsed.role {
+                assemblyRole = role
+            }
             if let getter = parsed.getterConfig {
                 getterConfigs.insert(getter)
             }
         }
 
-        return KnitDirectives(accessLevel: accessLevel, getterConfig: getterConfigs)
+        return KnitDirectives(accessLevel: accessLevel, getterConfig: getterConfigs, role: assemblyRole)
     }
 
-    static func parse(token: String) throws -> (accessLevel: AccessLevel?, getterConfig: GetterConfig?) {
+    private static func parse(token: String) throws -> ParseResult {
         if let accessLevel = AccessLevel(rawValue: token) {
-            return (accessLevel, nil)
+            return .init(accessLevel: accessLevel)
+        }
+        if let role = AssemblyRole(rawValue: token) {
+            return .init(role: role)
         }
         if token == "getter-callAsFunction" {
-            return (nil, .callAsFunction)
+            return .init(getterConfig: .callAsFunction)
         }
         if let nameMatch = getterNamedRegex.firstMatch(in: token, range: NSMakeRange(0, token.count)) {
             if nameMatch.numberOfRanges >= 2, nameMatch.range(at: 1).location != NSNotFound {
                 var range = nameMatch.range(at: 1)
                 range = NSRange(location: range.location + 2, length: range.length - 4)
                 let name = (token as NSString).substring(with: range)
-                return (nil, .identifiedGetter(name))
+                return .init(getterConfig: .identifiedGetter(name))
             }
-            return (nil, .identifiedGetter(nil))
+            return .init(getterConfig: .identifiedGetter(nil))
         }
         
         throw Error.unexpectedToken(token: token)
     }
 
     static var empty: KnitDirectives {
-        return .init(accessLevel: nil, getterConfig: [])
+        return .init(accessLevel: nil, getterConfig: [], role: nil)
     }
 
     private static let getterNamedRegex = try! NSRegularExpression(pattern: "getter-named(\\(\"\\w*\"\\))?")
@@ -115,4 +133,32 @@ public enum AccessLevel: String, CaseIterable, Codable {
 
     /// Centralized control of the default behavior.
     public static var `default`: AccessLevel = .internal
+}
+
+public enum AssemblyRole: String, CaseIterable, Codable {
+
+    /// The primary assembly for the module
+    case primary
+
+    /// Any secondary role for the module
+    case secondary
+
+    /// Centralized control of the default behavior.
+    public static var `default`: AssemblyRole = .primary
+}
+
+private struct ParseResult {
+    let accessLevel: AccessLevel?
+    let getterConfig: GetterConfig?
+    let role: AssemblyRole?
+
+    init(
+        accessLevel: AccessLevel? = nil,
+        getterConfig: GetterConfig? = nil,
+        role: AssemblyRole? = nil
+    ) {
+        self.accessLevel = accessLevel
+        self.getterConfig = getterConfig
+        self.role = role
+    }
 }

--- a/Tests/KnitCodeGenTests/ConfigurationSetTests.swift
+++ b/Tests/KnitCodeGenTests/ConfigurationSetTests.swift
@@ -155,6 +155,7 @@ private enum Factory {
 
     static let config2 = Configuration(
         name: "Module2",
+        role: .secondary,
         registrations: [
             .init(service: "Service2", accessLevel: .internal, getterConfig: [.callAsFunction]),
             .init(service: "ArgumentService", accessLevel: .internal, arguments: [.init(type: "String")])

--- a/Tests/KnitCodeGenTests/KnitDirectivesTests.swift
+++ b/Tests/KnitCodeGenTests/KnitDirectivesTests.swift
@@ -91,6 +91,23 @@ final class KnitDirectivesTests: XCTestCase {
         )
     }
 
+    func testAssemblyRole() {
+        XCTAssertEqual(
+            try parse("// @knit secondary"),
+            .init(role: .secondary)
+        )
+
+        XCTAssertEqual(
+            try parse("// @knit primary"),
+            .init(role: .primary)
+        )
+
+        XCTAssertEqual(
+            try parse("// @knit getter-named secondary"),
+            .init(getterConfig: [.identifiedGetter(nil)], role: .secondary)
+        )
+    }
+
     private func parse(_ comment: String) throws -> KnitDirectives {
         let trivia = Trivia(pieces: [.lineComment(comment)])
         return try KnitDirectives.parse(leadingTrivia: trivia)


### PR DESCRIPTION
This allows defining directly in the assembly which one is the primary assembly for the module. As an example `CommonCashAssembly` would be the primary assembly while `CommonCashAppAssemlby` would be the secondary.