### PR TITLE
Clarify what gets returned by ServiceCollection by child-parent relationships

### DIFF
--- a/Sources/Knit/ServiceCollection/Resolver+ServiceCollection.swift
+++ b/Sources/Knit/ServiceCollection/Resolver+ServiceCollection.swift
@@ -22,7 +22,7 @@ extension Resolver {
     /// - Returns: A ``ServiceCollection`` containing all registered services,
     ///            or an empty collection if no services were registered.
     public func resolveCollection<Service>(_ serviceType: Service.Type) -> ServiceCollection<Service> {
-        resolve(ServiceCollection<Service>.self) ?? .init(entries: [])
+        resolve(ServiceCollection<Service>.self) ?? .init(parent: nil, entries: [])
     }
 
 }

--- a/Sources/Knit/ServiceCollection/ServiceCollection.swift
+++ b/Sources/Knit/ServiceCollection/ServiceCollection.swift
@@ -5,5 +5,21 @@
 /// Represents the aggregate of all services registered using ``Container/registerIntoCollection(_:factory:)``
 /// or ``Container/autoregisterIntoCollection(_:initializer:)``.
 public struct ServiceCollection<T> {
-    public var entries: [T]
+    
+    // Box the parent in an array to remove issues of a recursive memory layout
+    // This array will only have 0 or 1 element
+    private let parent: [ServiceCollection<T>]
+    
+    /// Entries that were registered into the ServiceCollector in the current container
+    public let entries: [T]
+    
+    /// All entries from this and any parent containers
+    public var allEntries: [T] {
+        entries + parent.flatMap { $0.allEntries }
+    }
+    
+    public init(parent: ServiceCollection<T>?, entries: [T]) {
+        self.parent = parent.map { [$0] } ?? []
+        self.entries = entries
+    }
 }


### PR DESCRIPTION
This came up as part of office hours today where it isn't obvious whether `ServiceCollector` should replace or append to values from parent containers. The case for replacement is that normal registrations would shadow parent registrations effectively replacing them. The case for addition is that `registerIntoCollection` is normally additive.

From a practical point of view, the behaviour we want for Client routes depends on our router implementation. If it has a parent-child relationship then we would would shadowing and if it is re registering we would want additive.

This changes the internals of `ServiceCollection` to allow the caller to make that decision. `entries` does shadowing while `allEntries` is additive. Additional documentation also allows this to be surfaced rather than being an internal implementation choice.