### PR TITLE
Rename `implements` to `replaces`

### DIFF
--- a/Docs/Modules.md
+++ b/Docs/Modules.md
@@ -14,11 +14,11 @@ if the `ModuleAssembly` cannot be initialised without a parameter that is provid
 ## Overriding Implementations
 
 For testing it may be required that an entire module should be swapped out. For example, a database module assembly may want to setup an in memory database while running tests.
-For these cases `static var implements` defines which modules the assembly overrides. It can then be used as a replacement for any `ModuleAssembly` that it implements. When an override is defined the original assembly will not be registered, the override will be substituted.
+For these cases `static var replaces` defines which modules the assembly overrides. It can then be used as a replacement for any `ModuleAssembly` that it declares it replaces. When an override is defined the original assembly will not be registered, the override will be substituted.
 Overrides do not need to be in the same codebase as the original. The usual expectation is that the ModuleFakes would provide a separate version for testing if required.
 
 ## DefaultModuleAssemblyOverride
 
-Using `implements` provides the power to swap DI module implementations but requires explicit setup. A base assembly that implements `DefaultModuleAssemblyOverride` can automatically choose the override when default overrides are enabled in the `ModuleAssembler`. This defaults to true for unit testing and false for normal app runs.
+Using `replaces` provides the power to swap DI module implementations but requires explicit setup. A base assembly that implements `DefaultModuleAssemblyOverride` can automatically choose the override when default overrides are enabled in the `ModuleAssembler`. This defaults to true for unit testing and false for normal app runs.
 
 

--- a/Sources/Knit/Module/DependencyTree.swift
+++ b/Sources/Knit/Module/DependencyTree.swift
@@ -80,16 +80,16 @@ public struct DependencyTree: CustomDebugStringConvertible {
         let childRows = children.flatMap { debugDescription(assemblyRef: $0, indent: newIndent) }
 
         var selfRow = "\(indent)\(assemblyRef.name)"
-        let implementations = findImplementations(assemblyRef: assemblyRef).map { $0.name }.joined(separator: ", ")
-        if !implementations.isEmpty {
-            selfRow += " (\(implementations))"
+        let replacements = findReplacements(assemblyRef: assemblyRef).map { $0.name }.joined(separator: ", ")
+        if !replacements.isEmpty {
+            selfRow += " (\(replacements))"
         }
 
         return [selfRow] + childRows
     }
 
-    private func findImplementations(assemblyRef: AssemblyReference) -> [AssemblyReference] {
-        return allModules.filter { $0.type.doesImplement(type: assemblyRef.type) && $0 != assemblyRef}
+    private func findReplacements(assemblyRef: AssemblyReference) -> [AssemblyReference] {
+        return allModules.filter { $0.type.doesReplace(type: assemblyRef.type) && $0 != assemblyRef}
     }
 
     public func sourcePathString(moduleName: String) -> String {

--- a/Sources/Knit/Module/FakeAssembly.swift
+++ b/Sources/Knit/Module/FakeAssembly.swift
@@ -10,15 +10,15 @@ import Foundation
 /// * The FakeAssembly must use the same TargetResolver as the real assembly
 /// * The real assembly must have a DefaultModuleAssemblyOverride setup pointing to this fake
 /// * The FakeAssembly defaults to no dependencies to prevent expanding the DI graph
-/// * The FakeAssembly is defined to implement the real assembly
-public protocol FakeAssembly<ImplementedAssembly>: AutoInitModuleAssembly {
-    associatedtype ImplementedAssembly: DefaultModuleAssemblyOverride where
-        ImplementedAssembly.OverrideType == Self,
-        ImplementedAssembly.TargetResolver == Self.TargetResolver
+/// * The FakeAssembly is defined to replace the real assembly
+public protocol FakeAssembly<ReplacedAssembly>: AutoInitModuleAssembly {
+    associatedtype ReplacedAssembly: DefaultModuleAssemblyOverride where
+        ReplacedAssembly.OverrideType == Self,
+        ReplacedAssembly.TargetResolver == Self.TargetResolver
 }
 
 public extension FakeAssembly {
 
-    static var implements: [any ModuleAssembly.Type] { [ImplementedAssembly.self] }
+    static var replaces: [any ModuleAssembly.Type] { [ReplacedAssembly.self] }
     static var dependencies: [any ModuleAssembly.Type] { [] }
 }

--- a/Sources/Knit/Module/ModuleAssembly.swift
+++ b/Sources/Knit/Module/ModuleAssembly.swift
@@ -13,11 +13,10 @@ public protocol ModuleAssembly: Assembly {
 
     static var dependencies: [any ModuleAssembly.Type] { get }
 
-    /// A ModuleAssembly can implement any number of other modules' assemblies.
-    /// If this module implements another it is expected to provide all registrations that the implemented assemblies supply.
-    /// A common case is for an "implementation" assembly to fulfill all the abstract registrations from an AbstractAssembly.
-    /// Similarly, another common case is a fake assembly that registers fake services matching those from the original module.
-    static var implements: [any ModuleAssembly.Type] { get }
+    /// A ModuleAssembly can replace any number of other module assemblies.
+    /// If this assembly replaces another it is expected to provide all registrations from the replaced assemblies.
+    /// A common case is a fake assembly that registers fake services matching those from the original module.
+    static var replaces: [any ModuleAssembly.Type] { get }
 
     /// Filter the list of dependencies down to those which match the scope of this assembly
     /// This can be overridden in apps with custom Resolver hierarchies
@@ -31,7 +30,7 @@ public extension ModuleAssembly {
         TargetResolver.self
     }
 
-    static var implements: [any ModuleAssembly.Type] { [] }
+    static var replaces: [any ModuleAssembly.Type] { [] }
 
     static func scoped(_ dependencies: [any ModuleAssembly.Type]) -> [any ModuleAssembly.Type] {
         return dependencies.filter {

--- a/Sources/KnitCodeGen/AssemblyParser.swift
+++ b/Sources/KnitCodeGen/AssemblyParser.swift
@@ -130,7 +130,7 @@ public struct AssemblyParser {
             throw AssemblyParsingError.missingAssemblyType
         }
 
-        let fakeImplements = classDeclVisitor.fakeImplementedType.map { [$0] } ?? []
+        let fakeReplaces = classDeclVisitor.fakeReplacesType.map { [$0] } ?? []
 
         return Configuration(
             assemblyName: classDeclVisitor.assemblyName,
@@ -140,7 +140,7 @@ public struct AssemblyParser {
             registrations: classDeclVisitor.registrations,
             registrationsIntoCollections: classDeclVisitor.registrationsIntoCollections,
             imports: assemblyFileVisitor.imports,
-            implements: fakeImplements + classDeclVisitor.implements,
+            replaces: fakeReplaces + classDeclVisitor.replaces,
             targetResolver: targetResolver
         )
     }

--- a/Sources/KnitCodeGen/Configuration.swift
+++ b/Sources/KnitCodeGen/Configuration.swift
@@ -26,7 +26,7 @@ public struct Configuration: Encodable {
     public var registrationsIntoCollections: [RegistrationIntoCollection]
 
     public var imports: [ModuleImport] = []
-    public var implements: [String]
+    public var replaces: [String]
     public var targetResolver: String
 
     public init(
@@ -37,7 +37,7 @@ public struct Configuration: Encodable {
         registrations: [Registration],
         registrationsIntoCollections: [RegistrationIntoCollection],
         imports: [ModuleImport] = [],
-        implements: [String] = [],
+        replaces: [String] = [],
         targetResolver: String
     ) {
         self.assemblyName = assemblyName
@@ -47,7 +47,7 @@ public struct Configuration: Encodable {
         self.registrationsIntoCollections = registrationsIntoCollections
         self.imports = imports
         self.targetResolver = targetResolver
-        self.implements = implements
+        self.replaces = replaces
         self.moduleName = moduleName
     }
 
@@ -56,7 +56,7 @@ public struct Configuration: Encodable {
         case directives
         case assemblyType
         case registrations
-        case implements
+        case replaces
     }
 
     // Testing all registrations introduces complications, limit what is tested for simplicity

--- a/Sources/KnitCodeGen/FunctionCallRegistrationParsing.swift
+++ b/Sources/KnitCodeGen/FunctionCallRegistrationParsing.swift
@@ -86,7 +86,7 @@ extension FunctionCallExprSyntax {
         }
 
         let implementsCalledMethods = calledMethods.filter { method in
-            method.calledExpression.declName.baseName.text == "implements"
+            method.calledExpression.declName.baseName.text == Registration.FunctionName.implements.rawValue
         }
 
         var forwardedRegistrations = [Registration]()

--- a/Tests/KnitCodeGenTests/AssemblyParsingTests.swift
+++ b/Tests/KnitCodeGenTests/AssemblyParsingTests.swift
@@ -625,40 +625,40 @@ final class AssemblyParsingTests: XCTestCase {
         )
     }
 
-    func testAssemblyImplements() throws {
+    func testAssemblyReplaces() throws {
         let sourceFile: SourceFileSyntax = """
             class TestAssembly: Assembly {
                 func assemble(container: Container) {
                     container.register(A.self) { }
                 }
-                static var implements: [any ModuleAssembly.Type] {
+                static var replaces: [any ModuleAssembly.Type] {
                     [RealAssembly.self, SecondAssembly.self]
                 }
             }
             """
 
         let config = try assertParsesSyntaxTree(sourceFile)
-        XCTAssertEqual(config.implements, ["RealAssembly", "SecondAssembly"])
+        XCTAssertEqual(config.replaces, ["RealAssembly", "SecondAssembly"])
     }
 
-    func testImplementsAsLet() throws {
+    func testReplacesAsLet() throws {
         let sourceFile: SourceFileSyntax = """
             class TestAssembly: Assembly {
                 func assemble(container: Container) {
                     container.register(A.self) { }
                 }
-                static let implements: [any ModuleAssembly.Type] = [RealAssembly.self, SecondAssembly.self]
+                static let replaces: [any ModuleAssembly.Type] = [RealAssembly.self, SecondAssembly.self]
             }
             """
 
         let config = try assertParsesSyntaxTree(sourceFile)
-        XCTAssertEqual(config.implements, ["RealAssembly", "SecondAssembly"])
+        XCTAssertEqual(config.replaces, ["RealAssembly", "SecondAssembly"])
     }
     
-    func testInvalidImplements() throws {
+    func testInvalidReplaces() throws {
         let sourceFile: SourceFileSyntax = """
             class TestAssembly: Assembly {
-                static lazy var implements: [any ModuleAssembly.Type] = {
+                static lazy var replaces: [any ModuleAssembly.Type] = {
                 []
             }()
             """
@@ -669,7 +669,7 @@ final class AssemblyParsingTests: XCTestCase {
                 XCTAssertEqual(errors.count, 1)
                 XCTAssertEqual(
                     errors.first?.localizedDescription,
-                    "Unexpected implements syntax"
+                    "Unexpected replaces syntax"
                 )
             }
         )
@@ -678,26 +678,26 @@ final class AssemblyParsingTests: XCTestCase {
     func testFakeAssembly() throws {
         let sourceFile: SourceFileSyntax = """
             class TestAssembly: FakeAssembly {
-                typealias ImplementedAssembly = RealAssembly
+                typealias ReplacedAssembly = RealAssembly
             }
             """
 
         let config = try assertParsesSyntaxTree(sourceFile)
-        XCTAssertEqual(config.implements, ["RealAssembly"])
+        XCTAssertEqual(config.replaces, ["RealAssembly"])
         XCTAssertEqual(config.assemblyType, .fakeAssembly)
         XCTAssertEqual(config.assemblyName, "TestAssembly")
     }
 
-    func testFakeAssemblyCustomImplements() throws {
+    func testFakeAssemblyCustomReplaces() throws {
         let sourceFile: SourceFileSyntax = """
             class TestAssembly: FakeAssembly {
-                typealias ImplementedAssembly = RealAssembly
-                static var implements: [any ModuleAssembly.Type] { [AdditionalAssembly.self] }
+                typealias ReplacedAssembly = RealAssembly
+                static var replaces: [any ModuleAssembly.Type] { [AdditionalAssembly.self] }
             }
             """
 
         let config = try assertParsesSyntaxTree(sourceFile)
-        XCTAssertEqual(config.implements, ["RealAssembly", "AdditionalAssembly"])
+        XCTAssertEqual(config.replaces, ["RealAssembly", "AdditionalAssembly"])
         XCTAssertEqual(config.assemblyType, .fakeAssembly)
     }
 

--- a/Tests/KnitTests/ComplexDependencyTests.swift
+++ b/Tests/KnitTests/ComplexDependencyTests.swift
@@ -63,7 +63,7 @@ private struct Assembly2: ModuleAssembly {
 // Assembly2Fake overrides Assembly2
 private struct Assembly2Fake: AutoInitModuleAssembly {
     static var dependencies: [any ModuleAssembly.Type] { [] }
-    static var implements: [any ModuleAssembly.Type] { [Assembly2.self] }
+    static var replaces: [any ModuleAssembly.Type] { [Assembly2.self] }
     func assemble(container: Container) {}
 }
 

--- a/Tests/KnitTests/DependencyBuilderTests.swift
+++ b/Tests/KnitTests/DependencyBuilderTests.swift
@@ -133,7 +133,7 @@ final class DependencyBuilderTests: XCTestCase {
                 """
                 Assembly6 used as default override does not implement Assembly5
                 SUGGESTED FIX:
-                public static var implements: [any ModuleAssembly.Type] {
+                public static var replaces: [any ModuleAssembly.Type] {
                     return [Assembly5.self]
                 }
                 """
@@ -196,14 +196,14 @@ private struct Assembly1: ModuleAssembly {
     func assemble(container: Container) {}
 }
 
-// Assembly2 has no dependencies but implements Assembly8
+// Assembly2 has no dependencies but replaces Assembly8
 private struct Assembly2: AutoInitModuleAssembly {
 
     static var dependencies: [any ModuleAssembly.Type] {
         return []
     }
 
-    static var implements: [any ModuleAssembly.Type] { [Assembly8.self] }
+    static var replaces: [any ModuleAssembly.Type] { [Assembly8.self] }
 
     func assemble(container: Container) {}
 }

--- a/Tests/KnitTests/FakeAssemblyTests.swift
+++ b/Tests/KnitTests/FakeAssemblyTests.swift
@@ -17,7 +17,7 @@ private final class RealAssembly: AutoInitModuleAssembly {
 }
 
 private final class FakeTestAssembly: FakeAssembly {
-    typealias ImplementedAssembly = RealAssembly
+    typealias ReplacedAssembly = RealAssembly
     func assemble(container: Swinject.Container) {}
 }
 

--- a/Tests/KnitTests/ModuleAssemblerTests.swift
+++ b/Tests/KnitTests/ModuleAssemblerTests.swift
@@ -158,7 +158,7 @@ private struct Assembly5: AutoInitModuleAssembly {
         // Missing a concrete registration for `Assembly5Protocol`
     }
     
-    static var implements: [any ModuleAssembly.Type] {
+    static var replaces: [any ModuleAssembly.Type] {
         [AbstractAssembly5.self]
     }
 

--- a/Tests/KnitTests/ModuleAssemblyOverrideTests.swift
+++ b/Tests/KnitTests/ModuleAssemblyOverrideTests.swift
@@ -177,7 +177,7 @@ private struct Assembly2Fake: AutoInitModuleAssembly {
         container.autoregister(Service2Protocol.self, initializer: Service2Fake.init)
     }
 
-    static var implements: [any ModuleAssembly.Type] { [Assembly2.self] }
+    static var replaces: [any ModuleAssembly.Type] { [Assembly2.self] }
     static var dependencies: [any ModuleAssembly.Type] {
         return [FakeAssembly3.self]
     }
@@ -186,7 +186,7 @@ private struct Assembly2Fake: AutoInitModuleAssembly {
 private struct Assembly1Fake: AutoInitModuleAssembly {
     func assemble(container: Container) {}
     static var dependencies: [any ModuleAssembly.Type] { [] }
-    static var implements: [any ModuleAssembly.Type] { [Assembly1.self] }
+    static var replaces: [any ModuleAssembly.Type] { [Assembly1.self] }
 }
 
 extension Assembly1: DefaultModuleAssemblyOverride {
@@ -212,19 +212,19 @@ extension Assembly4: DefaultModuleAssemblyOverride {
 private struct Assembly4Fake: AutoInitModuleAssembly {
     static var dependencies: [any ModuleAssembly.Type] { [] }
     func assemble(container: Container) { }
-    static var implements: [any ModuleAssembly.Type] { [Assembly4.self] }
+    static var replaces: [any ModuleAssembly.Type] { [Assembly4.self] }
 }
 
 private struct Assembly4Fake2: AutoInitModuleAssembly {
     static var dependencies: [any ModuleAssembly.Type] { [] }
     func assemble(container: Container) { }
-    static var implements: [any ModuleAssembly.Type] { [Assembly4.self] }
+    static var replaces: [any ModuleAssembly.Type] { [Assembly4.self] }
 }
 
 private struct NonAutoOverride: ModuleAssembly {
     static var dependencies: [any ModuleAssembly.Type] { [] }
     func assemble(container: Container) { }
-    static var implements: [any ModuleAssembly.Type] { [Assembly1.self] }
+    static var replaces: [any ModuleAssembly.Type] { [Assembly1.self] }
 }
 
 private struct Assembly5: ModuleAssembly {
@@ -240,7 +240,7 @@ private struct MultipleDependencyAssembly: ModuleAssembly {
 private struct MultipleOverrideAssembly: AutoInitModuleAssembly {
     static var dependencies: [any ModuleAssembly.Type] { [] }
     func assemble(container: Container) { }
-    static var implements: [any ModuleAssembly.Type] { [Assembly1.self, Assembly4.self, Assembly5.self] }
+    static var replaces: [any ModuleAssembly.Type] { [Assembly1.self, Assembly4.self, Assembly5.self] }
 }
 
 private protocol Service2Protocol {}

--- a/Tests/KnitTests/ModuleCycleTests.swift
+++ b/Tests/KnitTests/ModuleCycleTests.swift
@@ -59,7 +59,7 @@ private struct Assembly3: AutoInitModuleAssembly {
     init() {}
     static var dependencies: [any ModuleAssembly.Type] { [Assembly2.self, Assembly4.self] }
     func assemble(container: Container) {}
-    static var implements: [any ModuleAssembly.Type] { [Assembly2.self] }
+    static var replaces: [any ModuleAssembly.Type] { [Assembly2.self] }
 }
 
 private struct Assembly4: AutoInitModuleAssembly {


### PR DESCRIPTION
This better represents the behavior that the API provides. It is also nice because there is no potential confusion with `registration.implements(Type.self)` from the Swinject API.