### PR TITLE
Add knit directive to handle types marked with @_spi

### DIFF
--- a/Sources/KnitCodeGen/FunctionCallRegistrationParsing.swift
+++ b/Sources/KnitCodeGen/FunctionCallRegistrationParsing.swift
@@ -183,7 +183,8 @@ private func makeRegistrationFor(
         arguments: registrationArguments,
         concurrencyModifier: concurrencyModifier,
         getterConfig: getterConfig,
-        functionName: functionName
+        functionName: functionName,
+        spi: directives.spi ?? defaultDirectives.spi
     )
 }
 

--- a/Sources/KnitCodeGen/Registration.swift
+++ b/Sources/KnitCodeGen/Registration.swift
@@ -26,6 +26,9 @@ public struct Registration: Equatable, Codable {
     /// The Swinject function that was used to register this factory
     public let functionName: FunctionName
 
+    /// System Programming Interface annotation that should be applied to the registration
+    public var spi: String?
+
     public init(
         service: String,
         name: String? = nil,
@@ -33,7 +36,8 @@ public struct Registration: Equatable, Codable {
         arguments: [Argument] = [],
         concurrencyModifier: String? = nil,
         getterConfig: Set<GetterConfig> = GetterConfig.default,
-        functionName: FunctionName = .register
+        functionName: FunctionName = .register,
+        spi: String? = nil
     ) {
         self.service = service
         self.name = name
@@ -42,6 +46,7 @@ public struct Registration: Equatable, Codable {
         self.arguments = arguments
         self.getterConfig = getterConfig
         self.functionName = functionName
+        self.spi = spi
     }
 
     /// This registration is forwarded to another service entry.
@@ -51,7 +56,7 @@ public struct Registration: Equatable, Codable {
 
     private enum CodingKeys: CodingKey {
         // ifConfigCondition is not encoded since ExprSyntax does not conform to codable
-        case service, name, accessLevel, arguments, getterConfig, functionName, concurrencyModifier
+        case service, name, accessLevel, arguments, getterConfig, functionName, concurrencyModifier, spi
     }
 
 }

--- a/Sources/KnitCodeGen/TypeSafetySourceFile.swift
+++ b/Sources/KnitCodeGen/TypeSafetySourceFile.swift
@@ -56,8 +56,11 @@ public enum TypeSafetySourceFile {
         getterType: GetterConfig = .callAsFunction
     ) throws -> DeclSyntaxProtocol {
         var modifier = ""
+        if let spi = registration.spi {
+            modifier += "@_spi(\(spi)) "
+        }
         if let concurrencyModifier = registration.concurrencyModifier {
-            modifier = "\(concurrencyModifier) "
+            modifier += "\(concurrencyModifier) "
         }
         modifier += registration.accessLevel == .public ? "public " : ""
         let nameInput = enumName.map { "name: \($0)" }

--- a/Tests/KnitCodeGenTests/KnitDirectivesTests.swift
+++ b/Tests/KnitCodeGenTests/KnitDirectivesTests.swift
@@ -91,6 +91,16 @@ final class KnitDirectivesTests: XCTestCase {
         )
     }
 
+    func testSPI() {
+        XCTAssertEqual(
+            try parse("// @knit @_spi(Testing)"),
+            .init(accessLevel: nil, spi: "Testing")
+        )
+
+        // Only 1 SPI is supported, the second will cause the parsing to throw
+        XCTAssertThrowsError(try parse("// @knit @_spi(First) @_spi(Second)"))
+    }
+
     func testModuleName() {
         XCTAssertEqual(
             try parse("// @knit module-name(\"Test\")"),

--- a/Tests/KnitCodeGenTests/RegistrationParsingTests.swift
+++ b/Tests/KnitCodeGenTests/RegistrationParsingTests.swift
@@ -583,6 +583,18 @@ final class RegistrationParsingTests: XCTestCase {
         )
     }
 
+    func testSPIParsing() throws {
+        try assertMultipleRegistrationsString(
+            """
+            // @knit @_spi(Testing)
+            container.registerAbstract(MyType.self)
+            """,
+            registrations: [
+                Registration(service: "MyType", functionName: .registerAbstract, spi: "Testing"),
+            ]
+        )
+    }
+
     func testIncorrectRegistrations() throws {
         try assertNoRegistrationsString("container.someOtherMethod(AType.self)", message: "Incorrect method name")
         try assertNoRegistrationsString("container.register(A)", message: "First param is not a metatype")

--- a/Tests/KnitCodeGenTests/TypeSafetySourceFileTests.swift
+++ b/Tests/KnitCodeGenTests/TypeSafetySourceFileTests.swift
@@ -157,6 +157,21 @@ final class TypeSafetySourceFileTests: XCTestCase {
         )
     }
 
+    func testRegistrationWithSPI() {
+        let registration = Registration(service: "A", accessLevel: .public, spi: "Testing")
+        XCTAssertEqual(
+            try TypeSafetySourceFile.makeResolver(
+                registration: registration,
+                enumName: nil
+            ).formatted().description,
+            """
+            @_spi(Testing) public func callAsFunction(file: StaticString = #fileID, function: StaticString = #function, line: UInt = #line) -> A {
+                knitUnwrap(resolve(A.self), callsiteFile: file, callsiteFunction: function, callsiteLine: line)
+            }
+            """
+        )
+    }
+
     func testArgumentNames() {
         let registration1 = Registration(service: "A", accessLevel: .public, arguments: [.init(type: "String?")])
         XCTAssertEqual(


### PR DESCRIPTION
This is to handle the case where a type is public with an `@_spi` modifier. The generated resolver needs to also be marked with the same `@_spi` modifier. I used knit directives to supply this information as the parser doesn't know about the original type.

This is a fairly rare case that happened to come up ideally we should support it.

Example error when trying to use `@_spi(Testing) protocol MySPIType` inside DI:

```
Generated/KnitDITypeSafety: error: cannot use protocol 'MySPIType' here; it is SPI

public func mySPIType(file: StaticString = #fileID, function: StaticString = #function, line: UInt = #line) -> MySPIType {
```