### PR TITLE
Change generated output to include links back to the assembly

### DIFF
--- a/Sources/KnitCodeGen/TypeSafetySourceFile.swift
+++ b/Sources/KnitCodeGen/TypeSafetySourceFile.swift
@@ -21,7 +21,7 @@ public enum TypeSafetySourceFile {
         let namedGroups = NamedRegistrationGroup.make(from: visibleRegistrations)
         return try SourceFileSyntax() {
             try ExtensionDeclSyntax("""
-                          // Generated from \(raw: assemblyName)
+                          /// Generated from ``\(raw: assemblyName)``
                           extension \(raw: extensionTarget)
                           """) {
 

--- a/Tests/KnitCodeGenTests/ConfigurationSetTests.swift
+++ b/Tests/KnitCodeGenTests/ConfigurationSetTests.swift
@@ -25,13 +25,13 @@ final class ConfigurationSetTests: XCTestCase {
 
             // The correct resolution of each of these types is enforced by a matching automated unit test
             // If a type registration is missing or broken then the automated tests will fail for that PR
-            // Generated from Module1Assembly
+            /// Generated from ``Module1Assembly``
             extension Resolver {
                 public func service1() -> Service1 {
                     knitUnwrap(resolve(Service1.self))
                 }
             }
-            // Generated from Module2Assembly
+            /// Generated from ``Module2Assembly``
             extension Resolver {
                 public func callAsFunction() -> Service2 {
                     knitUnwrap(resolve(Service2.self))
@@ -40,7 +40,7 @@ final class ConfigurationSetTests: XCTestCase {
                     knitUnwrap(resolve(ArgumentService.self, argument: string))
                 }
             }
-            // Generated from Module3Assembly
+            /// Generated from ``Module3Assembly``
             extension Resolver {
                 public func service3() -> Service3 {
                     knitUnwrap(resolve(Service3.self))

--- a/Tests/KnitCodeGenTests/TypeSafetySourceFileTests.swift
+++ b/Tests/KnitCodeGenTests/TypeSafetySourceFileTests.swift
@@ -26,7 +26,7 @@ final class TypeSafetySourceFileTests: XCTestCase {
         )
 
         let expected = """
-        // Generated from ModuleAssembly
+        /// Generated from ``ModuleAssembly``
         extension Resolve {
             func serviceA() -> ServiceA {
                 knitUnwrap(resolve(ServiceA.self))


### PR DESCRIPTION
Quality of life improvement which adds a clickable link to the outputted source code to navigate back to the assembly.

<img width="188" src="https://github.com/squareup/knit/assets/77594448/d9ae8df0-11f4-4f5b-8fdf-544a84043304">
