### PR TITLE
Make ServiceCollector aware of child/parent relationships

### DIFF
--- a/Sources/Knit/Module/ModuleAssembler.swift
+++ b/Sources/Knit/Module/ModuleAssembler.swift
@@ -8,6 +8,7 @@ public final class ModuleAssembler {
 
     let container: Container
     let parent: ModuleAssembler?
+    let serviceCollector: ServiceCollector
 
     /// The resolver for this ModuleAssemblers container
     public let resolver: Resolver
@@ -83,7 +84,8 @@ public final class ModuleAssembler {
 
         self.parent = parent
         self.container = Container(parent: parent?.container)
-        self.container.addBehavior(ServiceCollector())
+        self.serviceCollector = .init(parent: parent?.serviceCollector)
+        self.container.addBehavior(serviceCollector)
         let abstractRegistrations = self.container.registerAbstractContainer()
 
         let assembler = Assembler(container: self.container)


### PR DESCRIPTION
I thought about this potentially incorrect case today and wrote up tests to confirm my expectation then added a fix.

If we have 2 assemblers (App and SignedIn) the existing behaviour would cause any `registerIntoCollection` from the App level to be unavailable from the SignedIn resolver. To me this seemed non obvious because all other registrations from the parent are available in the child.