### PR TITLE
Prevent AbstractAssembly types from having non abstract registrations

### DIFF
--- a/Sources/Knit/Module/AbstractAssembly.swift
+++ b/Sources/Knit/Module/AbstractAssembly.swift
@@ -5,4 +5,4 @@
 import Foundation
 
 /// An AbstractAssembly can only contain abstract registrations and should not be initialised.
-protocol AbstractAssembly: ModuleAssembly { }
+public protocol AbstractAssembly: ModuleAssembly { }

--- a/Sources/KnitCodeGen/Registration.swift
+++ b/Sources/KnitCodeGen/Registration.swift
@@ -16,33 +16,42 @@ public struct Registration: Equatable, Codable {
     /// Argument types required to resolve the registration
     public var arguments: [Argument]
 
-    /// This registration is forwarded to another service entry.
-    public var isForwarded: Bool
-
     /// This registration's getter setting.
     public var getterConfig: Set<GetterConfig>
 
     public var ifConfigCondition: ExprSyntax?
+    
+    /// The Swinject function that was used to register this factory
+    public let functionName: FunctionName
 
     public init(
         service: String,
         name: String? = nil,
-        accessLevel: AccessLevel,
+        accessLevel: AccessLevel = .internal,
         arguments: [Argument] = [],
-        isForwarded: Bool = false,
-        getterConfig: Set<GetterConfig> = GetterConfig.default
+        getterConfig: Set<GetterConfig> = GetterConfig.default,
+        functionName: FunctionName = .register
     ) {
         self.service = service
         self.name = name
         self.accessLevel = accessLevel
         self.arguments = arguments
-        self.isForwarded = isForwarded
         self.getterConfig = getterConfig
+        self.functionName = functionName
+    }
+
+    var isAbstract: Bool {
+        return functionName == .registerAbstract
+    }
+
+    /// This registration is forwarded to another service entry.
+    var isForwarded: Bool {
+        return functionName == .implements
     }
 
     private enum CodingKeys: CodingKey {
         // ifConfigCondition is not encoded since ExprSyntax does not conform to codable
-        case service, name, accessLevel, arguments, isForwarded, getterConfig
+        case service, name, accessLevel, arguments, getterConfig, functionName
     }
 
 }
@@ -68,5 +77,15 @@ extension Registration {
             case computed
         }
 
+    }
+
+    public enum FunctionName: String, Codable {
+        case register
+        case autoregister
+        case registerAbstract
+        case implements
+
+        static let standaloneFunctions: Set<FunctionName> = [.register, .autoregister, .registerAbstract]
+        static let standaloneNames: Set<String> = Set(standaloneFunctions.map { $0.rawValue })
     }
 }

--- a/Tests/KnitCodeGenTests/AssemblyParsingTests.swift
+++ b/Tests/KnitCodeGenTests/AssemblyParsingTests.swift
@@ -504,6 +504,27 @@ final class AssemblyParsingTests: XCTestCase {
         XCTAssertEqual(config2?.moduleName, "My")
     }
 
+    func testAbstractAssemblyWithNonAbstractRegistrations() throws {
+        let sourceFile: SourceFileSyntax = """
+            class MyAbstractAssembly: AbstractAssembly {
+                func assemble(container: Container) {
+                    container.register(A.self) { }
+                }
+            }
+        """
+
+        _ = try assertParsesSyntaxTree(
+            sourceFile,
+            assertErrorsToPrint: { errors in
+                XCTAssertEqual(errors.count, 1)
+                XCTAssertEqual(
+                    errors.first?.localizedDescription,
+                    "AbstractAssemblys may only contain Abstract registrations"
+                )
+            }
+        )
+    }
+
 }
 
 private func assertParsesSyntaxTree(

--- a/Tests/KnitCodeGenTests/NamedRegistrationGroupTests.swift
+++ b/Tests/KnitCodeGenTests/NamedRegistrationGroupTests.swift
@@ -10,11 +10,11 @@ final class NamedRegistrationGroupTests: XCTestCase {
 
     func testRegistrationGrouping() throws {
         let registrations: [Registration] = [
-            .init(service: "ServiceA", name: nil, accessLevel: .internal, isForwarded: false),
-            .init(service: "ServiceA", name: "name1", accessLevel: .internal, isForwarded: false),
-            .init(service: "ServiceB", name: "name1", accessLevel: .internal, isForwarded: false),
-            .init(service: "ServiceA", name: "name2", accessLevel: .internal, isForwarded: false),
-            .init(service: "ServiceB", name: "name3", accessLevel: .public, isForwarded: false),
+            .init(service: "ServiceA", name: nil),
+            .init(service: "ServiceA", name: "name1"),
+            .init(service: "ServiceB", name: "name1"),
+            .init(service: "ServiceA", name: "name2"),
+            .init(service: "ServiceB", name: "name3", accessLevel: .public),
         ]
 
         let namedGroups = NamedRegistrationGroup.make(from: registrations)

--- a/Tests/KnitCodeGenTests/RegistrationParsingTests.swift
+++ b/Tests/KnitCodeGenTests/RegistrationParsingTests.swift
@@ -25,8 +25,8 @@ final class RegistrationParsingTests: XCTestCase {
             .inObjectScope(.container)
             """,
             registrations: [
-                Registration(service: "AType", name: nil, accessLevel: .internal, isForwarded: false),
-                Registration(service: "AnotherType", name: nil, accessLevel: .internal, isForwarded: true),
+                Registration(service: "AType", name: nil, accessLevel: .internal, functionName: .register),
+                Registration(service: "AnotherType", name: nil, accessLevel: .internal, functionName: .implements),
             ]
         )
         try assertRegistrationString(
@@ -143,8 +143,8 @@ final class RegistrationParsingTests: XCTestCase {
             .implements(B.self)
             """,
             registrations: [
-                Registration(service: "A", name: nil, accessLevel: .internal, isForwarded: false),
-                Registration(service: "B", name: nil, accessLevel: .internal, isForwarded: true),
+                Registration(service: "A", name: nil, accessLevel: .internal, functionName: .register),
+                Registration(service: "B", name: nil, accessLevel: .internal, functionName: .implements),
             ]
         )
 
@@ -157,10 +157,10 @@ final class RegistrationParsingTests: XCTestCase {
             .implements(D.self, name: "bar")
             """,
             registrations: [
-                Registration(service: "A", name: nil, accessLevel: .internal, isForwarded: false),
-                Registration(service: "B", name: nil, accessLevel: .internal, isForwarded: true),
-                Registration(service: "C", name: "foo", accessLevel: .public, isForwarded: true),
-                Registration(service: "D", name: "bar", accessLevel: .internal, isForwarded: true),
+                Registration(service: "A", name: nil, accessLevel: .internal, functionName: .autoregister),
+                Registration(service: "B", name: nil, accessLevel: .internal, functionName: .implements),
+                Registration(service: "C", name: "foo", accessLevel: .public, functionName: .implements),
+                Registration(service: "D", name: "bar", accessLevel: .internal, functionName: .implements),
             ]
         )
 
@@ -174,9 +174,9 @@ final class RegistrationParsingTests: XCTestCase {
             .implements(C.self)
             """,
             registrations: [
-                Registration(service: "A", name: nil, accessLevel: .hidden, isForwarded: false),
-                Registration(service: "B", name: nil, accessLevel: .public, isForwarded: true),
-                Registration(service: "C", name: nil, accessLevel: .hidden, isForwarded: true)
+                Registration(service: "A", name: nil, accessLevel: .hidden, functionName: .register),
+                Registration(service: "B", name: nil, accessLevel: .public, functionName: .implements),
+                Registration(service: "C", name: nil, accessLevel: .hidden, functionName: .implements)
             ]
         )
     }
@@ -268,7 +268,7 @@ final class RegistrationParsingTests: XCTestCase {
         try assertMultipleRegistrationsString(
             "container.autoregister(A.self, argument: URL.self, initializer: A.init)",
             registrations: [
-                Registration(service: "A", accessLevel: .internal, arguments: [.init(type: "URL")])
+                Registration(service: "A", accessLevel: .internal, arguments: [.init(type: "URL")], functionName: .autoregister)
             ]
         )
 
@@ -291,7 +291,8 @@ final class RegistrationParsingTests: XCTestCase {
                         .init(type: "URL"),
                         .init(type: "Int"),
                         .init(type: "String"),
-                    ]
+                    ],
+                    functionName: .autoregister
                 )
             ]
         )
@@ -302,7 +303,7 @@ final class RegistrationParsingTests: XCTestCase {
             container.autoregister(A.self, name: "test", argument: URL.self, initializer: A.init)
             """,
             registrations: [
-                Registration(service: "A", name: "test", accessLevel: .internal, arguments: [.init(type: "URL")])
+                Registration(service: "A", name: "test", arguments: [.init(type: "URL")], functionName: .autoregister)
             ]
         )
 
@@ -322,7 +323,8 @@ final class RegistrationParsingTests: XCTestCase {
                     service: "A",
                     name: "test",
                     accessLevel: .internal,
-                    arguments: [.init(type: "URL"), .init(type: "Int")]
+                    arguments: [.init(type: "URL"), .init(type: "Int")],
+                    functionName: .autoregister
                 )
             ]
         )
@@ -335,7 +337,7 @@ final class RegistrationParsingTests: XCTestCase {
                 container.register(A.self, factory: A.staticFunc)
             """,
             registrations: [
-                Registration(service: "A", accessLevel: .internal, arguments: [], isForwarded: false)
+                Registration(service: "A", arguments: [])
             ]
         )
     }
@@ -349,8 +351,8 @@ final class RegistrationParsingTests: XCTestCase {
             .implements(B.self)
             """,
             registrations: [
-                Registration(service: "A", accessLevel: .internal, arguments: [.init(type: "URL")]),
-                Registration(service: "B", accessLevel: .internal, arguments: [.init(type: "URL")], isForwarded: true)
+                Registration(service: "A", arguments: [.init(type: "URL")], functionName: .autoregister),
+                Registration(service: "B", arguments: [.init(type: "URL")], functionName: .implements)
             ]
         )
 
@@ -363,8 +365,8 @@ final class RegistrationParsingTests: XCTestCase {
             .implements(B.self)
             """,
             registrations: [
-                Registration(service: "A", accessLevel: .internal, arguments: [.init(identifier: "arg", type: "String")]),
-                Registration(service: "B", accessLevel: .internal, arguments: [.init(identifier: "arg", type: "String")], isForwarded: true)
+                Registration(service: "A", arguments: [.init(identifier: "arg", type: "String")]),
+                Registration(service: "B", arguments: [.init(identifier: "arg", type: "String")], functionName: .implements)
             ]
         )
     }
@@ -399,7 +401,7 @@ final class RegistrationParsingTests: XCTestCase {
             container.autoregister(A.self, argument: String?.self, initializer: A.init)
             """,
             registrations: [
-                Registration(service: "A", accessLevel: .internal, arguments: [.init(type: "String?")]),
+                Registration(service: "A", arguments: [.init(type: "String?")], functionName: .autoregister),
             ]
         )
 
@@ -410,11 +412,12 @@ final class RegistrationParsingTests: XCTestCase {
             registrations: [
                 Registration(
                     service: "A",
-                    accessLevel: .internal,
                     arguments: [
                         .init(type: "Result<Int, Error>"),
                         .init(type: "Optional<Int>"),
-                    ]),
+                    ],
+                    functionName: .autoregister
+                ),
             ]
         )
 
@@ -424,7 +427,7 @@ final class RegistrationParsingTests: XCTestCase {
             container.autoregister((String, Int?).self, initializer: Factory.make)
             """,
             registrations: [
-                .init(service: "(String, Int?)", accessLevel: .internal, getterConfig: [.identifiedGetter(nil)])
+                .init(service: "(String, Int?)", getterConfig: [.identifiedGetter(nil)], functionName: .autoregister)
             ]
         )
     }
@@ -433,7 +436,7 @@ final class RegistrationParsingTests: XCTestCase {
         try assertMultipleRegistrationsString(
             "container.autoregister(A.self, argument: (() -> Void).self, initializer: A.init)",
             registrations: [
-                Registration(service: "A", accessLevel: .internal, arguments: [.init(type: "(() -> Void)")]),
+                Registration(service: "A", arguments: [.init(type: "(() -> Void)")], functionName: .autoregister),
             ]
         )
 
@@ -444,7 +447,7 @@ final class RegistrationParsingTests: XCTestCase {
             }
             """,
             registrations: [
-                Registration(service: "A", accessLevel: .internal, arguments: [.init(identifier: "arg1", type: "() -> Void")]),
+                Registration(service: "A", arguments: [.init(identifier: "arg1", type: "() -> Void")]),
             ]
         )
     }

--- a/Tests/KnitCodeGenTests/TypeSafetySourceFileTests.swift
+++ b/Tests/KnitCodeGenTests/TypeSafetySourceFileTests.swift
@@ -14,11 +14,11 @@ final class TypeSafetySourceFileTests: XCTestCase {
             assemblyName: "ModuleAssembly",
             extensionTarget: "Resolve",
             registrations: [
-                .init(service: "ServiceA", name: nil, accessLevel: .internal, isForwarded: false),
-                .init(service: "ServiceB", name: "name", accessLevel: .internal, isForwarded: false),
-                .init(service: "ServiceB", name: "otherName", accessLevel: .internal, isForwarded: false),
-                .init(service: "ServiceC", name: nil, accessLevel: .hidden, isForwarded: false), // No resolver is created
-                .init(service: "ServiceD", name: nil, accessLevel: .public, isForwarded: true, getterConfig: GetterConfig.both),
+                .init(service: "ServiceA", name: nil),
+                .init(service: "ServiceB", name: "name"),
+                .init(service: "ServiceB", name: "otherName"),
+                .init(service: "ServiceC", name: nil, accessLevel: .hidden), // No resolver is created
+                .init(service: "ServiceD", name: nil, accessLevel: .public, getterConfig: GetterConfig.both, functionName: .implements),
                 .init(service: "ServiceE", name: nil, accessLevel: .public, arguments: [.init(type: "() -> Void")]),
                 .init(service: "ServiceF", name: nil, accessLevel: .public, getterConfig: [GetterConfig.identifiedGetter(nil)]),
                 .init(service: "(String, Int?)", name: nil, accessLevel: .public, getterConfig: [GetterConfig.identifiedGetter(nil)]),

--- a/Tests/KnitCodeGenTests/UnitTestSourceFileTests.swift
+++ b/Tests/KnitCodeGenTests/UnitTestSourceFileTests.swift
@@ -14,10 +14,10 @@ final class UnitTestSourceFileTests: XCTestCase {
             moduleName: "MyModule",
             importDecls: [.named("Swinject")],
             registrations: [
-                .init(service: "ServiceA", name: nil, accessLevel: .internal, isForwarded: false),
-                .init(service: "ServiceB", name: "name", accessLevel: .internal, isForwarded: false),
-                .init(service: "ServiceB", name: "otherName", accessLevel: .internal, isForwarded: true),
-                .init(service: "ServiceC", name: nil, accessLevel: .hidden, isForwarded: false),
+                .init(service: "ServiceA", name: nil),
+                .init(service: "ServiceB", name: "name"),
+                .init(service: "ServiceB", name: "otherName", functionName: .implements),
+                .init(service: "ServiceC", name: nil, accessLevel: .hidden),
                 .init(service: "ServiceD", accessLevel: .hidden, arguments: [.init(type: "String")]),
             ],
             registrationsIntoCollections: [
@@ -154,7 +154,7 @@ final class UnitTestSourceFileTests: XCTestCase {
             moduleName: "MyModule",
             importDecls: [.named("Swinject")],
             registrations: [
-                .init(service: "ServiceA", name: nil, accessLevel: .internal, isForwarded: false),
+                .init(service: "ServiceA", name: nil),
             ],
             registrationsIntoCollections: []
         )


### PR DESCRIPTION
I added `Registration.FunctionName` to distinguish between the registration types we support. This replaces `isForwarded` as `implements` is just one of the cases.

With that information it is now possible to raise an error if an `AbstractAssembly` includes non abstract registrations. The purpose of this is to be able to stop running tests against abstract assemblies as it doesn't make any sense. I'll put that change in a separate PR. https://github.com/squareup/knit/pull/131
