### PR TITLE
Fix unhandled cases when parsing main actor registrations

### DIFF
--- a/Tests/KnitCodeGenTests/RegistrationParsingTests.swift
+++ b/Tests/KnitCodeGenTests/RegistrationParsingTests.swift
@@ -550,6 +550,7 @@ final class RegistrationParsingTests: XCTestCase {
     }
 
     func testMainActorParsing() throws {
+        // Basic registration
         try assertMultipleRegistrationsString(
             """
             container.register(A.self) { @MainActor in A() }
@@ -558,6 +559,26 @@ final class RegistrationParsingTests: XCTestCase {
             registrations: [
                 Registration(service: "A", concurrencyModifier: "@MainActor", functionName: .register),
                 Registration(service: "B", concurrencyModifier: "@MainActor", functionName: .implements),
+            ]
+        )
+
+        // With arguments (must use mainActorFactory syntax)
+        try assertMultipleRegistrationsString(
+            """
+            container.register(
+                A.self,
+                mainActorFactory: { (resolver: Resolver, arg1: B, arg2: C) in
+                    A(arg1: arg1, arg2: arg2)
+                }
+            )
+            """,
+            registrations: [
+                Registration(
+                    service: "A",
+                    arguments: [.init(identifier: "arg1", type: "B"), .init(identifier: "arg2", type: "C")],
+                    concurrencyModifier: "@MainActor",
+                    functionName: .register
+                ),
             ]
         )
     }


### PR DESCRIPTION
This fixes some `@MainActor` parsing issues when used with parameters or when explicitly using the `mainActorFactory` param.

I was originally going to support `container.register(A.self) { @MainActor (r: Resolver, a: Arg) in ...` but having main actor there will not compile so the code must explicitly list the mainActorFactory param.