### PR TITLE
Retain type attributes for Registration Arguments

### DIFF
--- a/CLI/Sources/KnitCodeGen/FunctionCallRegistrationParsing.swift
+++ b/CLI/Sources/KnitCodeGen/FunctionCallRegistrationParsing.swift
@@ -311,8 +311,18 @@ private func getArgumentType(arg: LabeledExprSyntax) -> String? {
 
 private func getArgumentType(arg: ClosureParameterSyntax) -> String? {
     if arg.type?.is(AttributedTypeSyntax.self) == true {
-        return arg.type!.as(AttributedTypeSyntax.self)!
-            .with(\.attributes, []) // Clear any attributes
+        let type = arg.type!.as(AttributedTypeSyntax.self)!
+
+        // Filter out the `@escaping` attribute. Other type attributes should remain in place.
+        let attributes = type.attributes.filter { element in
+            if case .attribute(let attribute) = element {
+                let name = attribute.attributeName.as(IdentifierTypeSyntax.self)?.name.text
+                return name != "escaping"
+            }
+            return true
+        }
+        return type
+            .with(\.attributes, attributes) // Replace attributes with filtered list
             .description.trimmingCharacters(in: .whitespacesAndNewlines)
     }
     return arg.type?.description.trimmingCharacters(in: .whitespacesAndNewlines)

--- a/CLI/Sources/KnitCodeGen/Registration.swift
+++ b/CLI/Sources/KnitCodeGen/Registration.swift
@@ -78,7 +78,10 @@ extension Registration {
         }
 
         public enum Identifier: Codable, Equatable {
+            /// Used for arguments defined in `.register` registrations.
             case fixed(String)
+
+            /// Used for arguments provided to `.autoregister` registrations, as those do not receive explicit identifiers.
             case computed
         }
 

--- a/CLI/Tests/KnitCodeGenTests/RegistrationParsingTests.swift
+++ b/CLI/Tests/KnitCodeGenTests/RegistrationParsingTests.swift
@@ -450,6 +450,32 @@ final class RegistrationParsingTests: XCTestCase {
                 Registration(service: "A", arguments: [.init(identifier: "arg1", type: "() -> Void")]),
             ]
         )
+
+        try assertMultipleRegistrationsString(
+            """
+            container.register(A.self) { (resolver, arg1: @escaping @MainActor @Sendable (Bool) -> Void) in
+                A(arg: arg1)
+            }
+            """,
+            registrations: [
+                Registration(service: "A", arguments: [
+                    .init(identifier: "arg1", type: "@MainActor @Sendable (Bool) -> Void")
+                ]),
+            ]
+        )
+
+        try assertMultipleRegistrationsString(
+            """
+            container.register(A.self) { (resolver, arg1: @escaping @CustomGlobalActor () -> Void) in
+                A(arg: arg1)
+            }
+            """,
+            registrations: [
+                Registration(service: "A", arguments: [
+                    .init(identifier: "arg1", type: "@CustomGlobalActor () -> Void")
+                ]),
+            ]
+        )
     }
 
     func testArgumentMissingType() throws {


### PR DESCRIPTION
We should retain all type attributes on the arguments except for the `@escaping` attribute.