### PR TITLE
Add a codegen option module-name-regex to extract the module name from the filepath

### DIFF
--- a/Sources/KnitCodeGen/AssemblyParser.swift
+++ b/Sources/KnitCodeGen/AssemblyParser.swift
@@ -1,0 +1,103 @@
+//
+// Copyright © Block, Inc. All rights reserved.
+//
+
+import Foundation
+import SwiftSyntax
+import SwiftParser
+
+public struct AssemblyParser {
+
+    private let defaultTargetResolver: String
+    private let useTargetResolver: Bool
+    private let nameExtractor: ModuleNameExtractor
+
+    public init(
+        defaultTargetResolver: String = "Resolver",
+        useTargetResolver: Bool = false,
+        moduleNameRegex: String? = nil
+    ) throws {
+        self.defaultTargetResolver = defaultTargetResolver
+        self.useTargetResolver = useTargetResolver
+        self.nameExtractor = try ModuleNameExtractor(moduleNamePattern: moduleNameRegex)
+    }
+
+    public func parseAssemblies(
+        at paths: [String]
+    ) throws -> ConfigurationSet {
+        var configs = [Configuration]()
+        for path in paths {
+            let url = URL(fileURLWithPath: path, isDirectory: false)
+            var errorsToPrint = [Error]()
+
+            let source: String
+            do {
+                source = try String(contentsOf: url)
+            } catch {
+                throw AssemblyParsingError.fileReadError(error, path: path)
+            }
+            let syntaxTree = Parser.parse(source: source)
+            let configuration = try parseSyntaxTree(
+                syntaxTree,
+                path: path,
+                errorsToPrint: &errorsToPrint
+            )
+            guard let configuration else { continue }
+            configs.append(configuration)
+            printErrors(errorsToPrint, filePath: path, syntaxTree: syntaxTree)
+            if errorsToPrint.count > 0 {
+                throw AssemblyParsingError.parsingError
+            }
+        }
+        return ConfigurationSet(assemblies: configs)
+    }
+
+    func parseSyntaxTree(
+        _ syntaxTree: SyntaxProtocol,
+        path: String? = nil,
+        errorsToPrint: inout [Error]
+    ) throws -> Configuration? {
+        var extractedModuleName: String?
+        if let path {
+            extractedModuleName = nameExtractor.extractModuleName(path: path)
+        }
+
+        let assemblyFileVisitor = AssemblyFileVisitor()
+        assemblyFileVisitor.walk(syntaxTree)
+
+        if assemblyFileVisitor.directives.accessLevel == .ignore { return nil }
+
+        guard let assemblyName = assemblyFileVisitor.assemblyName else {
+            throw AssemblyParsingError.missingAssemblyName
+        }
+        let moduleName = assemblyFileVisitor.directives.moduleName ?? extractedModuleName ?? assemblyFileVisitor.moduleName
+        guard let moduleName else {
+            throw AssemblyParsingError.missingModuleName
+        }
+
+        guard let assemblyType = assemblyFileVisitor.assemblyType else {
+            throw AssemblyParsingError.missingAssemblyType
+        }
+
+        errorsToPrint.append(contentsOf: assemblyFileVisitor.assemblyErrors)
+        errorsToPrint.append(contentsOf: assemblyFileVisitor.registrationErrors)
+
+        let targetResolver: String
+        if useTargetResolver {
+            targetResolver = assemblyFileVisitor.targetResolver ?? defaultTargetResolver
+        } else {
+            targetResolver = defaultTargetResolver
+        }
+
+        return Configuration(
+            assemblyName: assemblyName,
+            moduleName: moduleName,
+            directives: assemblyFileVisitor.directives,
+            assemblyType: assemblyType,
+            registrations: assemblyFileVisitor.registrations,
+            registrationsIntoCollections: assemblyFileVisitor.registrationsIntoCollections,
+            imports: assemblyFileVisitor.imports,
+            targetResolver: targetResolver
+        )
+    }
+}

--- a/Sources/KnitCodeGen/Configuration.swift
+++ b/Sources/KnitCodeGen/Configuration.swift
@@ -8,7 +8,8 @@ import SwiftSyntax
 public struct Configuration: Encodable {
 
     /// Name of the module for this configuration.
-    public var name: String
+    public var assemblyName: String
+    public let moduleName: String
     public var directives: KnitDirectives
     public var assemblyType: String
 
@@ -19,7 +20,8 @@ public struct Configuration: Encodable {
     public var targetResolver: String
 
     public init(
-        name: String,
+        assemblyName: String,
+        moduleName: String,
         directives: KnitDirectives = .init(),
         assemblyType: String = "Assembly",
         registrations: [Registration],
@@ -27,33 +29,29 @@ public struct Configuration: Encodable {
         imports: [ModuleImport] = [],
         targetResolver: String
     ) {
-        self.name = name
+        self.assemblyName = assemblyName
         self.directives = directives
         self.assemblyType = assemblyType
         self.registrations = registrations
         self.registrationsIntoCollections = registrationsIntoCollections
         self.imports = imports
         self.targetResolver = targetResolver
+        self.moduleName = moduleName
     }
 
     public enum CodingKeys: CodingKey {
-        case name
+        case assemblyName
         case directives
         case assemblyType
         case registrations
     }
-
-    public var moduleName: String {
-        return directives.moduleName ?? name
-    }
-
 }
 
 public extension Configuration {
 
     func makeTypeSafetySourceFile() throws -> SourceFileSyntax {
         return try TypeSafetySourceFile.make(
-            assemblyName: "\(name)Assembly",
+            assemblyName: assemblyName,
             extensionTarget: targetResolver,
             registrations: registrations
         )
@@ -64,11 +62,6 @@ public extension Configuration {
             configuration: self
         )
     }
-
-    var assemblyName: String {
-        "\(name)Assembly"
-    }
-
 }
 
 func write(text: String, to path: String) {

--- a/Sources/KnitCodeGen/ModuleNameExtractor.swift
+++ b/Sources/KnitCodeGen/ModuleNameExtractor.swift
@@ -1,0 +1,39 @@
+//
+// Copyright © Block, Inc. All rights reserved.
+//
+
+import Foundation
+
+/// Extracts the module name from an assembly file path based on regex pattern matching
+struct ModuleNameExtractor {
+
+    let moduleNameRegex: NSRegularExpression?
+
+    init(moduleNamePattern: String?) throws {
+        if let moduleNamePattern {
+            let regex = try NSRegularExpression(pattern: moduleNamePattern)
+            self.init(moduleNameRegex: regex)
+        } else {
+            self.init(moduleNameRegex: nil)
+        }
+    }
+
+    init(moduleNameRegex: NSRegularExpression?) {
+        self.moduleNameRegex = moduleNameRegex
+    }
+
+    func extractModuleName(path: String) -> String? {
+        guard let moduleNameRegex else {
+            return nil
+        }
+        guard let match = moduleNameRegex.firstMatch(in: path, range: NSRange(location: 0, length: path.count)) else {
+            return nil
+        }
+        guard match.numberOfRanges == 2 else {
+            return nil
+        }
+        return (path as NSString).substring(with: match.range(at: 1))
+    }
+
+}
+

--- a/Sources/KnitCodeGen/UnitTestSourceFile.swift
+++ b/Sources/KnitCodeGen/UnitTestSourceFile.swift
@@ -13,7 +13,7 @@ public enum UnitTestSourceFile {
         let withArguments = configuration.registrations.filter { !$0.arguments.isEmpty }
         let hasArguments = !withArguments.isEmpty
         return try SourceFileSyntax() {
-            try ClassDeclSyntax("final class \(raw: configuration.name)RegistrationTests: XCTestCase") {
+            try ClassDeclSyntax("final class \(raw: configuration.moduleName)RegistrationTests: XCTestCase") {
 
                 try FunctionDeclSyntax("func testRegistrations()") {
 
@@ -26,8 +26,8 @@ public enum UnitTestSourceFile {
                     if hasArguments {
                         DeclSyntax("""
                             // In the test target for your module, please provide a static method that provides
-                            // an instance of \(raw: configuration.name)RegistrationTestArguments
-                            let args: \(raw: configuration.name)RegistrationTestArguments = \(raw: configuration.assemblyName).makeArgumentsForTests()
+                            // an instance of \(raw: configuration.moduleName)RegistrationTestArguments
+                            let args: \(raw: configuration.moduleName)RegistrationTestArguments = \(raw: configuration.assemblyName).makeArgumentsForTests()
                             """)
                     }
 
@@ -50,7 +50,7 @@ public enum UnitTestSourceFile {
             }
 
             if hasArguments {
-                try makeArgumentStruct(registrations: configuration.registrations, moduleName: configuration.name)
+                try makeArgumentStruct(registrations: configuration.registrations, moduleName: configuration.moduleName)
             }
         }
     }

--- a/Sources/KnitCommand/GenCommand.swift
+++ b/Sources/KnitCommand/GenCommand.swift
@@ -44,16 +44,23 @@ struct GenCommand: ParsableCommand {
     @Option(help: "Default type to extend when generating Resolver type safety methods")
     var defaultExtensionTargetResolver = "Resolver"
 
+    @Option(help: """
+                  Regex used to determine the module name of an assembly based on the filepath.
+                  The regex must contain a single capture group which is the name of the module.
+                  Assemblies can also use module-name("ABC") if file paths are not consistent
+                  """)
+    var moduleNameRegex: String?
+
     public init() {}
 
     public func run() throws {
         let parsedConfig: ConfigurationSet
         do {
-            parsedConfig = try parseAssemblies(
-                at: assemblyInputPath,
+            let assemblyParser = try AssemblyParser(
                 defaultTargetResolver: defaultExtensionTargetResolver,
-                useTargetResolver: useTargetResolver
-            )
+                useTargetResolver: useTargetResolver,
+                moduleNameRegex: moduleNameRegex)
+            parsedConfig = try assemblyParser.parseAssemblies(at: assemblyInputPath)
             if let jsonDataOutputPath {
                 let data = try JSONEncoder().encode(parsedConfig.assemblies)
                 try data.write(to: URL(fileURLWithPath: jsonDataOutputPath))

--- a/Tests/KnitCodeGenTests/ConfigurationSetTests.swift
+++ b/Tests/KnitCodeGenTests/ConfigurationSetTests.swift
@@ -148,7 +148,8 @@ final class ConfigurationSetTests: XCTestCase {
 private enum Factory {
 
     static let config1 = Configuration(
-        name: "Module1",
+        assemblyName: "Module1Assembly",
+        moduleName: "Module1",
         registrations: [
             .init(service: "Service1", accessLevel: .public)
         ],
@@ -162,7 +163,8 @@ private enum Factory {
     )
 
     static let config2 = Configuration(
-        name: "Module2",
+        assemblyName: "Module2Assembly",
+        moduleName: "Module2",
         registrations: [
             .init(service: "Service2", accessLevel: .internal, getterConfig: [.callAsFunction]),
             .init(service: "ArgumentService", accessLevel: .internal, arguments: [.init(type: "String")])
@@ -176,7 +178,8 @@ private enum Factory {
     )
 
     static let config3 = Configuration(
-        name: "Module3",
+        assemblyName: "Module3Assembly",
+        moduleName: "Module3",
         registrations: [
             .init(service: "Service3", accessLevel: .public),
         ],

--- a/Tests/KnitCodeGenTests/ModuleNameExtractorTests.swift
+++ b/Tests/KnitCodeGenTests/ModuleNameExtractorTests.swift
@@ -1,0 +1,32 @@
+//
+// Copyright © Block, Inc. All rights reserved.
+//
+
+import Foundation
+@testable import KnitCodeGen
+import XCTest
+
+final class ModuleNameExtractorTests: XCTestCase {
+
+    func testWithoutCaptureGroup() throws {
+        let extractor = try ModuleNameExtractor(moduleNamePattern: ".*")
+
+        XCTAssertNil(extractor.extractModuleName(path: "Module/Assembly.swift"))
+    }
+
+    func testCaptureGroup() throws {
+        let extractor = try ModuleNameExtractor(moduleNamePattern: "Code\\/(\\w+)/")
+        XCTAssertEqual(
+            extractor.extractModuleName(path: "Code/MyModule/"),
+            "MyModule"
+        )
+
+        XCTAssertEqual(
+            extractor.extractModuleName(path: "Code/MyModule/SomeFile.swift"),
+            "MyModule"
+        )
+
+        XCTAssertNil(extractor.extractModuleName(path: "External/MyModule/Assembly.swift"))
+    }
+
+}

--- a/Tests/KnitCodeGenTests/UnitTestSourceFileTests.swift
+++ b/Tests/KnitCodeGenTests/UnitTestSourceFileTests.swift
@@ -11,7 +11,7 @@ final class UnitTestSourceFileTests: XCTestCase {
 
     func test_generation() throws {
         let result = try UnitTestSourceFile.make(
-            name: "MyModule",
+            moduleName: "MyModule",
             importDecls: [.named("Swinject")],
             registrations: [
                 .init(service: "ServiceA", name: nil, accessLevel: .internal, isForwarded: false),
@@ -57,7 +57,7 @@ final class UnitTestSourceFileTests: XCTestCase {
 
     func test_generation_emptyRegistrations() throws {
         let result = try UnitTestSourceFile.make(
-            name: "MyModule",
+            moduleName: "MyModule",
             importDecls: [.named("Swinject")],
             registrations: [],
             registrationsIntoCollections: []
@@ -82,7 +82,7 @@ final class UnitTestSourceFileTests: XCTestCase {
 
     func test_generation_onlySingleRegistrations() throws {
         let result = try UnitTestSourceFile.make(
-            name: "MyModule",
+            moduleName: "MyModule",
             importDecls: [.named("Swinject")],
             registrations: [
                 .init(service: "ServiceA", name: nil, accessLevel: .internal, isForwarded: false),
@@ -110,7 +110,7 @@ final class UnitTestSourceFileTests: XCTestCase {
 
     func test_generation_onlyRegistrationsIntoCollections() throws {
         let result = try UnitTestSourceFile.make(
-            name: "MyModule",
+            moduleName: "MyModule",
             importDecls: [.named("Swinject")],
             registrations: [],
             registrationsIntoCollections: [
@@ -221,13 +221,14 @@ final class UnitTestSourceFileTests: XCTestCase {
 private extension UnitTestSourceFile {
 
     static func make(
-        name: String,
+        moduleName: String,
         importDecls: [ModuleImport],
         registrations: [Registration],
         registrationsIntoCollections: [RegistrationIntoCollection]
     ) throws -> SourceFileSyntax {
         let configuration = Configuration(
-            name: name,
+            assemblyName: moduleName + "Assembly",
+            moduleName: moduleName,
             registrations: registrations,
             registrationsIntoCollections: registrationsIntoCollections,
             imports: importDecls,


### PR DESCRIPTION
This is a follow on from the PR adding module-name to the parsing https://github.com/squareup/knit/pull/118. While I think there is still value in being able to completely override the module name it is also somewhat painful to constantly have to do so. This allows using a regex to do this where possible.

I ended up with a bit of churn in this PR as there were a few changes I needed in order to make the result of this cleaner.

* Created `AssemblyParser` to wrap `parseAssemblies` and `parseSyntaxTree` functions
* `Configuration` explicitly has `assemblyName` and `moduleName` passed in. Previously it took `name` which could be confused.
* Updated tests to match these changes.
* Created `ModuleNameExtractor` to encapsulate the path extraction.

