### PR TITLE
Introduce FakeAssembly

### DIFF
--- a/Sources/Knit/Module/FakeAssembly.swift
+++ b/Sources/Knit/Module/FakeAssembly.swift
@@ -1,0 +1,24 @@
+//
+// Copyright © Block, Inc. All rights reserved.
+//
+
+import Foundation
+
+/// An assembly that functions as a fake replacement for another
+/// This type is designed to handle the base case for fake assemblies, for more complex cases use a standard ModuleAssembly
+/// The following rules are applied:
+/// * The FakeAssembly must use the same TargetResolver as the real assembly
+/// * The real assembly must have a DefaultModuleAssemblyOverride setup pointing to this fake
+/// * The FakeAssembly defaults to no dependencies to prevent expanding the DI graph
+/// * The FakeAssembly is defined to implement the real assembly
+public protocol FakeAssembly<ImplementedAssembly>: AutoInitModuleAssembly {
+    associatedtype ImplementedAssembly: DefaultModuleAssemblyOverride where
+        ImplementedAssembly.OverrideType == Self,
+        ImplementedAssembly.TargetResolver == Self.TargetResolver
+}
+
+public extension FakeAssembly {
+
+    static var implements: [any ModuleAssembly.Type] { [ImplementedAssembly.self] }
+    static var dependencies: [any ModuleAssembly.Type] { [] }
+}

--- a/Sources/KnitCodeGen/AssemblyParser.swift
+++ b/Sources/KnitCodeGen/AssemblyParser.swift
@@ -130,6 +130,8 @@ public struct AssemblyParser {
             throw AssemblyParsingError.missingAssemblyType
         }
 
+        let fakeImplements = classDeclVisitor.fakeImplementedType.map { [$0] } ?? []
+
         return Configuration(
             assemblyName: classDeclVisitor.assemblyName,
             moduleName: moduleName,
@@ -138,7 +140,7 @@ public struct AssemblyParser {
             registrations: classDeclVisitor.registrations,
             registrationsIntoCollections: classDeclVisitor.registrationsIntoCollections,
             imports: assemblyFileVisitor.imports,
-            implements: classDeclVisitor.implements,
+            implements: fakeImplements + classDeclVisitor.implements,
             targetResolver: targetResolver
         )
     }

--- a/Sources/KnitCodeGen/AssemblyParsing.swift
+++ b/Sources/KnitCodeGen/AssemblyParsing.swift
@@ -121,6 +121,8 @@ class ClassDeclVisitor: SyntaxVisitor, IfConfigVisitor {
 
     private(set) var targetResolver: String?
 
+    private(set) var fakeImplementedType: String?
+
     /// For any registrations parsed, this #if condition should be applied when it is used
     var currentIfConfigCondition: IfConfigVisitorCondition?
 
@@ -207,9 +209,13 @@ class ClassDeclVisitor: SyntaxVisitor, IfConfigVisitor {
     }
 
     override func visit(_ node: TypeAliasDeclSyntax) -> SyntaxVisitorContinueKind {
-        if node.name.text == "TargetResolver",
-           let identifier = node.initializer.value.as(IdentifierTypeSyntax.self) {
+        guard let identifier = node.initializer.value.as(IdentifierTypeSyntax.self) else {
+            return .skipChildren
+        }
+        if node.name.text == "TargetResolver" {
             self.targetResolver = identifier.name.text
+        } else if node.name.text == "ImplementedAssembly" {
+            self.fakeImplementedType = identifier.name.text
         }
 
         return .skipChildren

--- a/Sources/KnitCodeGen/Configuration.swift
+++ b/Sources/KnitCodeGen/Configuration.swift
@@ -18,6 +18,7 @@ public struct Configuration: Encodable {
         case moduleAssembly = "ModuleAssembly"
         case autoInitAssembly = "AutoInitModuleAssembly"
         case abstractAssembly = "AbstractAssembly"
+        case fakeAssembly = "FakeAssembly"
     }
     public var assemblyType: AssemblyType
 

--- a/Sources/KnitCodeGen/KnitModuleSourceFile.swift
+++ b/Sources/KnitCodeGen/KnitModuleSourceFile.swift
@@ -67,7 +67,9 @@ public enum KnitModuleSourceFile {
         let accessorBlock = AccessorBlockSyntax(
             accessors: .getter(.init(stringLiteral: "\(moduleName)_KnitModule.allAssemblies"))
         )
-        return try ExtensionDeclSyntax("extension \(raw: configuration.assemblyName): GeneratedModuleAssembly") {
+        // Don't conform FakeAssembly to GeneratedModuleAssembly to prevent conflicting implementations of `dependencies`
+        let conformance = configuration.assemblyType != .fakeAssembly ? ": GeneratedModuleAssembly" : ""
+        return try ExtensionDeclSyntax("extension \(raw: configuration.assemblyName)\(raw: conformance)") {
             VariableDeclSyntax.makeVar(
                 keywords: [.public, .static],
                 name: "generatedDependencies",

--- a/Tests/KnitCodeGenTests/AssemblyParsingTests.swift
+++ b/Tests/KnitCodeGenTests/AssemblyParsingTests.swift
@@ -675,6 +675,31 @@ final class AssemblyParsingTests: XCTestCase {
         )
     }
 
+    func testFakeAssembly() throws {
+        let sourceFile: SourceFileSyntax = """
+            class TestAssembly: FakeAssembly {
+                typealias ImplementedAssembly = RealAssembly
+            }
+            """
+
+        let config = try assertParsesSyntaxTree(sourceFile)
+        XCTAssertEqual(config.implements, ["RealAssembly"])
+        XCTAssertEqual(config.assemblyType, .fakeAssembly)
+        XCTAssertEqual(config.assemblyName, "TestAssembly")
+    }
+
+    func testFakeAssemblyCustomImplements() throws {
+        let sourceFile: SourceFileSyntax = """
+            class TestAssembly: FakeAssembly {
+                typealias ImplementedAssembly = RealAssembly
+                static var implements: [any ModuleAssembly.Type] { [AdditionalAssembly.self] }
+            }
+            """
+
+        let config = try assertParsesSyntaxTree(sourceFile)
+        XCTAssertEqual(config.implements, ["RealAssembly", "AdditionalAssembly"])
+        XCTAssertEqual(config.assemblyType, .fakeAssembly)
+    }
 
 }
 

--- a/Tests/KnitTests/FakeAssemblyTests.swift
+++ b/Tests/KnitTests/FakeAssemblyTests.swift
@@ -1,0 +1,26 @@
+//
+// Copyright © Block, Inc. All rights reserved.
+//
+
+import Knit
+import XCTest
+
+final class FakeAssemblyTests: XCTestCase {
+    func testFakeAssembly() {
+        XCTAssertEqual(FakeTestAssembly.dependencies.count, 0)
+    }
+}
+
+private final class RealAssembly: AutoInitModuleAssembly {
+    static var dependencies: [any ModuleAssembly.Type] { [] }
+    func assemble(container: Swinject.Container) {}
+}
+
+private final class FakeTestAssembly: FakeAssembly {
+    typealias ImplementedAssembly = RealAssembly
+    func assemble(container: Swinject.Container) {}
+}
+
+extension RealAssembly: DefaultModuleAssemblyOverride {
+    typealias OverrideType = FakeTestAssembly
+}


### PR DESCRIPTION
This PR created a `FakeAssembly` type designed to be used like `class FakeFeatureAssembly: FakeAssembly { ... }`. This solves potential foot guns when creating a fake assembly which are only identified at runtime.

* Forgetting to set the same `TargetResolver`
* Not setting up `DefaultModuleAssemblyOverride` for the real class
* Forgetting to add `static var dependencies: [any ModuleAssembly.Type] { [] }` to prevent the fake pulling in more assemblies.
* Forgetting to add `static var implements: [any ModuleAssembly.Type] { [ RealAssembly.self ] }` so the fake completely replaces the real assembly.

It is designed to solve the most common cases, where it doesn't quite work a custom fake can be created that doesn't use `FakeAssembly`
