### PR TITLE
Add an option to output the KnitModule source file via the GenCommand

### DIFF
--- a/Sources/Knit/Module/KnitModule.swift
+++ b/Sources/Knit/Module/KnitModule.swift
@@ -8,4 +8,15 @@ public protocol KnitModule {
     
     /// The list of all assemblies contained in this module
     static var assemblies: [any ModuleAssembly.Type] { get }
+    
+    /// The list of modules that this module depends on
+    static var moduleDependencies: [KnitModule.Type] { get }
+}
+
+public extension KnitModule {
+
+    /// All known assemblies that are involved in this modules dependency graph
+    static var allAssemblies: [any ModuleAssembly.Type] {
+        return moduleDependencies.flatMap { $0.assemblies } + assemblies
+    }
 }

--- a/Sources/KnitCodeGen/AssemblyParser.swift
+++ b/Sources/KnitCodeGen/AssemblyParser.swift
@@ -24,7 +24,8 @@ public struct AssemblyParser {
 
     public func parseAssemblies(
         at paths: [String],
-        externalTestingAssemblies: [String]
+        externalTestingAssemblies: [String],
+        moduleDependencies: [String]
     ) throws -> ConfigurationSet {
         let configs = try paths.flatMap { path in
             return try parse(
@@ -41,7 +42,11 @@ public struct AssemblyParser {
             )
         }
 
-        return ConfigurationSet(assemblies: configs, externalTestingAssemblies: additionalConfigs)
+        return ConfigurationSet(
+            assemblies: configs,
+            externalTestingAssemblies: additionalConfigs,
+            moduleDependencies: moduleDependencies
+        )
     }
 
     private func parse(path: String, defaultTargetResolver: String, useTargetResolver: Bool) throws -> [Configuration] {

--- a/Sources/KnitCodeGen/SwiftSyntax+Helpers.swift
+++ b/Sources/KnitCodeGen/SwiftSyntax+Helpers.swift
@@ -1,0 +1,54 @@
+//
+// Copyright © Block, Inc. All rights reserved.
+//
+
+import SwiftSyntax
+import SwiftSyntaxBuilder
+
+// Helpers to simplify common swift code patterns
+
+extension AccessorBlockSyntax {
+    
+    /// Create an AccessorBlockSyntax for an array of values
+    static func arrayAccessor(elements: [String]) -> AccessorBlockSyntax {
+        AccessorBlockSyntax(
+            accessors: .getter(.init(
+                itemsBuilder: {
+                    let elements = ArrayElementListSyntax {
+                        for element in elements {
+                            ArrayElementSyntax(
+                                leadingTrivia: [ .newlines(1) ],
+                                expression: "\(raw: element)" as ExprSyntax
+                            )
+                        }
+                    }
+
+                    ArrayExprSyntax(elements: elements)
+                }
+            ))
+        )
+    }
+}
+
+extension VariableDeclSyntax {
+
+    static func makeVar(
+        keywords: [Keyword],
+        name: String,
+        type: String,
+        accessorBlock: AccessorBlockSyntax
+    ) -> VariableDeclSyntax {
+        let modifiers = keywords.map { DeclModifierSyntax(name: TokenSyntax(.keyword($0), presence: .present)) }
+        return VariableDeclSyntax(
+            modifiers: .init(modifiers),
+            bindingSpecifier: .keyword(.var),
+            bindingsBuilder: {
+                PatternBindingSyntax(
+                    pattern: IdentifierPatternSyntax(identifier: .identifier(name)),
+                    typeAnnotation: TypeAnnotationSyntax(type: TypeSyntax(stringLiteral: type)),
+                    accessorBlock: accessorBlock
+                )
+            }
+        )
+    }
+}

--- a/Sources/KnitCommand/GenCommand.swift
+++ b/Sources/KnitCommand/GenCommand.swift
@@ -27,7 +27,14 @@ struct GenCommand: ParsableCommand {
     var externalTestingAssemblies: [String] = []
 
     @Option(help: """
-                  Path to the file location in the current module where the unit test source should be written.
+                    An array of string arguments for the name of each module dependency.
+                    If none are provided a file will still be written to the outputPath.
+                    If the module name ends in "Assembly" it will be treated as an additional assembly.
+                    """)
+    var dependencyModuleNames = [String]()
+
+    @Option(help: """
+                  Path to the file location in the current module where the resolver type safety source should be written.
                   For example: `${PODS_TARGET_SRCROOT}/Sources/Generated/KnitDITypeSafety.swift`
                   """)
     var typeSafetyExtensionsOutputPath: String?
@@ -37,6 +44,12 @@ struct GenCommand: ParsableCommand {
                   For example: `${PODS_TARGET_SRCROOT}/UnitTests/Generated/KnitDIRegistrationTests.swift`
                   """)
     var unitTestOutputPath: String?
+
+    @Option(help: """
+                  Path to the file location in the current module where the KnitModule defintion should be written.
+                  For example: `${PODS_TARGET_SRCROOT}/Sources/Generated/KnitDITypeSafety.swift`
+                  """)
+    var knitModuleOutputPath: String?
 
     @Option(help: """
                   Path to the file location where the intermediate parsed data should be written
@@ -68,7 +81,8 @@ struct GenCommand: ParsableCommand {
                 moduleNameRegex: moduleNameRegex)
             parsedConfig = try assemblyParser.parseAssemblies(
                 at: assemblyInputPath,
-                externalTestingAssemblies: externalTestingAssemblies
+                externalTestingAssemblies: externalTestingAssemblies,
+                moduleDependencies: dependencyModuleNames
             )
             if let jsonDataOutputPath {
                 let data = try JSONEncoder().encode(parsedConfig.allAssemblies)
@@ -81,7 +95,8 @@ struct GenCommand: ParsableCommand {
 
         try parsedConfig.writeGeneratedFiles(
             typeSafetyExtensionsOutputPath: typeSafetyExtensionsOutputPath,
-            unitTestOutputPath: unitTestOutputPath
+            unitTestOutputPath: unitTestOutputPath,
+            knitModuleOutputPath: knitModuleOutputPath
         )
     }
 

--- a/Tests/KnitCodeGenTests/KnitModuleSourceFileTests.swift
+++ b/Tests/KnitCodeGenTests/KnitModuleSourceFileTests.swift
@@ -25,18 +25,34 @@ final class KnitModuleSourceFileTests: XCTestCase {
             ),
         ]
 
-        let result = try XCTUnwrap(KnitModuleSourceFile.make(configurations: configurations))
+        let result = try XCTUnwrap(
+            KnitModuleSourceFile.make(
+                configurations: configurations,
+                dependencies: ["ModuleB", "ModuleC"]
+            )
+        )
 
         let expected = #"""
-        // Generated using Knit
-        // Do not edit directly!
-
-        import Knit
         public enum MyModule_KnitModule: KnitModule {
             public static var assemblies: [any ModuleAssembly.Type] {
                 [
                     MyAssembly.self,
                     SecondAssembly.self]
+            }
+            public static var moduleDependencies: [KnitModule.Type] {
+                [
+                    ModuleB_KnitModule.self,
+                    ModuleC_KnitModule.self]
+            }
+        }
+        extension MyAssembly: GeneratedModuleAssembly {
+            public static var generatedDependencies: [any ModuleAssembly.Type] {
+                MyModule_KnitModule.allAssemblies
+            }
+        }
+        extension SecondAssembly: GeneratedModuleAssembly {
+            public static var generatedDependencies: [any ModuleAssembly.Type] {
+                MyModule_KnitModule.allAssemblies
             }
         }
         """#

--- a/Tests/KnitCodeGenTests/UnitTestSourceFileTests.swift
+++ b/Tests/KnitCodeGenTests/UnitTestSourceFileTests.swift
@@ -79,7 +79,8 @@ final class UnitTestSourceFileTests: XCTestCase {
 
         let set = ConfigurationSet(
             assemblies: [mainConfiguration, appConfiguration],
-            externalTestingAssemblies: []
+            externalTestingAssemblies: [],
+            moduleDependencies: []
         )
 
         let expected = #"""
@@ -138,7 +139,8 @@ final class UnitTestSourceFileTests: XCTestCase {
         
         let set = ConfigurationSet(
             assemblies: [configuration],
-            externalTestingAssemblies: []
+            externalTestingAssemblies: [],
+            moduleDependencies: []
         )
         
         // No tests are generated as the assembly is abstract


### PR DESCRIPTION
I've set up the code to generate this in a different file which makes this completely backwards compatible. In the future we may want to combine the type safe resolvers and knit module files but in the short term this makes for an easier migration.

I've gotten a draft branch to integrate this with cash-ios to shake out any issues, tests are green locally.

Once this is fully integrated, `ModuleDependenciesCommand` can be deleted.