### PR TITLE
Fix Xcode exact line error reporting

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -6,7 +6,7 @@ import PackageDescription
 let package = Package(
     name: "Knit",
     platforms: [
-        .macOS(.v12),
+        .macOS(.v13),
     ],
     products: [
         .library(name: "Knit", targets: ["Knit"]),

--- a/Sources/KnitCodeGen/AssemblyParser.swift
+++ b/Sources/KnitCodeGen/AssemblyParser.swift
@@ -50,7 +50,7 @@ public struct AssemblyParser {
     }
 
     private func parse(path: String, defaultTargetResolver: String, useTargetResolver: Bool) throws -> [Configuration] {
-        let url = URL(fileURLWithPath: path, isDirectory: false)
+        let url = URL(filePath: path, directoryHint: .notDirectory)
         var errorsToPrint = [Error]()
 
         let source: String


### PR DESCRIPTION
With Bazel it seems necessary to have absolute paths to correctly get line-level errors to appear in Xcode.