### PR TITLE
Disable test generation for abstract assemblies

### DIFF
--- a/Sources/KnitCodeGen/Configuration.swift
+++ b/Sources/KnitCodeGen/Configuration.swift
@@ -63,6 +63,10 @@ public struct Configuration: Encodable {
         return String(assemblyName.dropLast(8))
     }
 
+    var isAbstract: Bool {
+        return assemblyType == "AbstractAssembly"
+    }
+
 }
 
 public extension Configuration {

--- a/Sources/KnitCodeGen/ConfigurationSet.swift
+++ b/Sources/KnitCodeGen/ConfigurationSet.swift
@@ -60,7 +60,9 @@ public extension ConfigurationSet {
 
     func makeUnitTestSourceFile(includeExtensions: Bool = true) throws -> String {
         let header = HeaderSourceFile.make(imports: unitTestImports().sorted, comment: nil)
-        var body = try assemblies.map { try $0.makeUnitTestSourceFile() }
+        var body = try assemblies
+            .filter { !$0.isAbstract }
+            .map { try $0.makeUnitTestSourceFile() }
         body.append(contentsOf: try makeAdditionalTestsSources())
         let allRegistrations = allAssemblies.flatMap { $0.registrations }
         let allRegistrationsIntoCollections = allAssemblies.flatMap { $0.registrationsIntoCollections }

--- a/Tests/KnitCodeGenTests/UnitTestSourceFileTests.swift
+++ b/Tests/KnitCodeGenTests/UnitTestSourceFileTests.swift
@@ -124,6 +124,35 @@ final class UnitTestSourceFileTests: XCTestCase {
         XCTAssertEqual(try set.makeUnitTestSourceFile(includeExtensions: false), expected)
     }
 
+    func test_abstract_unit_tests() throws {
+        let configuration = Configuration(
+            assemblyName: "ModuleAbstractAssembly",
+            moduleName: "Module",
+            assemblyType: "AbstractAssembly",
+            registrations: [
+                .init(service: "ServiceA", accessLevel: .internal, arguments: [.init(type: "String")]),
+            ],
+            registrationsIntoCollections: [],
+            targetResolver: "Resolver"
+        )
+        
+        let set = ConfigurationSet(
+            assemblies: [configuration],
+            externalTestingAssemblies: []
+        )
+        
+        // No tests are generated as the assembly is abstract
+        let expected = #"""
+        // Generated using Knit
+        // Do not edit directly!
+
+        @testable import Module
+        import XCTest
+        """#
+        XCTAssertEqual(try set.makeUnitTestSourceFile(includeExtensions: false), expected)
+
+    }
+
     func test_generation_emptyRegistrations() throws {
         let result = try UnitTestSourceFile.make(
             moduleName: "MyModule",


### PR DESCRIPTION
There's not really a point in running tests on a pure abstract assembly since it would have to use fakes. This stops the tests being generated.