### PR TITLE
Add missing registration options for main actor

### DIFF
--- a/Sources/Knit/Container+MainActor.swift
+++ b/Sources/Knit/Container+MainActor.swift
@@ -7,13 +7,22 @@ import Swinject
 // This code should move into the Swinject library.
 // There is an open pull request to make this change https://github.com/Swinject/Swinject/pull/570
 
+// MARK: - MainActor registration
 extension Container {
-    // Register a service type's factory with the assumption that the registration
-    // will happen on the main thread.
-    //
-    // This method relies on the type eventually being resolved by a caller on the main
-    // thread using the knit generated resolver. If that call is not made on the main
-    // thread then a crash will occur.
+
+    /// Adds a registration for the specified service with the factory closure to specify how the service is
+    /// resolved with dependencies which must be resolved on the main actor.
+    ///
+    /// - Parameters:
+    ///   - serviceType:        The service type to register.
+    ///   - name:               A registration name, which is used to differentiate from other registrations
+    ///                         that have the same service and factory types.
+    ///   - mainActorFactory:   The @MainActor closure to specify how the service type is resolved with the dependencies of the type.
+    ///                         It is invoked when the ``Container`` needs to instantiate the instance.
+    ///                         It takes a ``Resolver`` to inject dependencies to the instance,
+    ///                         and returns the instance of the component type for the service.
+    ///
+    /// - Returns: A registered ``ServiceEntry`` to configure more settings with method chaining.
     @discardableResult
     public func register<Service>(
         _ serviceType: Service.Type,
@@ -26,7 +35,23 @@ extension Container {
             }
         }
     }
+}
 
+// MARK: - MainActor registration with Arguments
+extension Container {
+    /// Adds a registration for the specified service with the factory closure to specify how the service is
+    /// resolved with dependencies which must be resolved on the main actor.
+    ///
+    /// - Parameters:
+    ///   - serviceType:        The service type to register.
+    ///   - name:               A registration name, which is used to differentiate from other registrations
+    ///                         that have the same service and factory types.
+    ///   - mainActorFactory:   The @MainActor closure to specify how the service type is resolved with the dependencies of the type.
+    ///                         It is invoked when the ``Container`` needs to instantiate the instance.
+    ///                         It takes a `Resolver` instance and 1 argument to inject dependencies to the instance,
+    ///                         and returns the instance of the component type for the service.
+    ///
+    /// - Returns: A registered ``ServiceEntry`` to configure more settings with method chaining.
     @discardableResult
     public func register<Service, Arg1>(
         _ serviceType: Service.Type,
@@ -39,4 +64,213 @@ extension Container {
             }
         }
     }
+
+    /// Adds a registration for the specified service with the factory closure to specify how the service is
+    /// resolved with dependencies which must be resolved on the main actor.
+    ///
+    /// - Parameters:
+    ///   - serviceType:        The service type to register.
+    ///   - name:               A registration name, which is used to differentiate from other registrations
+    ///                         that have the same service and factory types.
+    ///   - mainActorFactory:   The @MainActor closure to specify how the service type is resolved with the dependencies of the type.
+    ///                         It is invoked when the ``Container`` needs to instantiate the instance.
+    ///                         It takes a `Resolver` instance and 2 arguments to inject dependencies to the instance,
+    ///                         and returns the instance of the component type for the service.
+    ///
+    /// - Returns: A registered ``ServiceEntry`` to configure more settings with method chaining.
+    @discardableResult
+    public func register<Service, Arg1, Arg2>(
+        _ serviceType: Service.Type,
+        name: String? = nil,
+        mainActorFactory: @escaping @MainActor (Resolver, Arg1, Arg2) -> Service
+    ) -> ServiceEntry<Service> {
+        return register(serviceType) { (resolver: Resolver, arg1: Arg1, arg2: Arg2) in
+            MainActor.assumeIsolated {
+                return mainActorFactory(resolver, arg1, arg2)
+            }
+        }
+    }
+
+    /// Adds a registration for the specified service with the factory closure to specify how the service is
+    /// resolved with dependencies which must be resolved on the main actor.
+    ///
+    /// - Parameters:
+    ///   - serviceType:        The service type to register.
+    ///   - name:               A registration name, which is used to differentiate from other registrations
+    ///                         that have the same service and factory types.
+    ///   - mainActorFactory:   The @MainActor closure to specify how the service type is resolved with the dependencies of the type.
+    ///                         It is invoked when the ``Container`` needs to instantiate the instance.
+    ///                         It takes a `Resolver` instance and 3 arguments to inject dependencies to the instance,
+    ///                         and returns the instance of the component type for the service.
+    ///
+    /// - Returns: A registered ``ServiceEntry`` to configure more settings with method chaining.
+    @discardableResult
+    public func register<Service, Arg1, Arg2, Arg3>(
+        _ serviceType: Service.Type,
+        name: String? = nil,
+        mainActorFactory: @escaping @MainActor (Resolver, Arg1, Arg2, Arg3) -> Service
+    ) -> ServiceEntry<Service> {
+        return register(serviceType) { (resolver: Resolver, arg1: Arg1, arg2: Arg2, arg3: Arg3) in
+            MainActor.assumeIsolated {
+                return mainActorFactory(resolver, arg1, arg2, arg3)
+            }
+        }
+    }
+
+    /// Adds a registration for the specified service with the factory closure to specify how the service is
+    /// resolved with dependencies which must be resolved on the main actor.
+    ///
+    /// - Parameters:
+    ///   - serviceType:        The service type to register.
+    ///   - name:               A registration name, which is used to differentiate from other registrations
+    ///                         that have the same service and factory types.
+    ///   - mainActorFactory:   The @MainActor closure to specify how the service type is resolved with the dependencies of the type.
+    ///                         It is invoked when the ``Container`` needs to instantiate the instance.
+    ///                         It takes a `Resolver` instance and 4 arguments to inject dependencies to the instance,
+    ///                         and returns the instance of the component type for the service.
+    ///
+    /// - Returns: A registered ``ServiceEntry`` to configure more settings with method chaining.
+    @discardableResult
+    public func register<Service, Arg1, Arg2, Arg3, Arg4>(
+        _ serviceType: Service.Type,
+        name: String? = nil,
+        mainActorFactory: @escaping @MainActor (Resolver, Arg1, Arg2, Arg3, Arg4) -> Service
+    ) -> ServiceEntry<Service> {
+        return register(serviceType) { (resolver: Resolver, arg1: Arg1, arg2: Arg2, arg3: Arg3, arg4: Arg4) in
+            MainActor.assumeIsolated {
+                return mainActorFactory(resolver, arg1, arg2, arg3, arg4)
+            }
+        }
+    }
+
+    /// Adds a registration for the specified service with the factory closure to specify how the service is
+    /// resolved with dependencies which must be resolved on the main actor.
+    ///
+    /// - Parameters:
+    ///   - serviceType:        The service type to register.
+    ///   - name:               A registration name, which is used to differentiate from other registrations
+    ///                         that have the same service and factory types.
+    ///   - mainActorFactory:   The @MainActor closure to specify how the service type is resolved with the dependencies of the type.
+    ///                         It is invoked when the ``Container`` needs to instantiate the instance.
+    ///                         It takes a `Resolver` instance and 5 arguments to inject dependencies to the instance,
+    ///                         and returns the instance of the component type for the service.
+    ///
+    /// - Returns: A registered ``ServiceEntry`` to configure more settings with method chaining.
+    @discardableResult
+    public func register<Service, Arg1, Arg2, Arg3, Arg4, Arg5>(
+        _ serviceType: Service.Type,
+        name: String? = nil,
+        mainActorFactory: @escaping @MainActor (Resolver, Arg1, Arg2, Arg3, Arg4, Arg5) -> Service
+    ) -> ServiceEntry<Service> {
+        return register(serviceType) { (resolver: Resolver, arg1: Arg1, arg2: Arg2, arg3: Arg3, arg4: Arg4, arg5: Arg5) in
+            MainActor.assumeIsolated {
+                return mainActorFactory(resolver, arg1, arg2, arg3, arg4, arg5)
+            }
+        }
+    }
+
+    /// Adds a registration for the specified service with the factory closure to specify how the service is
+    /// resolved with dependencies which must be resolved on the main actor.
+    ///
+    /// - Parameters:
+    ///   - serviceType:        The service type to register.
+    ///   - name:               A registration name, which is used to differentiate from other registrations
+    ///                         that have the same service and factory types.
+    ///   - mainActorFactory:   The @MainActor closure to specify how the service type is resolved with the dependencies of the type.
+    ///                         It is invoked when the ``Container`` needs to instantiate the instance.
+    ///                         It takes a `Resolver` instance and 6 arguments to inject dependencies to the instance,
+    ///                         and returns the instance of the component type for the service.
+    ///
+    /// - Returns: A registered ``ServiceEntry`` to configure more settings with method chaining.
+    @discardableResult
+    public func register<Service, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6>(
+        _ serviceType: Service.Type,
+        name: String? = nil,
+        mainActorFactory: @escaping @MainActor (Resolver, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6) -> Service
+    ) -> ServiceEntry<Service> {
+        return register(serviceType) { (resolver: Resolver, arg1: Arg1, arg2: Arg2, arg3: Arg3, arg4: Arg4, arg5: Arg5, arg6: Arg6) in
+            MainActor.assumeIsolated {
+                return mainActorFactory(resolver, arg1, arg2, arg3, arg4, arg5, arg6)
+            }
+        }
+    }
+
+    /// Adds a registration for the specified service with the factory closure to specify how the service is
+    /// resolved with dependencies which must be resolved on the main actor.
+    ///
+    /// - Parameters:
+    ///   - serviceType:        The service type to register.
+    ///   - name:               A registration name, which is used to differentiate from other registrations
+    ///                         that have the same service and factory types.
+    ///   - mainActorFactory:   The @MainActor closure to specify how the service type is resolved with the dependencies of the type.
+    ///                         It is invoked when the ``Container`` needs to instantiate the instance.
+    ///                         It takes a `Resolver` instance and 7 arguments to inject dependencies to the instance,
+    ///                         and returns the instance of the component type for the service.
+    ///
+    /// - Returns: A registered ``ServiceEntry`` to configure more settings with method chaining.
+    @discardableResult
+    public func register<Service, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7>(
+        _ serviceType: Service.Type,
+        name: String? = nil,
+        mainActorFactory: @escaping @MainActor (Resolver, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7) -> Service
+    ) -> ServiceEntry<Service> {
+        return register(serviceType) { (resolver: Resolver, arg1: Arg1, arg2: Arg2, arg3: Arg3, arg4: Arg4, arg5: Arg5, arg6: Arg6, arg7: Arg7) in
+            MainActor.assumeIsolated {
+                return mainActorFactory(resolver, arg1, arg2, arg3, arg4, arg5, arg6, arg7)
+            }
+        }
+    }
+
+    /// Adds a registration for the specified service with the factory closure to specify how the service is
+    /// resolved with dependencies which must be resolved on the main actor.
+    ///
+    /// - Parameters:
+    ///   - serviceType:        The service type to register.
+    ///   - name:               A registration name, which is used to differentiate from other registrations
+    ///                         that have the same service and factory types.
+    ///   - mainActorFactory:   The @MainActor closure to specify how the service type is resolved with the dependencies of the type.
+    ///                         It is invoked when the ``Container`` needs to instantiate the instance.
+    ///                         It takes a `Resolver` instance and 8 arguments to inject dependencies to the instance,
+    ///                         and returns the instance of the component type for the service.
+    ///
+    /// - Returns: A registered ``ServiceEntry`` to configure more settings with method chaining.
+    @discardableResult
+    public func register<Service, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8>(
+        _ serviceType: Service.Type,
+        name: String? = nil,
+        mainActorFactory: @escaping @MainActor (Resolver, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8) -> Service
+    ) -> ServiceEntry<Service> {
+        return register(serviceType) { (resolver: Resolver, arg1: Arg1, arg2: Arg2, arg3: Arg3, arg4: Arg4, arg5: Arg5, arg6: Arg6, arg7: Arg7, arg8: Arg8) in
+            MainActor.assumeIsolated {
+                return mainActorFactory(resolver, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8)
+            }
+        }
+    }
+
+    /// Adds a registration for the specified service with the factory closure to specify how the service is
+    /// resolved with dependencies which must be resolved on the main actor.
+    ///
+    /// - Parameters:
+    ///   - serviceType:        The service type to register.
+    ///   - name:               A registration name, which is used to differentiate from other registrations
+    ///                         that have the same service and factory types.
+    ///   - mainActorFactory:   The @MainActor closure to specify how the service type is resolved with the dependencies of the type.
+    ///                         It is invoked when the ``Container`` needs to instantiate the instance.
+    ///                         It takes a `Resolver` instance and 9 arguments to inject dependencies to the instance,
+    ///                         and returns the instance of the component type for the service.
+    ///
+    /// - Returns: A registered ``ServiceEntry`` to configure more settings with method chaining.
+    @discardableResult
+    public func register<Service, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8, Arg9>(
+        _ serviceType: Service.Type,
+        name: String? = nil,
+        mainActorFactory: @escaping @MainActor (Resolver, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8, Arg9) -> Service
+    ) -> ServiceEntry<Service> {
+        return register(serviceType) { (resolver: Resolver, arg1: Arg1, arg2: Arg2, arg3: Arg3, arg4: Arg4, arg5: Arg5, arg6: Arg6, arg7: Arg7, arg8: Arg8, arg9: Arg9) in
+            MainActor.assumeIsolated {
+                return mainActorFactory(resolver, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9)
+            }
+        }
+    }
+
 }


### PR DESCRIPTION
The original main actor work only adding registrations for the common cases. This adds options for all remaining cases matching what is available for regular registrations.

This code is copied directly from https://github.com/Swinject/Swinject/pull/570. Once that PR merges this can be removed.