### PR TITLE
Set minimum iOS version in the package file

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -7,6 +7,7 @@ let package = Package(
     name: "Knit",
     platforms: [
         .macOS(.v14),
+        .iOS(.v15),
     ],
     products: [
         .library(name: "Knit", targets: ["Knit"]),


### PR DESCRIPTION
At cash we always consume the library via the podspec. This fixes build issues when consuming via SPM