### PR TITLE
Expose access to the ModuleAssembler Container

### DIFF
--- a/Sources/Knit/Module/ScopedModuleAssembler.swift
+++ b/Sources/Knit/Module/ScopedModuleAssembler.swift
@@ -14,6 +14,11 @@ public final class ScopedModuleAssembler<ScopedResolver> {
         internalAssembler.resolver as! ScopedResolver
     }
 
+    /// The container that registrations have been placed in. Prefer using resolver unless mutable access is required
+    public var _container: Container {
+        return internalAssembler._container
+    }
+
     public convenience init(
         parent: ModuleAssembler? = nil,
         _ modules: [any Assembly],


### PR DESCRIPTION
I was doing some experimental work which required using `container.resetObjectScope`. Since only `Resolver` is exposed I was unable to make this call.

I've added a comment to discourage it's use, but it's there when required.