### PR TITLE
Allow directories to be provided for parsing assemblies

### DIFF
--- a/Sources/KnitCodeGen/AssemblyParser.swift
+++ b/Sources/KnitCodeGen/AssemblyParser.swift
@@ -86,7 +86,7 @@ public struct AssemblyParser {
         
         // If the file doesn't contain assemblies in a valid format, throw to let the developer know
         if assemblyFileVisitor.classDeclVisitors.isEmpty && !assemblyFileVisitor.hasIgnoredConfigurations {
-            throw AssemblyParsingError.noAssembliesFound
+            throw AssemblyParsingError.noAssembliesFound(path ?? "Missing Path")
         }
 
 

--- a/Sources/KnitCodeGen/AssemblyParsing.swift
+++ b/Sources/KnitCodeGen/AssemblyParsing.swift
@@ -243,7 +243,7 @@ enum AssemblyParsingError: Error {
     case fileReadError(Error, path: String)
     case missingAssemblyType
     case parsingError
-    case noAssembliesFound
+    case noAssembliesFound(String)
     case moduleNameMismatch
 }
 
@@ -260,8 +260,8 @@ extension AssemblyParsingError: LocalizedError {
             return "There were one or more errors parsing the assembly file"
         case .missingAssemblyType:
             return "Assembly files must inherit from an *Assembly type"
-        case .noAssembliesFound:
-            return "The given file did not contain any valid assemblies"
+        case let .noAssembliesFound(path):
+            return "The given file path did not contain any valid assemblies: \(path)"
         case .moduleNameMismatch:
             return "Assemblies in a single file have different modules"
         }


### PR DESCRIPTION
This simplifies the command when a module contains multiple assemblies. Instead of passing them individually the entire directory can be processed.

I haven't added any tests because it depends on the real file system. Adding mocks seems like overkill for this small usage. I did test that cash-ios still worked when migrating some Knit inputs to use folders. 