### PR TITLE
Remove the ability to use the regular Assembly type in Knit

### DIFF
--- a/Sources/Knit/Module/ModuleAssembler.swift
+++ b/Sources/Knit/Module/ModuleAssembler.swift
@@ -35,7 +35,7 @@ public final class ModuleAssembler {
      */
     public convenience init(
         parent: ModuleAssembler? = nil,
-        _ modules: [any Assembly],
+        _ modules: [any ModuleAssembly],
         overrideBehavior: OverrideBehavior = .defaultOverridesWhenTesting,
         assemblyValidation: ((any ModuleAssembly.Type) throws -> Void)? = nil,
         errorFormatter: ModuleAssemblerErrorFormatter = DefaultModuleAssemblerErrorFormatter(),
@@ -68,17 +68,14 @@ public final class ModuleAssembler {
     // Internal required init that throws rather than fatal errors
     required init(
         parent: ModuleAssembler? = nil,
-        _modules modules: [any Assembly],
+        _modules modules: [any ModuleAssembly],
         overrideBehavior: OverrideBehavior = .defaultOverridesWhenTesting,
         assemblyValidation: ((any ModuleAssembly.Type) throws -> Void)? = nil,
         errorFormatter: ModuleAssemblerErrorFormatter = DefaultModuleAssemblerErrorFormatter(),
         postAssemble: ((Container) -> Void)? = nil
     ) throws {
-        let moduleAssemblies = modules.compactMap { $0 as? any ModuleAssembly }
-        let nonModuleAssemblies = modules.filter { !($0 is any ModuleAssembly) }
-
         self.builder = try DependencyBuilder(
-            modules: moduleAssemblies,
+            modules: modules,
             assemblyValidation: assemblyValidation,
             overrideBehavior: overrideBehavior,
             isRegisteredInParent: { type in
@@ -97,7 +94,6 @@ public final class ModuleAssembler {
         self._container.register(DependencyTree.self) { _ in dependencyTree }
 
         let assembler = Assembler(container: self._container)
-        assembler.apply(assemblies: nonModuleAssemblies)
         assembler.apply(assemblies: builder.assemblies)
         postAssemble?(_container)
 

--- a/Sources/Knit/Module/ScopedModuleAssembler.swift
+++ b/Sources/Knit/Module/ScopedModuleAssembler.swift
@@ -21,7 +21,7 @@ public final class ScopedModuleAssembler<ScopedResolver> {
 
     public convenience init(
         parent: ModuleAssembler? = nil,
-        _ modules: [any Assembly],
+        _ modules: [any ModuleAssembly],
         overrideBehavior: OverrideBehavior = .defaultOverridesWhenTesting,
         errorFormatter: ModuleAssemblerErrorFormatter = DefaultModuleAssemblerErrorFormatter(),
         postAssemble: ((Container) -> Void)? = nil,
@@ -48,17 +48,14 @@ public final class ScopedModuleAssembler<ScopedResolver> {
     // Internal required init that throws rather than fatal errors
     required init(
         parent: ModuleAssembler? = nil,
-        _modules modules: [any Assembly],
+        _modules modules: [any ModuleAssembly],
         overrideBehavior: OverrideBehavior = .defaultOverridesWhenTesting,
         errorFormatter: ModuleAssemblerErrorFormatter = DefaultModuleAssemblerErrorFormatter(),
         postAssemble: ((Container) -> Void)? = nil
     ) throws {
         // For provided modules, fail early if they are scoped incorrectly
         for assembly in modules {
-            guard let moduleAssembly = assembly as? any ModuleAssembly else {
-                continue
-            }
-            let moduleAssemblyType = type(of: moduleAssembly)
+            let moduleAssemblyType = type(of: assembly)
             if moduleAssemblyType.resolverType != ScopedResolver.self {
                 let scopingError = ScopedModuleAssemblerError.incorrectTargetResolver(
                     expected: String(describing: ScopedResolver.self),


### PR DESCRIPTION
The ability to use other assemblies isn't something that ever got used so I'm taking it out. I don't think this is a particular issue for performance but less code means less places for performance issues to hide.