### PR TITLE
Conform additional assemblies to GeneratedModuleAssembly

### DIFF
--- a/Sources/KnitCodeGen/ModuleAssemblyExtensionSourceFile.swift
+++ b/Sources/KnitCodeGen/ModuleAssemblyExtensionSourceFile.swift
@@ -17,44 +17,77 @@ public enum ModuleAssemblyExtensionSourceFile {
             for dependencyModuleName in dependencyModuleNames where !dependencyModuleName.hasSuffix("Assembly") {
                 DeclSyntax("import \(raw: dependencyModuleName)")
             }
-
-            try ExtensionDeclSyntax("extension \(raw: currentModuleName)Assembly: GeneratedModuleAssembly") {
-
-                // `public static var generatedDependencies: [any ModuleAssembly.Type]`
-                VariableDeclSyntax(
-                    modifiers: [
-                        DeclModifierSyntax(name: TokenSyntax(.keyword(.public), presence: .present)),
-                        DeclModifierSyntax(name: TokenSyntax(.keyword(.static), presence: .present)),
-                    ],
-                    bindingSpecifier: .keyword(.var),
-                    bindingsBuilder: {
-                        PatternBindingSyntax(
-                            pattern: IdentifierPatternSyntax(identifier: .identifier("generatedDependencies")),
-                            typeAnnotation: TypeAnnotationSyntax(type: "[any ModuleAssembly.Type]" as TypeSyntax),
-                            accessorBlock: AccessorBlockSyntax(
-                                
-                                // Make the computed property accessor
-                                accessors: .getter(.init(
-                                    itemsBuilder: {
-                                        let elements = ArrayElementListSyntax {
-                                            // Turn each module name string into a meta type of the Assembly
-                                            for name in (dependencyModuleNames + additionalAssemblies) {
-                                                ArrayElementSyntax(
-                                                    leadingTrivia: [ .newlines(1) ],
-                                                    expression: "\(raw: typeName(name)).self" as ExprSyntax
-                                                )
-                                            }
-                                        }
-
-                                        ArrayExprSyntax(elements: elements)
-                                    }
-                                ))
-                            )
-                        )
-                    }
-                )
+            try mainExtension(
+                currentModuleName: currentModuleName,
+                dependencyModuleNames: dependencyModuleNames,
+                additionalAssemblies: additionalAssemblies
+            )
+            for assembly in additionalAssemblies {
+                try makeAdditionalExtension(additionalAssembly: assembly, mainAssembly: "\(currentModuleName)Assembly")
             }
         }
+    }
+
+    private static func mainExtension(
+        currentModuleName: String,
+        dependencyModuleNames: [String],
+        additionalAssemblies: [String]
+    ) throws -> ExtensionDeclSyntax {
+        try ExtensionDeclSyntax("extension \(raw: currentModuleName)Assembly: GeneratedModuleAssembly") {
+
+            // `public static var generatedDependencies: [any ModuleAssembly.Type]`
+            makeDependenciesVar(
+                accessorBlock: AccessorBlockSyntax(
+                    // Make the computed property accessor
+                    accessors: .getter(.init(
+                        itemsBuilder: {
+                            let elements = ArrayElementListSyntax {
+                                // Turn each module name string into a meta type of the Assembly
+                                for name in (dependencyModuleNames + additionalAssemblies) {
+                                    ArrayElementSyntax(
+                                        leadingTrivia: [ .newlines(1) ],
+                                        expression: "\(raw: typeName(name)).self" as ExprSyntax
+                                    )
+                                }
+                            }
+
+                            ArrayExprSyntax(elements: elements)
+                        }
+                    ))
+                )
+            )
+        }
+    }
+
+    private static func makeAdditionalExtension(
+        additionalAssembly: String,
+        mainAssembly: String
+    ) throws -> ExtensionDeclSyntax {
+        return try ExtensionDeclSyntax("extension \(raw: additionalAssembly): GeneratedModuleAssembly") {
+            // `public static var dependencies: [any ModuleAssembly.Type]`
+            makeDependenciesVar(
+                accessorBlock: AccessorBlockSyntax(
+                    accessors: .getter(.init(stringLiteral: "\(mainAssembly).generatedDependencies"))
+                )
+            )
+        }
+    }
+
+    private static func makeDependenciesVar(accessorBlock: AccessorBlockSyntax) -> VariableDeclSyntax {
+        VariableDeclSyntax(
+            modifiers: [
+                DeclModifierSyntax(name: TokenSyntax(.keyword(.public), presence: .present)),
+                DeclModifierSyntax(name: TokenSyntax(.keyword(.static), presence: .present)),
+            ],
+            bindingSpecifier: .keyword(.var),
+            bindingsBuilder: {
+                PatternBindingSyntax(
+                    pattern: IdentifierPatternSyntax(identifier: .identifier("generatedDependencies")),
+                    typeAnnotation: TypeAnnotationSyntax(type: "[any ModuleAssembly.Type]" as TypeSyntax),
+                    accessorBlock: accessorBlock
+                )
+            }
+        )
     }
 
     private static func typeName(_ name: String) -> String {

--- a/Tests/KnitCodeGenTests/ModuleAssemblyExtensionSourceFileTests.swift
+++ b/Tests/KnitCodeGenTests/ModuleAssemblyExtensionSourceFileTests.swift
@@ -91,6 +91,11 @@ final class ModuleAssemblyExtensionSourceFileTests: XCTestCase {
                     DependencyAOtherAssembly.self]
             }
         }
+        extension DependencyAOtherAssembly: GeneratedModuleAssembly {
+            public static var generatedDependencies: [any ModuleAssembly.Type] {
+                CurrentModuleAssembly.generatedDependencies
+            }
+        }
         """#
 
         XCTAssertEqual(


### PR DESCRIPTION
Previously we only created `generatedDependencies` for the main assembly. This meant any additional assemblies needed to have `dependencies` implemented manually. This was some extra boilerplate that added confusion.

This PR adds extra `generatedDependencies` implementations which point back to the original list. Everything that uses these wraps in `scoped()` to filter out non matching dependencies.