### PR TITLE
Fix crash in ServiceCollector

### DIFF
--- a/Sources/Knit/ServiceCollection/ServiceCollector.swift
+++ b/Sources/Knit/ServiceCollection/ServiceCollector.swift
@@ -49,8 +49,8 @@ public final class ServiceCollector: Behavior {
             // Register a `ServiceCollection` for it:
             container.register(ServiceCollection<Service>.self) { resolver in
                 var factories: [(any Resolver) -> Any] = []
-                if let parent = self.parent {
-                    factories.append(contentsOf: parent.factoriesByService[ObjectIdentifier(type)]!)
+                if let parentFactories = self.parent?.factoriesByService[ObjectIdentifier(type)] {
+                    factories.append(contentsOf: parentFactories)
                 }
                 factories.append(contentsOf: self.factoriesByService[ObjectIdentifier(type)]!)
                 return .init(entries: factories.map { $0(resolver) as! Service })
@@ -58,7 +58,10 @@ public final class ServiceCollector: Behavior {
         }
         var factories = factoriesByService[ObjectIdentifier(Service.self)] ?? []
         factories.append {
-            $0.resolve(Service.self, name: name)!
+            guard let service = $0.resolve(Service.self, name: name) else {
+                fatalError("Could not resolve \(Service.self) inside ServiceCollector")
+            }
+            return service
         }
         factoriesByService[ObjectIdentifier(Service.self)] = factories
     }

--- a/Tests/KnitTests/ServiceCollectorTests.swift
+++ b/Tests/KnitTests/ServiceCollectorTests.swift
@@ -27,6 +27,12 @@ struct AssemblyB: AutoInitModuleAssembly {
     }
 }
 
+struct AssemblyC: AutoInitModuleAssembly {
+    static var dependencies: [any ModuleAssembly.Type] = []
+
+    func assemble(container: Container) { }
+}
+
 final class CustomService: ServiceProtocol {
     var name: String
 
@@ -272,6 +278,22 @@ final class ServiceCollectorTests: XCTestCase {
         XCTAssertEqual(
             child.resolver.resolveCollection(ServiceProtocol.self).entries.count,
             2
+        )
+    }
+
+    func test_childWithEmptyParent() {
+        let parent = ModuleAssembler([AssemblyC()])
+        let child = ModuleAssembler(parent: parent, [AssemblyB()])
+
+        // Parent has no services registered
+        XCTAssertEqual(
+            parent.resolver.resolveCollection(ServiceProtocol.self).entries.count,
+            0
+        )
+
+        XCTAssertEqual(
+            child.resolver.resolveCollection(ServiceProtocol.self).entries.count,
+            1
         )
     }
 


### PR DESCRIPTION
Found this while testing in cash-ios. The force unwrap didn't work if the same type hadn't been registered in the parent. 
Added a test to conform the issue and then fixed.
Also replaced one force unwrap with a fatal error just in case.