### PR TITLE
Move SPM plugin product to top-level package

### DIFF
--- a/CLI/Package.resolved
+++ b/CLI/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "0cc5029beb3d7f7a732a22a11b5b71fe843fa1b43dfdae3c158cc8308f08fecb",
+  "originHash" : "8356d4b0a2a1eb05a8278b65cdebafc0bd17e755976a506666ed9ef9d24e595c",
   "pins" : [
     {
       "identity" : "swift-argument-parser",

--- a/CLI/Package.swift
+++ b/CLI/Package.swift
@@ -4,13 +4,12 @@
 import PackageDescription
 
 let package = Package(
-    name: "Knit CLI",
+    name: "Knit-CLI",
     platforms: [
         .macOS(.v14),
     ],
     products: [
         .executable(name: "knit-cli", targets: ["KnitCommand"]),
-        .plugin(name: "KnitBuildPlugin", targets: ["KnitBuildPlugin"]),
     ],
     dependencies: [
         .package(url: "https://github.com/apple/swift-syntax.git", from: "510.0.2"),
@@ -23,13 +22,6 @@ let package = Package(
                 .product(name: "SwiftSyntax", package: "swift-syntax"),
                 .product(name: "ArgumentParser", package: "swift-argument-parser"),
                 .target(name: "KnitCodeGen"),
-            ]
-        ),
-        .plugin(
-            name: "KnitBuildPlugin",
-            capability: .buildTool,
-            dependencies: [
-                .target(name: "KnitCommand"),
             ]
         ),
         .target(

--- a/CLI/README.md
+++ b/CLI/README.md
@@ -4,6 +4,11 @@ The Knit CLI is responsible for parsing Assembly files and producing type safety
 The `knit-cli` executable is the primary interface for this parsing and file generation.
 An Xcode Build Plugin is also provided to integrate with Xcode projects that use SPM Package Dependencies.
 
+## Releases
+
+Each Github release has a zip file that includes a precompiled executable of the Knit CLI,
+along with source files.
+
 ## Xcode Build Plugin
 
 For projects that do not have complex or custom build configurations, you can use the vended build plugin.

--- a/Example/KnitExample.xcodeproj/project.pbxproj
+++ b/Example/KnitExample.xcodeproj/project.pbxproj
@@ -129,7 +129,7 @@
 			buildRules = (
 			);
 			dependencies = (
-				2CEFF6392C75A71C0069B6D6 /* PBXTargetDependency */,
+				2C1CC8BA2C76939F00B1CD49 /* PBXTargetDependency */,
 			);
 			name = KnitExample;
 			packageProductDependencies = (
@@ -150,7 +150,7 @@
 			buildRules = (
 			);
 			dependencies = (
-				2CEFF6602C75C23C0069B6D6 /* PBXTargetDependency */,
+				2C1CC8BC2C7693A400B1CD49 /* PBXTargetDependency */,
 				C44755122A3FEA120072333A /* PBXTargetDependency */,
 			);
 			name = KnitExampleTests;
@@ -189,8 +189,7 @@
 			);
 			mainGroup = C43334E62A3FDD43003BA9E3;
 			packageReferences = (
-				2C360AE82B4E1A2B00C88B99 /* XCLocalSwiftPackageReference ".." */,
-				2CEFF6372C75A70E0069B6D6 /* XCLocalSwiftPackageReference "../CLI" */,
+				2C1CC8B62C7692F000B1CD49 /* XCLocalSwiftPackageReference "../../knit" */,
 			);
 			productRefGroup = C43334F02A3FDD43003BA9E3 /* Products */;
 			projectDirPath = "";
@@ -244,13 +243,13 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
-		2CEFF6392C75A71C0069B6D6 /* PBXTargetDependency */ = {
+		2C1CC8BA2C76939F00B1CD49 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			productRef = 2CEFF6382C75A71C0069B6D6 /* KnitBuildPlugin */;
+			productRef = 2C1CC8B92C76939F00B1CD49 /* KnitBuildPlugin */;
 		};
-		2CEFF6602C75C23C0069B6D6 /* PBXTargetDependency */ = {
+		2C1CC8BC2C7693A400B1CD49 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			productRef = 2CEFF65F2C75C23C0069B6D6 /* KnitBuildPlugin */;
+			productRef = 2C1CC8BB2C7693A400B1CD49 /* KnitBuildPlugin */;
 		};
 		C44755122A3FEA120072333A /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
@@ -386,6 +385,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"KnitExample/Preview Content\"";
+				DEVELOPMENT_TEAM = "";
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
@@ -415,6 +415,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"KnitExample/Preview Content\"";
+				DEVELOPMENT_TEAM = "";
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
@@ -505,30 +506,26 @@
 /* End XCConfigurationList section */
 
 /* Begin XCLocalSwiftPackageReference section */
-		2C360AE82B4E1A2B00C88B99 /* XCLocalSwiftPackageReference ".." */ = {
+		2C1CC8B62C7692F000B1CD49 /* XCLocalSwiftPackageReference "../../knit" */ = {
 			isa = XCLocalSwiftPackageReference;
-			relativePath = ..;
-		};
-		2CEFF6372C75A70E0069B6D6 /* XCLocalSwiftPackageReference "../CLI" */ = {
-			isa = XCLocalSwiftPackageReference;
-			relativePath = ../CLI;
+			relativePath = ../../knit;
 		};
 /* End XCLocalSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
+		2C1CC8B92C76939F00B1CD49 /* KnitBuildPlugin */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 2C1CC8B62C7692F000B1CD49 /* XCLocalSwiftPackageReference "../../knit" */;
+			productName = "plugin:KnitBuildPlugin";
+		};
+		2C1CC8BB2C7693A400B1CD49 /* KnitBuildPlugin */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 2C1CC8B62C7692F000B1CD49 /* XCLocalSwiftPackageReference "../../knit" */;
+			productName = "plugin:KnitBuildPlugin";
+		};
 		2C360AE92B4E1A2C00C88B99 /* Knit */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = Knit;
-		};
-		2CEFF6382C75A71C0069B6D6 /* KnitBuildPlugin */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 2CEFF6372C75A70E0069B6D6 /* XCLocalSwiftPackageReference "../CLI" */;
-			productName = "plugin:KnitBuildPlugin";
-		};
-		2CEFF65F2C75C23C0069B6D6 /* KnitBuildPlugin */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 2CEFF6372C75A70E0069B6D6 /* XCLocalSwiftPackageReference "../CLI" */;
-			productName = "plugin:KnitBuildPlugin";
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/Example/KnitExample.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Example/KnitExample.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "c561c8bdb692bd354441bef5d98821c84386c537a966155ffbc6e755f41a4dac",
+  "originHash" : "34fd4e568c3aa20d73aa77d14541b56e3bbf5fe47ce50cdb20bb9b76b3b2ea74",
   "pins" : [
     {
       "identity" : "swift-argument-parser",

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,6 +1,24 @@
 {
-  "originHash" : "facf095a5c234101eb4a21c59eef779060d0777c6cc8aba029ed01234afc8953",
+  "originHash" : "80b25f78b0b17934ec8338366df30b99e1b361299a3ebc0c9671bdb9b520b5b6",
   "pins" : [
+    {
+      "identity" : "swift-argument-parser",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-argument-parser",
+      "state" : {
+        "revision" : "41982a3656a71c768319979febd796c6fd111d5c",
+        "version" : "1.5.0"
+      }
+    },
+    {
+      "identity" : "swift-syntax",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-syntax.git",
+      "state" : {
+        "revision" : "2bc86522d115234d1f588efe2bcb4ce4be8f8b82",
+        "version" : "510.0.3"
+      }
+    },
     {
       "identity" : "swinject",
       "kind" : "remoteSourceControl",

--- a/Package.swift
+++ b/Package.swift
@@ -10,11 +10,13 @@ let package = Package(
         .iOS(.v15),
     ],
     products: [
-        .library(name: "Knit", targets: ["Knit"])
+        .library(name: "Knit", targets: ["Knit"]),
+        .plugin(name: "KnitBuildPlugin", targets: ["KnitBuildPlugin"]),
     ],
     dependencies: [
         .package(url: "https://github.com/Swinject/Swinject.git", from: "2.9.1"),
         .package(url: "https://github.com/Swinject/SwinjectAutoregistration.git", from: "2.9.1"),
+        .package(name: "Knit-CLI", path: "CLI/"),
     ],
     targets: [
         .target(
@@ -29,6 +31,13 @@ let package = Package(
             name: "KnitTests",
             dependencies: [
                 "Knit",
+            ]
+        ),
+        .plugin(
+            name: "KnitBuildPlugin",
+            capability: .buildTool,
+            dependencies: [
+                .product(name: "knit-cli", package: "Knit-CLI"),
             ]
         ),
     ]

--- a/Plugins/KnitBuildPlugin/KnitBuildPlugin.swift
+++ b/Plugins/KnitBuildPlugin/KnitBuildPlugin.swift
@@ -102,7 +102,7 @@ extension XcodePluginContext {
 
         return .buildCommand(
             displayName: "Knit Plugin: Generate Knit files based on config \(configFilePath.description)",
-            executable: try self.tool(named: "KnitCommand").path,
+            executable: try self.tool(named: "knit-cli").path,
             arguments: arguments,
             inputFiles: assemblyInputPaths,
             outputFiles: [typeSafetyOutputPath, unitTestOutputPath].compactMap { $0 }


### PR DESCRIPTION
This allows consumers who specify the package with a git repo URL to be able to consume the build plugin from that top level package.