### PR TITLE
Correctly name unit test arguments structs

### DIFF
--- a/Sources/KnitCodeGen/ConfigurationSet.swift
+++ b/Sources/KnitCodeGen/ConfigurationSet.swift
@@ -58,17 +58,21 @@ public extension ConfigurationSet {
         return Self.join(sourceFiles: sourceFiles)
     }
 
-    func makeUnitTestSourceFile() throws -> String {
+    func makeUnitTestSourceFile(includeExtensions: Bool = true) throws -> String {
         let header = HeaderSourceFile.make(imports: unitTestImports().sorted, comment: nil)
         var body = try assemblies.map { try $0.makeUnitTestSourceFile() }
         body.append(contentsOf: try makeAdditionalTestsSources())
         let allRegistrations = allAssemblies.flatMap { $0.registrations }
         let allRegistrationsIntoCollections = allAssemblies.flatMap { $0.registrationsIntoCollections }
-        let resolverExtensions = try UnitTestSourceFile.resolverExtensions(
-            registrations: allRegistrations,
-            registrationsIntoCollections: allRegistrationsIntoCollections
-        )
-        let sourceFiles = [header] + body + [resolverExtensions]
+        var sourceFiles = [header] + body
+        if includeExtensions {
+            let resolverExtensions = try UnitTestSourceFile.resolverExtensions(
+                registrations: allRegistrations,
+                registrationsIntoCollections: allRegistrationsIntoCollections
+            )
+            sourceFiles.append(resolverExtensions)
+        }
+
         return Self.join(sourceFiles: sourceFiles)
     }
 

--- a/Sources/KnitCodeGen/UnitTestSourceFile.swift
+++ b/Sources/KnitCodeGen/UnitTestSourceFile.swift
@@ -37,8 +37,8 @@ public enum UnitTestSourceFile {
                     if hasArguments && !isAdditionalTest {
                         DeclSyntax("""
                             // In the test target for your module, please provide a static method that provides
-                            // an instance of \(raw: configuration.moduleName)RegistrationTestArguments
-                            let args: \(raw: configuration.moduleName)RegistrationTestArguments = \(raw: configuration.assemblyName).makeArgumentsForTests()
+                            // an instance of \(raw: configuration.assemblyShortName)RegistrationTestArguments
+                            let args: \(raw: configuration.assemblyShortName)RegistrationTestArguments = \(raw: configuration.assemblyName).makeArgumentsForTests()
                             """)
                     }
 
@@ -61,7 +61,7 @@ public enum UnitTestSourceFile {
             }
 
             if hasArguments {
-                try makeArgumentStruct(registrations: configuration.registrations, moduleName: configuration.moduleName)
+                try makeArgumentStruct(registrations: configuration.registrations, assemblyName: configuration.assemblyShortName)
             }
         }
     }
@@ -205,7 +205,7 @@ public enum UnitTestSourceFile {
     }
 
     /// Generate code for a struct that contains all of the parameters used to resolve services
-    static func makeArgumentStruct(registrations: [Registration], moduleName: String) throws -> StructDeclSyntax {
+    static func makeArgumentStruct(registrations: [Registration], assemblyName: String) throws -> StructDeclSyntax {
         let fields = registrations.flatMap { $0.serviceNamedArguments() }
         var seen: Set<String> = []
         // Make sure duplicate parameters don't get created
@@ -218,7 +218,7 @@ public enum UnitTestSourceFile {
             return true
         }
 
-        return try StructDeclSyntax("struct \(raw: moduleName)RegistrationTestArguments") {
+        return try StructDeclSyntax("struct \(raw: assemblyName)RegistrationTestArguments") {
             for field in uniqueFields {
                 DeclSyntax("let \(raw: field.resolvedIdentifier()): \(raw: field.type)")
             }


### PR DESCRIPTION
I found this when trying to use `--module-name-regex`. Previously something like `CommonCashAppAssembly` would get the module name calculated as `CommonCashApp`. This made some places in `UnitTestSourceFile` which were using module name work until that value was corrected.

I added an extra test which would have caught this issue, which is most of the lines from this test.