### PR TITLE
Automatically generate DefaultOverrides for FakeAssembly

### DIFF
--- a/Sources/Knit/Module/FakeAssembly.swift
+++ b/Sources/Knit/Module/FakeAssembly.swift
@@ -10,6 +10,9 @@ import Foundation
 /// * The FakeAssembly must use the same TargetResolver as the real assembly
 /// * The real assembly must have a DefaultModuleAssemblyOverride setup pointing to this fake
 /// * The FakeAssembly defaults to no dependencies to prevent expanding the DI graph
+///
+/// Knit will then generate the following for you:
+/// * An extension on the real assembly to conform to DefaultModuleAssemblyOverride and pointing to this fake
 /// * The FakeAssembly is defined to replace the real assembly
 public protocol FakeAssembly<ReplacedAssembly>: AutoInitModuleAssembly {
     associatedtype ReplacedAssembly: DefaultModuleAssemblyOverride where

--- a/Sources/KnitCodeGen/Configuration.swift
+++ b/Sources/KnitCodeGen/Configuration.swift
@@ -35,7 +35,7 @@ public struct Configuration: Encodable {
         directives: KnitDirectives = .init(),
         assemblyType: AssemblyType = .baseAssembly,
         registrations: [Registration],
-        registrationsIntoCollections: [RegistrationIntoCollection],
+        registrationsIntoCollections: [RegistrationIntoCollection] = [],
         imports: [ModuleImport] = [],
         replaces: [String] = [],
         targetResolver: String
@@ -82,9 +82,7 @@ public extension Configuration {
 
     func makeTypeSafetySourceFile() throws -> SourceFileSyntax {
         return try TypeSafetySourceFile.make(
-            assemblyName: assemblyName,
-            extensionTarget: targetResolver,
-            registrations: registrations
+            from: self
         )
     }
 

--- a/Tests/KnitCodeGenTests/ConfigurationSetTests.swift
+++ b/Tests/KnitCodeGenTests/ConfigurationSetTests.swift
@@ -276,7 +276,6 @@ private enum Factory {
             .init(service: "ArgumentService", accessLevel: .internal, arguments: [.init(type: "String")])
 
         ],
-        registrationsIntoCollections: [],
         imports: [
             .named("Dependency2")
         ],
@@ -289,7 +288,6 @@ private enum Factory {
         registrations: [
             .init(service: "Service3", accessLevel: .public),
         ],
-        registrationsIntoCollections: [],
         imports: [
             .named("Dependency2")
         ],

--- a/Tests/KnitCodeGenTests/KnitModuleSourceFileTests.swift
+++ b/Tests/KnitCodeGenTests/KnitModuleSourceFileTests.swift
@@ -13,14 +13,12 @@ final class KnitModuleSourceFileTests: XCTestCase {
                 assemblyName: "MyAssembly",
                 moduleName: "MyModule",
                 registrations: [],
-                registrationsIntoCollections: [],
                 targetResolver: "AppResolver"
             ),
             .init(
                 assemblyName: "SecondAssembly",
                 moduleName: "MyModule",
                 registrations: [],
-                registrationsIntoCollections: [],
                 targetResolver: "SignedInResolver"
             ),
         ]

--- a/Tests/KnitCodeGenTests/UnitTestSourceFileTests.swift
+++ b/Tests/KnitCodeGenTests/UnitTestSourceFileTests.swift
@@ -62,7 +62,6 @@ final class UnitTestSourceFileTests: XCTestCase {
             registrations: [
                 .init(service: "ServiceA", accessLevel: .internal, arguments: [.init(type: "String")]),
             ],
-            registrationsIntoCollections: [],
             targetResolver: "SignedInResolver"
         )
 
@@ -73,7 +72,6 @@ final class UnitTestSourceFileTests: XCTestCase {
                 .init(service: "ServiceB", name: nil, accessLevel: .internal),
                 .init(service: "ServiceC", accessLevel: .internal, arguments: [.init(type: "String")]),
             ],
-            registrationsIntoCollections: [],
             targetResolver: "AppResolver"
         )
 
@@ -133,7 +131,6 @@ final class UnitTestSourceFileTests: XCTestCase {
             registrations: [
                 .init(service: "ServiceA", accessLevel: .internal, arguments: [.init(type: "String")]),
             ],
-            registrationsIntoCollections: [],
             targetResolver: "Resolver"
         )
         


### PR DESCRIPTION
If using the FakeAssembly protocol then we can automatically generate DefaultModuleAssemblyOverride extensions for the replaced types.