### PR TITLE
Create ModuleImportContainer to maintain an ordered unique list of imports

### DIFF
--- a/Sources/KnitCodeGen/ModuleImport.swift
+++ b/Sources/KnitCodeGen/ModuleImport.swift
@@ -8,10 +8,16 @@ import SwiftSyntax
 public struct ModuleImport {
     let decl: ImportDeclSyntax
     let ifConfigCondition: ExprSyntax?
+    let name: String
+    let isTestable: Bool
 
     init(decl: ImportDeclSyntax, ifConfigCondition: ExprSyntax? = nil) {
         self.decl = decl
         self.ifConfigCondition = ifConfigCondition
+        let desc = decl.description
+        self.name = String(desc.split(separator: " ").last!)
+        self.isTestable = desc.hasPrefix("@testable")
+
     }
 
     var description: String {
@@ -26,5 +32,32 @@ public struct ModuleImport {
     static func testable(name: String) -> ModuleImport {
         let decl = try! ImportDeclSyntax("@testable import \(raw: name)")
         return ModuleImport(decl: decl)
+    }
+}
+
+/// Container that allows inserting import statements to prevent duplicates
+/// Adding a @testable import will replace the existing non testable import
+public struct ModuleImportSet {
+    private var imports: [ModuleImport] = []
+
+    init(imports: [ModuleImport]) {
+        imports.forEach { insert($0) }
+    }
+    
+    mutating func insert(_ imp: ModuleImport) {
+        if let existingIndex = imports.firstIndex(where: { $0.name == imp.name}) {
+            if imp.isTestable {
+                imports[existingIndex] = imp
+            }
+        } else {
+            imports.append(imp)
+        }
+    }
+    
+    /// Imports sorted by name
+    var sorted: [ModuleImport] {
+        return imports.sorted { import1, import2 in
+            return import1.name < import2.name
+        }
     }
 }

--- a/Tests/KnitCodeGenTests/ModuleImportTests.swift
+++ b/Tests/KnitCodeGenTests/ModuleImportTests.swift
@@ -1,0 +1,66 @@
+//
+// Copyright © Block, Inc. All rights reserved.
+//
+
+@testable import KnitCodeGen
+import XCTest
+
+final class ModuleImportTests: XCTestCase {
+
+    func testNamedImport() {
+        let imp = ModuleImport.named("Test")
+        XCTAssertEqual(imp.description, "import Test")
+    }
+
+    func testTestableImport() {
+        let imp = ModuleImport.testable(name: "Test")
+        XCTAssertEqual(imp.description, "@testable import Test")
+    }
+
+    func testImportContainerInit() {
+        let container = ModuleImportSet(imports: [
+            .named("Test1"),
+            .named("Test2"),
+            .named("Test1"),
+            .testable(name: "Test2")
+        ])
+
+        XCTAssertEqual(container.sorted.count, 2)
+        XCTAssertEqual(
+            container.sorted.map { $0.description },
+            [
+                "import Test1",
+                "@testable import Test2"
+            ]
+        )
+    }
+
+    func testImportContainerInsert() {
+        var container = ModuleImportSet(imports: [])
+        container.insert(.named("MyModule"))
+        XCTAssertEqual(
+            container.sorted.map { $0.description },
+            [
+                "import MyModule",
+            ]
+        )
+        container.insert(.named("MyModule"))
+        XCTAssertEqual(container.sorted.count, 1)
+
+        container.insert(.named("MyModule2"))
+        XCTAssertEqual(container.sorted.count, 2)
+
+        container.insert(.testable(name: "AModule"))
+        container.insert(.named("AModule"))
+        XCTAssertEqual(container.sorted.count, 3)
+
+        XCTAssertEqual(
+            container.sorted.map { $0.description },
+            [
+                "@testable import AModule",
+                "import MyModule",
+                "import MyModule2",
+            ]
+        )
+    }
+}


### PR DESCRIPTION
This is part of the work to enable combined unit testing. In that case imports are being added from multiple locations so it becomes important to make sure there are no duplicates.

The code to do this was previously in `ConfigurationSet` but now exists in a standalone container which correctly handles @testable matching.