### PR TITLE
Parse module-name knit directives

### DIFF
--- a/Sources/KnitCodeGen/Configuration.swift
+++ b/Sources/KnitCodeGen/Configuration.swift
@@ -9,6 +9,7 @@ public struct Configuration: Encodable {
 
     /// Name of the module for this configuration.
     public var name: String
+    public var directives: KnitDirectives
     public var assemblyType: String
 
     public var registrations: [Registration]
@@ -19,6 +20,7 @@ public struct Configuration: Encodable {
 
     public init(
         name: String,
+        directives: KnitDirectives = .init(),
         assemblyType: String = "Assembly",
         registrations: [Registration],
         registrationsIntoCollections: [RegistrationIntoCollection],
@@ -26,6 +28,7 @@ public struct Configuration: Encodable {
         targetResolver: String
     ) {
         self.name = name
+        self.directives = directives
         self.assemblyType = assemblyType
         self.registrations = registrations
         self.registrationsIntoCollections = registrationsIntoCollections
@@ -35,8 +38,13 @@ public struct Configuration: Encodable {
 
     public enum CodingKeys: CodingKey {
         case name
+        case directives
         case assemblyType
         case registrations
+    }
+
+    public var moduleName: String {
+        return directives.moduleName ?? name
     }
 
 }

--- a/Sources/KnitCodeGen/ConfigurationSet.swift
+++ b/Sources/KnitCodeGen/ConfigurationSet.swift
@@ -55,7 +55,7 @@ public extension ConfigurationSet {
 
     func makeUnitTestSourceFile() throws -> String {
         var allImports = allImports
-        allImports.append(.testable(name: primaryAssembly.name))
+        allImports.append(.testable(name: primaryAssembly.moduleName))
         allImports.append(.named("XCTest"))
         let header = HeaderSourceFile.make(imports: sortImports(allImports), comment: nil)
         let body = try assemblies.map { try $0.makeUnitTestSourceFile() }

--- a/Tests/KnitCodeGenTests/AssemblyParsingTests.swift
+++ b/Tests/KnitCodeGenTests/AssemblyParsingTests.swift
@@ -460,6 +460,19 @@ final class AssemblyParsingTests: XCTestCase {
         XCTAssertEqual(config.registrations.count, 0)
     }
 
+    func testCustomModuleName() throws {
+        let sourceFile: SourceFileSyntax = """
+            // @knit module-name("Custom")
+            class MyAssembly: Assembly {
+            }
+        """
+
+        let config = try assertParsesSyntaxTree(sourceFile)
+        XCTAssertEqual(config.directives.moduleName, "Custom")
+        XCTAssertEqual(config.moduleName, "Custom")
+        XCTAssertEqual(config.name, "My")
+    }
+
 }
 
 private func assertParsesSyntaxTree(

--- a/Tests/KnitCodeGenTests/KnitDirectivesTests.swift
+++ b/Tests/KnitCodeGenTests/KnitDirectivesTests.swift
@@ -91,6 +91,26 @@ final class KnitDirectivesTests: XCTestCase {
         )
     }
 
+    func testModuleName() {
+        XCTAssertEqual(
+            try parse("// @knit module-name(\"Test\")"),
+            .init(moduleName: "Test")
+        )
+
+        XCTAssertEqual(
+            try parse("// @knit module-name(\"MyModuleName\")"),
+            .init(moduleName: "MyModuleName")
+        )
+
+        XCTAssertEqual(
+            try parse("// @knit getter-callAsFunction module-name(\"A\")"),
+            .init(getterConfig: [.callAsFunction], moduleName: "A")
+        )
+
+        XCTAssertThrowsError(try parse("// @knit module-name"))
+        XCTAssertThrowsError(try parse("// @knit module-name()"))
+    }
+
     private func parse(_ comment: String) throws -> KnitDirectives {
         let trivia = Trivia(pieces: [.lineComment(comment)])
         return try KnitDirectives.parse(leadingTrivia: trivia)


### PR DESCRIPTION
This is an alternative solution to https://github.com/squareup/knit/pull/117. This lets an assembly define a custom module name rather than using the default value extracted by looking at the assembly name.