### PR TITLE
Fix a Swift 6 build warning in extensions

### DIFF
--- a/Sources/KnitCodeGen/TypeSafetySourceFile.swift
+++ b/Sources/KnitCodeGen/TypeSafetySourceFile.swift
@@ -130,7 +130,11 @@ public enum TypeSafetySourceFile {
                 try ExtensionDeclSyntax(
                     extendedType: TypeSyntax("\(raw: replacedType)"),
                     inheritanceClause: InheritanceClauseSyntax(inheritedTypesBuilder: {
-                        InheritedTypeSyntax(type: TypeSyntax(stringLiteral: "DefaultModuleAssemblyOverride"))
+                        InheritedTypeSyntax(type: MemberTypeSyntax(
+                            // explicitly qualifying the type with the Knit module fixes a warning for Swift 6
+                            baseType: IdentifierTypeSyntax(name: "Knit"),
+                            name: TokenSyntax(stringLiteral: "DefaultModuleAssemblyOverride")
+                        ))
                     }),
                     memberBlockBuilder: {
                         try TypeAliasDeclSyntax("public typealias OverrideType = \(raw: config.assemblyName)")

--- a/Tests/KnitCodeGenTests/TypeSafetySourceFileTests.swift
+++ b/Tests/KnitCodeGenTests/TypeSafetySourceFileTests.swift
@@ -206,7 +206,7 @@ final class TypeSafetySourceFileTests: XCTestCase {
         }
         /// For assemblies that conform to `FakeAssembly`, Knit automatically generates
         /// default overrides for all other types it replaces.
-        extension RealAssembly: DefaultModuleAssemblyOverride {
+        extension RealAssembly: Knit.DefaultModuleAssemblyOverride {
             public typealias OverrideType = MyFakeAssembly
         }
         """
@@ -235,10 +235,10 @@ final class TypeSafetySourceFileTests: XCTestCase {
         }
         /// For assemblies that conform to `FakeAssembly`, Knit automatically generates
         /// default overrides for all other types it replaces.
-        extension RealAssembly: DefaultModuleAssemblyOverride {
+        extension RealAssembly: Knit.DefaultModuleAssemblyOverride {
             public typealias OverrideType = MyFakeAssembly
         }
-        extension OtherRealAssembly: DefaultModuleAssemblyOverride {
+        extension OtherRealAssembly: Knit.DefaultModuleAssemblyOverride {
             public typealias OverrideType = MyFakeAssembly
         }
         """


### PR DESCRIPTION
In Xcode 16 extensions on a type from another module or conforming to a protocol from another module (or both!) require either the `@retroactive` attribute or a fully-qualified type name like `Knit.DefaultModuleAssemblyOverride`:

```
Code/Utilities/EncryptionFakes/Generated/KnitDITypeSafety+EncryptionFakes.swift:15:1: warning: extension declares a conformance of imported type 'EncryptionAssembly' to imported protocol 'DefaultModuleAssemblyOverride'; this will not behave correctly if the owners of 'Encryption' introduce this conformance in the future
13 | /// For assemblies that conform to `FakeAssembly`, Knit automatically generates
14 | /// default overrides for all other types it replaces.
15 | extension EncryptionAssembly: DefaultModuleAssemblyOverride {
   | |- warning: extension declares a conformance of imported type 'EncryptionAssembly' to imported protocol 'DefaultModuleAssemblyOverride'; this will not behave correctly if the owners of 'Encryption' introduce this conformance in the future
   | `- note: add '@retroactive' to silence this warning
16 |     public typealias OverrideType = EncryptionFakesAssembly
17 | }
```