### PR TITLE
Define first part of KnitModule with the associated code generation

### DIFF
--- a/Sources/Knit/Module/KnitModule.swift
+++ b/Sources/Knit/Module/KnitModule.swift
@@ -1,0 +1,11 @@
+//
+// Copyright © Block, Inc. All rights reserved.
+//
+
+import Foundation
+
+public protocol KnitModule {
+    
+    /// The list of all assemblies contained in this module
+    static var assemblies: [any ModuleAssembly.Type] { get }
+}

--- a/Sources/KnitCodeGen/KnitModuleSourceFile.swift
+++ b/Sources/KnitCodeGen/KnitModuleSourceFile.swift
@@ -1,0 +1,85 @@
+//  Created by Alex Skorulis on 10/4/2024.
+
+import Foundation
+import SwiftSyntax
+import SwiftSyntaxBuilder
+
+/// Source code defining a KnitModule implementation for module configurations
+public enum KnitModuleSourceFile {
+    
+    public static func make(
+        configurations: [Configuration]
+    ) throws -> SourceFileSyntax {
+        guard let firstConfig = configurations.first else {
+            throw Error.noAssemblies
+        }
+        return SourceFileSyntax(leadingTrivia: TriviaProvider.headerTrivia) {
+            DeclSyntax("import Knit")
+            makeTypeDefinition(moduleName: firstConfig.moduleName, configurations: configurations)
+        }
+    }
+
+    private static func makeTypeDefinition(
+        moduleName: String,
+        configurations: [Configuration]
+    ) -> EnumDeclSyntax {
+        let assemblyNames = configurations.map { $0.assemblyName }
+        return EnumDeclSyntax(
+            modifiers: [
+                DeclModifierSyntax(name: TokenSyntax(.keyword(.public), presence: .present))
+            ],
+            name: "\(raw: moduleName)_KnitModule: KnitModule"
+        ) {
+            makeAssembliesVar(assemblyNames: assemblyNames)
+        }
+    }
+
+    private static func makeAssembliesVar(assemblyNames: [String]) -> VariableDeclSyntax {
+        let accessorBlock = AccessorBlockSyntax(
+            accessors: .getter(.init(
+                itemsBuilder: {
+                    let elements = ArrayElementListSyntax {
+                        for name in assemblyNames {
+                            ArrayElementSyntax(
+                                leadingTrivia: [ .newlines(1) ],
+                                expression: "\(raw: name).self" as ExprSyntax
+                            )
+                        }
+                    }
+
+                    ArrayExprSyntax(elements: elements)
+                }
+            ))
+        )
+
+        return VariableDeclSyntax(
+            modifiers: [
+                DeclModifierSyntax(name: TokenSyntax(.keyword(.public), presence: .present)),
+                DeclModifierSyntax(name: TokenSyntax(.keyword(.static), presence: .present)),
+            ],
+            bindingSpecifier: .keyword(.var),
+            bindingsBuilder: {
+                PatternBindingSyntax(
+                    pattern: IdentifierPatternSyntax(identifier: .identifier("assemblies")),
+                    typeAnnotation: TypeAnnotationSyntax(type: "[any ModuleAssembly.Type]" as TypeSyntax),
+                    accessorBlock: accessorBlock
+                )
+            }
+        )
+    }
+}
+
+// MARK: -
+
+extension KnitModuleSourceFile {
+    enum Error: LocalizedError {
+        case noAssemblies
+
+        var errorDescription: String? {
+            switch self {
+            case .noAssemblies:
+                return "Attempting to generate a KnitModule without any Configurations"
+            }
+        }
+    }
+}

--- a/Tests/KnitCodeGenTests/KnitModuleSourceFileTests.swift
+++ b/Tests/KnitCodeGenTests/KnitModuleSourceFileTests.swift
@@ -1,0 +1,49 @@
+//
+// Copyright © Block, Inc. All rights reserved.
+//
+
+@testable import KnitCodeGen
+import XCTest
+
+final class KnitModuleSourceFileTests: XCTestCase {
+
+    func test_generation() throws {
+        let configurations: [Configuration] = [
+            .init(
+                assemblyName: "MyAssembly",
+                moduleName: "MyModule",
+                registrations: [],
+                registrationsIntoCollections: [],
+                targetResolver: "AppResolver"
+            ),
+            .init(
+                assemblyName: "SecondAssembly",
+                moduleName: "MyModule",
+                registrations: [],
+                registrationsIntoCollections: [],
+                targetResolver: "SignedInResolver"
+            ),
+        ]
+
+        let result = try XCTUnwrap(KnitModuleSourceFile.make(configurations: configurations))
+
+        let expected = #"""
+        // Generated using Knit
+        // Do not edit directly!
+
+        import Knit
+        public enum MyModule_KnitModule: KnitModule {
+            public static var assemblies: [any ModuleAssembly.Type] {
+                [
+                    MyAssembly.self,
+                    SecondAssembly.self]
+            }
+        }
+        """#
+
+        XCTAssertEqual(
+            result.formatted().description,
+            expected
+        )
+    }
+}


### PR DESCRIPTION
This is the first definition of KnitModule which will help to consolidate multiple commands and simplify code paths where modules have multiple assemblies.

This code is currently only used by the tests. In order to keep the PRs small I'm breaking this work into multiple chunks.