### PR TITLE
Create DependencyTree to hold graph setup information

### DIFF
--- a/Sources/Knit/Module/DependencyTree.swift
+++ b/Sources/Knit/Module/DependencyTree.swift
@@ -1,0 +1,115 @@
+//
+// Copyright © Block, Inc. All rights reserved.
+//
+
+import Foundation
+
+/// Storage for details of how the dependency tree was constructed
+public struct DependencyTree: CustomDebugStringConvertible {
+
+    // Assemblies that were originally provided to create the tree
+    private let inputModules: [AssemblyReference]
+    
+    // List of all registered modules
+    private var allModules: Set<AssemblyReference>
+
+    // List of how each module was pulled into the graph
+    private var moduleSources: [AssemblyReference: AssemblyReference] = [:]
+
+    init(inputModules: [any ModuleAssembly]) {
+        self.inputModules = inputModules.map { AssemblyReference(type(of: $0)) }
+        allModules = Set(self.inputModules)
+    }
+
+    mutating func add(
+        assemblyType: any ModuleAssembly.Type,
+        source: (any ModuleAssembly.Type)?
+    ) {
+        let fromInputs = inputModules.contains(where: { $0.type == assemblyType })
+        let typeReference = AssemblyReference(assemblyType)
+        if let source, !fromInputs && moduleSources[typeReference] == nil {
+            moduleSources[typeReference] = AssemblyReference(source)
+        }
+        allModules.insert(typeReference)
+    }
+
+    // MARK: - Public API
+
+    public func sourcePath(moduleName: String) -> [String] {
+        guard let match = allModules.first(where: { $0.name == moduleName}) else {
+            return ["** Knit: Could not find module \(moduleName) **"]
+        }
+        return sourcePath(moduleType: match.type)
+    }
+
+    public func sourcePath(moduleType: any ModuleAssembly.Type) -> [String] {
+        var path: [String] = []
+        buildSourcePath(moduleName: AssemblyReference(moduleType), path: &path)
+        return path
+    }
+
+    public var debugDescription: String {
+        return inputModules.flatMap { debugDescription(assemblyRef: $0, indent: "") }.joined(separator: "\n")
+    }
+
+    public func dumpGraph() {
+        print("Dependency Graph:\n\(debugDescription)")
+    }
+
+    // MARK: - Private Methods
+
+    private func buildSourcePath(moduleName: AssemblyReference, path: inout [String]) {
+        path.insert(moduleName.name, at: 0)
+        guard let source = moduleSources[moduleName] else {
+            return
+        }
+
+        // Prevent an infinite loop
+        if path.contains(source.name) {
+            return
+        }
+        return buildSourcePath(moduleName: source, path: &path)
+    }
+
+    private func debugDescription(assemblyRef: AssemblyReference, indent: String) -> [String] {
+        let children = moduleSources.filter { key, value in
+            return value == assemblyRef
+        }.keys.sorted(by: { $0.name < $1.name })
+        let hasDash = indent.firstIndex(of: "-") != nil
+        let newIndent = hasDash ? "  \(indent)" : "  - \(indent)"
+        let childRows = children.flatMap { debugDescription(assemblyRef: $0, indent: newIndent) }
+
+        var selfRow = "\(indent)\(assemblyRef.name)"
+        let implementations = findImplementations(assemblyRef: assemblyRef).map { $0.name }.joined(separator: ", ")
+        if !implementations.isEmpty {
+            selfRow += " (\(implementations))"
+        }
+
+        return [selfRow] + childRows
+    }
+
+    private func findImplementations(assemblyRef: AssemblyReference) -> [AssemblyReference] {
+        return allModules.filter { $0.type.doesImplement(type: assemblyRef.type) && $0 != assemblyRef}
+    }
+}
+
+/// Wrapper for the types to allow them to be hashable
+private struct AssemblyReference: Hashable {
+
+    let type: any ModuleAssembly.Type
+    let name: String
+
+    init(_ type: any ModuleAssembly.Type) {
+        self.type = type
+        self.name = String(describing: type)
+    }
+
+    func hash(into hasher: inout Hasher) {
+        hasher.combine(name)
+    }
+    
+    static func == (lhs: AssemblyReference, rhs: AssemblyReference) -> Bool {
+        return lhs.type == rhs.type
+    }
+
+}

--- a/Sources/Knit/Module/ModuleAssembler.swift
+++ b/Sources/Knit/Module/ModuleAssembler.swift
@@ -86,6 +86,10 @@ public final class ModuleAssembler {
         self.container.addBehavior(ServiceCollector())
         let abstractRegistrations = self.container.registerAbstractContainer()
 
+        // Expose the dependency tree for debugging
+        let dependencyTree = builder.dependencyTree
+        self.container.register(DependencyTree.self) { _ in dependencyTree }
+
         let assembler = Assembler(container: self.container)
         assembler.apply(assemblies: nonModuleAssemblies)
         assembler.apply(assemblies: builder.assemblies)
@@ -120,4 +124,11 @@ public final class ModuleAssembler {
         return registeredModules.contains(where: {$0.matches(moduleType: type)})
     }
 
+}
+
+// Publicly expose the dependency tree so it can be used for debugging
+public extension Resolver {
+    func _dependencyTree() -> DependencyTree {
+        return knitUnwrap(resolve(DependencyTree.self))
+    }
 }

--- a/Sources/KnitCodeGen/UnitTestSourceFile.swift
+++ b/Sources/KnitCodeGen/UnitTestSourceFile.swift
@@ -148,7 +148,7 @@ public enum UnitTestSourceFile {
 
     /// Generate a function to assert that a type can be resolved
     private static func makeTypeAssert() throws -> FunctionDeclSyntax {
-        let string: SyntaxNodeString = """
+        let string: SyntaxNodeString = #"""
         func assertTypeResolves<T>(
             _ type: T.Type,
             name: String? = nil,
@@ -157,18 +157,22 @@ public enum UnitTestSourceFile {
         ) {
             XCTAssertNotNil(
                 resolve(type, name: name),
-                "The container did not resolve the type: \\(type). Check that this type is registered correctly.",
+                """
+                The container did not resolve the type: \(type). Check that this type is registered correctly.
+                Dependency Graph:
+                \(_dependencyTree())
+                """,
                 file: file,
                 line: line
             )
         }
-        """
+        """#
         return try FunctionDeclSyntax(string)
     }
 
     /// Generate a function to assert that a value resolved correctly
     private static func makeResultAssert() throws -> FunctionDeclSyntax {
-        let string: SyntaxNodeString = """
+        let string: SyntaxNodeString = #"""
         func assertTypeResolved<T>(
             _ result: T?,
             file: StaticString = #filePath,
@@ -176,12 +180,16 @@ public enum UnitTestSourceFile {
         ) {
             XCTAssertNotNil(
                 result,
-                "The container did not resolve the type: \\(T.self). Check that this type is registered correctly.",
+                """
+                The container did not resolve the type: \(T.self). Check that this type is registered correctly.
+                Dependency Graph:
+                \(_dependencyTree())
+                """,
                 file: file,
                 line: line
             )
         }
-        """
+        """#
         return try FunctionDeclSyntax(string)
     }
 

--- a/Tests/KnitCodeGenTests/ConfigurationSetTests.swift
+++ b/Tests/KnitCodeGenTests/ConfigurationSetTests.swift
@@ -95,7 +95,11 @@ final class ConfigurationSetTests: XCTestCase {
                 ) {
                     XCTAssertNotNil(
                         resolve(type, name: name),
-                        "The container did not resolve the type: \(type). Check that this type is registered correctly.",
+                        """
+                        The container did not resolve the type: \(type). Check that this type is registered correctly.
+                        Dependency Graph:
+                        \(_dependencyTree())
+                        """,
                         file: file,
                         line: line
                     )
@@ -107,7 +111,11 @@ final class ConfigurationSetTests: XCTestCase {
                 ) {
                     XCTAssertNotNil(
                         result,
-                        "The container did not resolve the type: \(T.self). Check that this type is registered correctly.",
+                        """
+                        The container did not resolve the type: \(T.self). Check that this type is registered correctly.
+                        Dependency Graph:
+                        \(_dependencyTree())
+                        """,
                         file: file,
                         line: line
                     )

--- a/Tests/KnitTests/ComplexDependencyTests.swift
+++ b/Tests/KnitTests/ComplexDependencyTests.swift
@@ -14,6 +14,21 @@ final class ComplexDependencyTests: XCTestCase {
         XCTAssertTrue(builder.assemblies[0] is Assembly2Fake)
         XCTAssertTrue(builder.assemblies[1] is Assembly3)
         XCTAssertTrue(builder.assemblies[2] is Assembly1)
+
+        XCTAssertEqual(
+            builder.dependencyTree.sourcePath(moduleType: Assembly2Fake.self),
+            ["Assembly1", "Assembly3", "Assembly2Fake"]
+        )
+
+        XCTAssertEqual(
+            builder.dependencyTree.debugDescription,
+            """
+            Assembly1
+              - Assembly2 (Assembly2Fake)
+              - Assembly3
+                - Assembly2Fake
+            """
+        )
     }
 
     func testCyclicDependency() throws {
@@ -21,6 +36,14 @@ final class ComplexDependencyTests: XCTestCase {
         XCTAssertEqual(builder.assemblies.count, 2)
         XCTAssertTrue(builder.assemblies[0] is Assembly5)
         XCTAssertTrue(builder.assemblies[1] is Assembly4)
+
+        XCTAssertEqual(
+            builder.dependencyTree.debugDescription,
+            """
+            Assembly4
+              - Assembly5
+            """
+        )
     }
 
 }

--- a/Tests/KnitTests/DependencyBuilderTests.swift
+++ b/Tests/KnitTests/DependencyBuilderTests.swift
@@ -14,6 +14,16 @@ final class DependencyBuilderTests: XCTestCase {
         XCTAssertTrue(builder.assemblies[0] is Assembly2)
         XCTAssertTrue(builder.assemblies[1] is Assembly1)
         XCTAssertTrue(builder.assemblies[2] is Assembly3)
+
+        XCTAssertEqual(
+            builder.dependencyTree.debugDescription,
+            """
+            Assembly3
+            Assembly1
+              - Assembly2
+            """
+        )
+
     }
 
     func test_assembly3OrderChange() throws {
@@ -23,6 +33,15 @@ final class DependencyBuilderTests: XCTestCase {
         XCTAssertTrue(builder.assemblies[0] is Assembly2)
         XCTAssertTrue(builder.assemblies[1] is Assembly1)
         XCTAssertTrue(builder.assemblies[2] is Assembly3)
+
+        XCTAssertEqual(
+            builder.dependencyTree.debugDescription,
+            """
+            Assembly1
+              - Assembly2
+            Assembly3
+            """
+        )
     }
 
     func test_assembly1() throws {
@@ -31,6 +50,14 @@ final class DependencyBuilderTests: XCTestCase {
 
         XCTAssertTrue(builder.assemblies[0] is Assembly2)
         XCTAssertTrue(builder.assemblies[1] is Assembly1)
+
+        XCTAssertEqual(
+            builder.dependencyTree.debugDescription,
+            """
+            Assembly1
+              - Assembly2
+            """
+        )
     }
 
     func test_diamondShape() throws {
@@ -40,6 +67,15 @@ final class DependencyBuilderTests: XCTestCase {
         XCTAssertTrue(builder.assemblies[0] is Assembly1)
         XCTAssertTrue(builder.assemblies[1] is Assembly2)
         XCTAssertTrue(builder.assemblies[2] is Assembly4)
+
+        XCTAssertEqual(
+            builder.dependencyTree.debugDescription,
+            """
+            Assembly4
+              - Assembly2
+            Assembly1
+            """
+        )
     }
 
     func test_parentRegistered() throws {
@@ -52,6 +88,29 @@ final class DependencyBuilderTests: XCTestCase {
         // Assembly2 is not registered because the builder was told that it had been done by the parent
         XCTAssertEqual(builder.assemblies.count, 1)
         XCTAssertTrue(builder.assemblies[0] is Assembly1)
+
+        XCTAssertEqual(
+            builder.dependencyTree.debugDescription,
+            """
+            Assembly1
+            """
+        )
+    }
+
+    func test_overrideTree() throws {
+        let builder = try DependencyBuilder(
+            modules: [Assembly9()],
+            overrideBehavior: .useDefaultOverrides
+        )
+
+        XCTAssertEqual(
+            builder.dependencyTree.debugDescription,
+            """
+            Assembly9
+              - Assembly2
+              - Assembly8 (Assembly2)
+            """
+        )
     }
 
     func test_missingAssembly() {
@@ -137,12 +196,14 @@ private struct Assembly1: ModuleAssembly {
     func assemble(container: Container) {}
 }
 
-// Assembly2 has no dependencies
+// Assembly2 has no dependencies but implements Assembly8
 private struct Assembly2: AutoInitModuleAssembly {
 
     static var dependencies: [any ModuleAssembly.Type] {
         return []
     }
+
+    static var implements: [any ModuleAssembly.Type] { [Assembly8.self] }
 
     func assemble(container: Container) {}
 }
@@ -182,6 +243,18 @@ private struct Assembly7: ModuleAssembly {
     func assemble(container: Container) {}
     static var dependencies: [any ModuleAssembly.Type] { [Assembly5.self] }
 }
+
+private struct Assembly8: AutoInitModuleAssembly, DefaultModuleAssemblyOverride {
+    func assemble(container: Container) {}
+    static var dependencies: [any ModuleAssembly.Type] { [] }
+    typealias OverrideType = Assembly2
+}
+
+private struct Assembly9: AutoInitModuleAssembly {
+    func assemble(container: Container) {}
+    static var dependencies: [any ModuleAssembly.Type] { [Assembly8.self] }
+}
+
 
 private enum DependencyBuilderTestError: LocalizedError {
     case failedValidation

--- a/Tests/KnitTests/DependencyTreeTests.swift
+++ b/Tests/KnitTests/DependencyTreeTests.swift
@@ -1,0 +1,61 @@
+//
+// Copyright © Block, Inc. All rights reserved.
+//
+
+@testable import Knit
+import XCTest
+
+final class DependencyTreeTests: XCTestCase {
+
+    func test_source_paths() {
+        var tree = DependencyTree(inputModules: [Assembly1()])
+        tree.add(assemblyType: Assembly2.self, source: Assembly1.self)
+
+        XCTAssertEqual(
+            tree.sourcePath(moduleType: Assembly1.self),
+            ["Assembly1"]
+        )
+
+        XCTAssertEqual(
+            tree.sourcePath(moduleType: Assembly2.self),
+            ["Assembly1", "Assembly2"]
+        )
+    }
+
+    func test_tree_structure() {
+        var tree = DependencyTree(inputModules: [Assembly1(), Assembly4()])
+        tree.add(assemblyType: Assembly2.self, source: Assembly1.self)
+        tree.add(assemblyType: Assembly3.self, source: Assembly2.self)
+
+        XCTAssertEqual(
+            tree.debugDescription,
+            """
+            Assembly1
+              - Assembly2
+                - Assembly3
+            Assembly4
+            """
+        )
+    }
+
+}
+
+private struct Assembly1: AutoInitModuleAssembly {
+    static var dependencies: [any ModuleAssembly.Type] { return [] }
+    func assemble(container: Container) {}
+}
+
+private struct Assembly2: AutoInitModuleAssembly {
+    static var dependencies: [any ModuleAssembly.Type] { return [] }
+    func assemble(container: Container) {}
+}
+
+private struct Assembly3: AutoInitModuleAssembly {
+    static var dependencies: [any ModuleAssembly.Type] { return [] }
+    func assemble(container: Container) {}
+}
+
+private struct Assembly4: AutoInitModuleAssembly {
+    static var dependencies: [any ModuleAssembly.Type] { return [] }
+    func assemble(container: Container) {}
+}

--- a/Tests/KnitTests/ModuleAssemblyOverrideTests.swift
+++ b/Tests/KnitTests/ModuleAssemblyOverrideTests.swift
@@ -23,6 +23,16 @@ final class ModuleAssemblyOverrideTests: XCTestCase {
         XCTAssertTrue(builder.assemblies[0] is Assembly1)
         XCTAssertTrue(builder.assemblies[1] is FakeAssembly3)
         XCTAssertTrue(builder.assemblies[2] is Assembly2Fake)
+
+        XCTAssertEqual(
+            builder.dependencyTree.debugDescription,
+            """
+            Assembly2 (Assembly2Fake)
+              - Assembly1
+            Assembly2Fake
+              - FakeAssembly3
+            """
+        )
     }
 
     func test_serviceRegisteredWithoutFakes() {
@@ -106,6 +116,13 @@ final class ModuleAssemblyOverrideTests: XCTestCase {
         let child = ModuleAssembler(parent: parent, [Assembly1()], overrideBehavior: .disableDefaultOverrides)
         XCTAssertTrue(child.isRegistered(Assembly1.self))
         XCTAssertTrue(child.registeredModules.isEmpty)
+
+        XCTAssertEqual(
+            child.resolver._dependencyTree().debugDescription,
+            """
+            Assembly1
+            """
+        )
     }
 
     func test_multipleOverrides() {
@@ -118,6 +135,17 @@ final class ModuleAssemblyOverrideTests: XCTestCase {
         XCTAssertTrue(assembler.isRegistered(Assembly5.self))
         XCTAssertTrue(assembler.isRegistered(MultipleDependencyAssembly.self))
         XCTAssertTrue(assembler.isRegistered(MultipleOverrideAssembly.self))
+
+        XCTAssertEqual(
+            assembler.resolver._dependencyTree().debugDescription,
+            """
+            MultipleDependencyAssembly
+              - Assembly1 (MultipleOverrideAssembly)
+              - Assembly5 (MultipleOverrideAssembly)
+                - Assembly4 (MultipleOverrideAssembly)
+            MultipleOverrideAssembly
+            """
+        )
     }
 
 }


### PR DESCRIPTION
This collects all assembly registration information into a `DependencyTree` object which can then be used later to understand the setup of the graph. This allows a failing test to print out the dependency tree to make it easier to understand what when wrong.

The output shows how each assembly type was pulled into the graph and if it was replaced. Replacements are shown in brackets.

Example output on a failure. Without this information it's difficult to understand why `FileManaging` is missing. With the information I can see that `DataArchiversAssembly` was replaced with `InMemoryDataArchiversAssembly` which prevented `FileSystem` from being pulled into the graph.

```
XCTAssertNotNil failed - The container did not resolve the type: FileManaging. Check that this type is registered correctly.
Dependency Graph:
FeatureFlagsAppAssembly
  - CustomerDataAssembly (InMemoryCustomerDataAssembly)
  - DataArchiversAssembly (InMemoryDataArchiversAssembly)
  - FoundationAdditionsAssembly
    - BlackHoleLoggerAssembly
    - LoggingAssembly (BlackHoleLoggerAssembly)
  - InMemoryCustomerDataAssembly
  - InMemoryDataArchiversAssembly
  - InMemoryKeyValueStoreAssembly
  - KeyValueStoreAssembly (InMemoryKeyValueStoreAssembly)
```