### PR TITLE
Add support for registering factories on the main thread

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -6,7 +6,7 @@ import PackageDescription
 let package = Package(
     name: "Knit",
     platforms: [
-        .macOS(.v13),
+        .macOS(.v14),
     ],
     products: [
         .library(name: "Knit", targets: ["Knit"]),

--- a/Sources/Knit/Container+MainActor.swift
+++ b/Sources/Knit/Container+MainActor.swift
@@ -1,0 +1,42 @@
+//
+// Copyright © Block, Inc. All rights reserved.
+//
+
+import Swinject
+
+// This code should move into the Swinject library.
+// There is an open pull request to make this change https://github.com/Swinject/Swinject/pull/570
+
+extension Container {
+    // Register a service type's factory with the assumption that the registration
+    // will happen on the main thread.
+    //
+    // This method relies on the type eventually being resolved by a caller on the main
+    // thread using the knit generated resolver. If that call is not made on the main
+    // thread then a crash will occur.
+    @discardableResult
+    public func register<Service>(
+        _ serviceType: Service.Type,
+        name: String? = nil,
+        mainActorFactory: @escaping @MainActor (Resolver) -> Service
+    ) -> ServiceEntry<Service> {
+        return register(serviceType, name: name) { r in
+            MainActor.assumeIsolated {
+                return mainActorFactory(r)
+            }
+        }
+    }
+
+    @discardableResult
+    public func register<Service, Arg1>(
+        _ serviceType: Service.Type,
+        name: String? = nil,
+        mainActorFactory: @escaping @MainActor (Resolver, Arg1) -> Service
+    ) -> ServiceEntry<Service> {
+        return register(serviceType) { (resolver: Resolver, arg1: Arg1) in
+            MainActor.assumeIsolated {
+                return mainActorFactory(resolver, arg1)
+            }
+        }
+    }
+}

--- a/Sources/KnitCodeGen/Registration.swift
+++ b/Sources/KnitCodeGen/Registration.swift
@@ -13,6 +13,8 @@ public struct Registration: Equatable, Codable {
 
     public var accessLevel: AccessLevel
 
+    public let concurrencyModifier: String?
+
     /// Argument types required to resolve the registration
     public var arguments: [Argument]
 
@@ -29,12 +31,14 @@ public struct Registration: Equatable, Codable {
         name: String? = nil,
         accessLevel: AccessLevel = .internal,
         arguments: [Argument] = [],
+        concurrencyModifier: String? = nil,
         getterConfig: Set<GetterConfig> = GetterConfig.default,
         functionName: FunctionName = .register
     ) {
         self.service = service
         self.name = name
         self.accessLevel = accessLevel
+        self.concurrencyModifier = concurrencyModifier
         self.arguments = arguments
         self.getterConfig = getterConfig
         self.functionName = functionName
@@ -47,7 +51,7 @@ public struct Registration: Equatable, Codable {
 
     private enum CodingKeys: CodingKey {
         // ifConfigCondition is not encoded since ExprSyntax does not conform to codable
-        case service, name, accessLevel, arguments, getterConfig, functionName
+        case service, name, accessLevel, arguments, getterConfig, functionName, concurrencyModifier
     }
 
 }

--- a/Sources/KnitCodeGen/TypeSafetySourceFile.swift
+++ b/Sources/KnitCodeGen/TypeSafetySourceFile.swift
@@ -55,7 +55,11 @@ public enum TypeSafetySourceFile {
         enumName: String? = nil,
         getterType: GetterConfig = .callAsFunction
     ) throws -> DeclSyntaxProtocol {
-        let modifier = registration.accessLevel == .public ? "public " : ""
+        var modifier = ""
+        if let concurrencyModifier = registration.concurrencyModifier {
+            modifier = "\(concurrencyModifier) "
+        }
+        modifier += registration.accessLevel == .public ? "public " : ""
         let nameInput = enumName.map { "name: \($0)" }
         let nameUsage = enumName != nil ? "name: name.rawValue" : nil
         let (argInput, argUsage) = argumentString(registration: registration)

--- a/Tests/KnitCodeGenTests/RegistrationParsingTests.swift
+++ b/Tests/KnitCodeGenTests/RegistrationParsingTests.swift
@@ -549,6 +549,19 @@ final class RegistrationParsingTests: XCTestCase {
         )
     }
 
+    func testMainActorParsing() throws {
+        try assertMultipleRegistrationsString(
+            """
+            container.register(A.self) { @MainActor in A() }
+            .implements(B.self)
+            """,
+            registrations: [
+                Registration(service: "A", concurrencyModifier: "@MainActor", functionName: .register),
+                Registration(service: "B", concurrencyModifier: "@MainActor", functionName: .implements),
+            ]
+        )
+    }
+
     func testIncorrectRegistrations() throws {
         try assertNoRegistrationsString("container.someOtherMethod(AType.self)", message: "Incorrect method name")
         try assertNoRegistrationsString("container.register(A)", message: "First param is not a metatype")

--- a/Tests/KnitCodeGenTests/TypeSafetySourceFileTests.swift
+++ b/Tests/KnitCodeGenTests/TypeSafetySourceFileTests.swift
@@ -246,4 +246,27 @@ final class TypeSafetySourceFileTests: XCTestCase {
         XCTAssertEqual(expected, result.formatted().description)
     }
 
+    func test_mainActor_resolver() throws {
+        let result = try TypeSafetySourceFile.make(
+            from: Configuration(
+                assemblyName: "MainActorAssembly",
+                moduleName: "Module",
+                registrations: [
+                    .init(service: "ServiceA", concurrencyModifier: "@MainActor")
+                ],
+                targetResolver: "Resolver"
+            )
+        )
+        let expected = """
+        /// Generated from ``MainActorAssembly``
+        extension Resolver {
+            @MainActor func serviceA(file: StaticString = #fileID, function: StaticString = #function, line: UInt = #line) -> ServiceA {
+                knitUnwrap(resolve(ServiceA.self), callsiteFile: file, callsiteFunction: function, callsiteLine: line)
+            }
+        }
+        """
+
+        XCTAssertEqual(expected, result.formatted().description)
+    }
+
 }


### PR DESCRIPTION
This allows `container.register(ServiceA.self) { @MainActor in ServiceA() }` to be generated as
```
extension Resolver {
  @MainActor func serviceA() -> ServiceA
}
```

Any other assembly registrations will then need to be marked as @MainActor in order to consume the resolver function. The structure can be extended to support other concurrency patterns like async in the future.