### PR TITLE
Create ModuleAssemblerErrorFormatter

### DIFF
--- a/Sources/Knit/Module/Container+AbstractRegistration.swift
+++ b/Sources/Knit/Module/Container+AbstractRegistration.swift
@@ -53,10 +53,10 @@ extension Container {
     }
 
     // Collect
-    struct AbstractRegistrationErrors: LocalizedError {
+    public struct AbstractRegistrationErrors: LocalizedError {
         let errors: [AbstractRegistrationError]
 
-        var errorDescription: String? {
+        public var errorDescription: String? {
             return errors.map { $0.localizedDescription }.joined(separator: "\n")
         }
     }

--- a/Sources/Knit/Module/DependencyTree.swift
+++ b/Sources/Knit/Module/DependencyTree.swift
@@ -91,6 +91,15 @@ public struct DependencyTree: CustomDebugStringConvertible {
     private func findImplementations(assemblyRef: AssemblyReference) -> [AssemblyReference] {
         return allModules.filter { $0.type.doesImplement(type: assemblyRef.type) && $0 != assemblyRef}
     }
+
+    public func sourcePathString(moduleName: String) -> String {
+        let modules = sourcePath(moduleName: moduleName).joined(separator: " -> ")
+        return "Dependency path: \(modules)"
+    }
+
+    public func sourcePathString(moduleType: any ModuleAssembly.Type) -> String {
+        return sourcePathString(moduleName: String(describing: moduleType))
+    }
 }
 
 /// Wrapper for the types to allow them to be hashable

--- a/Sources/Knit/Module/ModuleAssemblerErrorFormatter.swift
+++ b/Sources/Knit/Module/ModuleAssemblerErrorFormatter.swift
@@ -1,0 +1,72 @@
+//
+// Copyright © Block, Inc. All rights reserved.
+//
+
+import Foundation
+
+public protocol ModuleAssemblerErrorFormatter {
+    func format(knitError: KnitAssemblyError, dependencyTree: DependencyTree?) -> String
+}
+
+extension ModuleAssemblerErrorFormatter {
+
+    func format(error: Error, dependencyTree: DependencyTree?) -> String {
+        if let abstract = error as? Container.AbstractRegistrationErrors {
+            return format(knitError: .abstract(abstract), dependencyTree: dependencyTree)
+        } else if let scoped = error as? ScopedModuleAssemblerError {
+            return format(knitError: .scoped(scoped), dependencyTree: dependencyTree)
+        } else if let builder = error as? DependencyBuilderError {
+            return format(knitError: .dependencyBuilder(builder), dependencyTree: dependencyTree)
+        } else {
+            // Crash on unexpected errors, new errors should be added to KnitAssemblyError as they are introduced
+            fatalError("Unexpected error thrown during Knit graph construction: \(error.localizedDescription)")
+        }
+    }
+}
+
+public struct DefaultModuleAssemblerErrorFormatter: ModuleAssemblerErrorFormatter {
+
+    public init() {}
+
+    public func format(knitError: KnitAssemblyError, dependencyTree: DependencyTree?) -> String {
+        let info = "Error creating ModuleAssembler. Please make sure all necessary assemblies are provided."
+        switch knitError {
+        case let .abstract(abstractErrors):
+            let messages = abstractErrors.errors.map { abstractError in
+                let assemblyName = abstractError.file.replacingOccurrences(of: ".swift", with: "")
+                if let path = dependencyTree?.sourcePathString(moduleName: assemblyName) {
+                    return "\(abstractError.localizedDescription)\n\(path)"
+                } else {
+                    return abstractError.localizedDescription
+                }
+            }
+            return "\(messages.joined(separator: "\n"))\n\(info)"
+        default:
+            return "Error: \(knitError.localizedDescription)\(info)"
+        }
+    }
+
+}
+
+public enum KnitAssemblyError {
+    
+    /// An error that occured while the DependencyBuilder was building the tree
+    case dependencyBuilder(DependencyBuilderError)
+
+    /// An error related to validating the scoping rules
+    case scoped(ScopedModuleAssemblerError)
+
+    /// Errors related to abstract registrations
+    case abstract(Container.AbstractRegistrationErrors)
+
+    public var localizedDescription: String {
+        switch self {
+        case let .dependencyBuilder(dependencyBuilderError):
+            return dependencyBuilderError.localizedDescription
+        case let .scoped(scopedModuleAssemblerError):
+            return scopedModuleAssemblerError.localizedDescription
+        case let .abstract(abstractRegistrationErrors):
+            return abstractRegistrationErrors.localizedDescription
+        }
+    }
+}

--- a/Sources/Knit/Module/ScopedModuleAssembler.swift
+++ b/Sources/Knit/Module/ScopedModuleAssembler.swift
@@ -65,11 +65,11 @@ public final class ScopedModuleAssembler<ScopedResolver> {
 
 // MARK: - Errors
 
-enum ScopedModuleAssemblerError: LocalizedError {
+public enum ScopedModuleAssemblerError: LocalizedError {
 
     case incorrectTargetResolver(expected: String, actual: String)
 
-    var errorDescription: String? {
+    public var errorDescription: String? {
         switch self {
         case let .incorrectTargetResolver(expected, actual):
             return """

--- a/Tests/KnitTests/AbstractRegistrationTests.swift
+++ b/Tests/KnitTests/AbstractRegistrationTests.swift
@@ -61,7 +61,8 @@ final class AbstractRegistrationTests: XCTestCase {
         let builder = try DependencyBuilder(modules: [Assembly1()])
         let error = Container.AbstractRegistrationError(serviceType: "String", file: "Assembly2.swift", name: nil)
         let errors = Container.AbstractRegistrationErrors(errors: [error])
-        let result = ModuleAssembler.formatErrors(dependencyBuilder: builder, error: errors)
+        let formatter = DefaultModuleAssemblerErrorFormatter()
+        let result = formatter.format(error: errors, dependencyTree: builder.dependencyTree)
         XCTAssertEqual(
             result,
             """

--- a/Tests/KnitTests/DependencyBuilderTests.swift
+++ b/Tests/KnitTests/DependencyBuilderTests.swift
@@ -159,7 +159,7 @@ final class DependencyBuilderTests: XCTestCase {
                     "'Assembly1' is the assembly that should fail, and the reason from the embedded error should also be displayed"
                 )
 
-                if case let DependencyBuilder.Error.assemblyValidationFailure(moduleType, reason: reasonError) = error {
+                if case let DependencyBuilderError.assemblyValidationFailure(moduleType, reason: reasonError) = error {
                     XCTAssert(moduleType == Assembly1.self)
                     if case DependencyBuilderTestError.failedValidation = reasonError {
                         // Correct `reasonError`

--- a/Tests/KnitTests/ModuleAssemblerErrorFormatterTests.swift
+++ b/Tests/KnitTests/ModuleAssemblerErrorFormatterTests.swift
@@ -1,0 +1,33 @@
+//
+// Copyright © Block, Inc. All rights reserved.
+//
+
+@testable import Knit
+import XCTest
+
+final class ModuleAssemblerErrorFormatterTests: XCTestCase {
+
+    func testScopedErrorConversion() {
+        let formatter = TestErrorFormatter()
+        let message = formatter.format(
+            error: ScopedModuleAssemblerError.incorrectTargetResolver(expected: "A", actual: "B"),
+            dependencyTree: nil
+        )
+        XCTAssertEqual(message, "Scoped")
+    }
+}
+
+private final class TestErrorFormatter: ModuleAssemblerErrorFormatter {
+
+    func format(knitError: KnitAssemblyError, dependencyTree: DependencyTree?) -> String {
+        switch knitError {
+        case .dependencyBuilder:
+            return "Dependency Builder"
+        case .scoped:
+            return "Scoped"
+        case .abstract:
+            return "Abstract"
+        }
+    }
+
+}

--- a/Tests/KnitTests/ModuleCycleTests.swift
+++ b/Tests/KnitTests/ModuleCycleTests.swift
@@ -15,12 +15,12 @@ final class ModuleCycleTests: XCTestCase {
         XCTAssertTrue(assembler.isRegistered(Assembly4.self))
 
         XCTAssertEqual(
-            assembler.builder.sourcePath(moduleType: Assembly1.self),
+            assembler.builder.dependencyTree.sourcePath(moduleType: Assembly1.self),
             ["\(Assembly1.self)"]
         )
 
         XCTAssertEqual(
-            assembler.builder.sourcePath(moduleType: Assembly3.self),
+            assembler.builder.dependencyTree.sourcePath(moduleType: Assembly3.self),
             ["\(Assembly1.self)", "\(Assembly3.self)"]
         )
     }
@@ -28,12 +28,12 @@ final class ModuleCycleTests: XCTestCase {
     func test_sourceCycle() {
         let assembler = ModuleAssembler([Assembly5()])
         XCTAssertEqual(
-            assembler.builder.sourcePath(moduleType: Assembly5.self),
+            assembler.builder.dependencyTree.sourcePath(moduleType: Assembly5.self),
             ["\(Assembly5.self)"]
         )
 
         XCTAssertEqual(
-            assembler.builder.sourcePath(moduleType: Assembly7.self),
+            assembler.builder.dependencyTree.sourcePath(moduleType: Assembly7.self),
             ["\(Assembly5.self)", "\(Assembly6.self)", "\(Assembly7.self)"]
         )
     }


### PR DESCRIPTION
This allows an external caller to add more helpful information into the failures that is specific to the app setup.