### PR TITLE
Parse ModuleAssembly implements syntax

### DIFF
--- a/Sources/KnitCodeGen/AssemblyParser.swift
+++ b/Sources/KnitCodeGen/AssemblyParser.swift
@@ -112,6 +112,7 @@ public struct AssemblyParser {
             registrations: assemblyFileVisitor.registrations,
             registrationsIntoCollections: assemblyFileVisitor.registrationsIntoCollections,
             imports: assemblyFileVisitor.imports,
+            implements: assemblyFileVisitor.implements,
             targetResolver: targetResolver
         )
     }

--- a/Sources/KnitCodeGen/Configuration.swift
+++ b/Sources/KnitCodeGen/Configuration.swift
@@ -17,6 +17,7 @@ public struct Configuration: Encodable {
     public var registrationsIntoCollections: [RegistrationIntoCollection]
 
     public var imports: [ModuleImport] = []
+    public var implements: [String]
     public var targetResolver: String
 
     public init(
@@ -27,6 +28,7 @@ public struct Configuration: Encodable {
         registrations: [Registration],
         registrationsIntoCollections: [RegistrationIntoCollection],
         imports: [ModuleImport] = [],
+        implements: [String] = [],
         targetResolver: String
     ) {
         self.assemblyName = assemblyName
@@ -36,6 +38,7 @@ public struct Configuration: Encodable {
         self.registrationsIntoCollections = registrationsIntoCollections
         self.imports = imports
         self.targetResolver = targetResolver
+        self.implements = implements
         self.moduleName = moduleName
     }
 
@@ -44,6 +47,7 @@ public struct Configuration: Encodable {
         case directives
         case assemblyType
         case registrations
+        case implements
     }
 
     // Testing all registrations introduces complications, limit what is tested for simplicity


### PR DESCRIPTION
This will allow future validation to ensure that when one ModuleAssembly is marked as implementing another it registers the same interface.  