### PR TITLE
Fix treatment of `@escaping` attribute on registration arguments and fix identifier uniqueness bug

### DIFF
--- a/CLI/Sources/KnitCodeGen/FunctionCallRegistrationParsing.swift
+++ b/CLI/Sources/KnitCodeGen/FunctionCallRegistrationParsing.swift
@@ -310,21 +310,6 @@ private func getArgumentType(arg: LabeledExprSyntax) -> String? {
 }
 
 private func getArgumentType(arg: ClosureParameterSyntax) -> String? {
-    if arg.type?.is(AttributedTypeSyntax.self) == true {
-        let type = arg.type!.as(AttributedTypeSyntax.self)!
-
-        // Filter out the `@escaping` attribute. Other type attributes should remain in place.
-        let attributes = type.attributes.filter { element in
-            if case .attribute(let attribute) = element {
-                let name = attribute.attributeName.as(IdentifierTypeSyntax.self)?.name.text
-                return name != "escaping"
-            }
-            return true
-        }
-        return type
-            .with(\.attributes, attributes) // Replace attributes with filtered list
-            .description.trimmingCharacters(in: .whitespacesAndNewlines)
-    }
     return arg.type?.description.trimmingCharacters(in: .whitespacesAndNewlines)
 }
 

--- a/CLI/Tests/KnitCodeGenTests/RegistrationParsingTests.swift
+++ b/CLI/Tests/KnitCodeGenTests/RegistrationParsingTests.swift
@@ -447,7 +447,7 @@ final class RegistrationParsingTests: XCTestCase {
             }
             """,
             registrations: [
-                Registration(service: "A", arguments: [.init(identifier: "arg1", type: "() -> Void")]),
+                Registration(service: "A", arguments: [.init(identifier: "arg1", type: "@escaping () -> Void")]),
             ]
         )
 
@@ -459,7 +459,7 @@ final class RegistrationParsingTests: XCTestCase {
             """,
             registrations: [
                 Registration(service: "A", arguments: [
-                    .init(identifier: "arg1", type: "@MainActor @Sendable (Bool) -> Void")
+                    .init(identifier: "arg1", type: "@escaping @MainActor @Sendable (Bool) -> Void")
                 ]),
             ]
         )
@@ -472,7 +472,7 @@ final class RegistrationParsingTests: XCTestCase {
             """,
             registrations: [
                 Registration(service: "A", arguments: [
-                    .init(identifier: "arg1", type: "@CustomGlobalActor () -> Void")
+                    .init(identifier: "arg1", type: "@escaping @CustomGlobalActor () -> Void")
                 ]),
             ]
         )

--- a/CLI/Tests/KnitCodeGenTests/TypeSafetySourceFileTests.swift
+++ b/CLI/Tests/KnitCodeGenTests/TypeSafetySourceFileTests.swift
@@ -20,7 +20,10 @@ final class TypeSafetySourceFileTests: XCTestCase {
                     .init(service: "ServiceB", name: "otherName"),
                     .init(service: "ServiceC", name: nil, accessLevel: .hidden), // No resolver is created
                     .init(service: "ServiceD", name: nil, accessLevel: .public, getterConfig: GetterConfig.both, functionName: .implements),
-                    .init(service: "ServiceE", name: nil, accessLevel: .public, arguments: [.init(type: "() -> Void")]),
+                    .init(service: "ServiceE", name: nil, accessLevel: .public, arguments: [
+                        .init(type: "@escaping () -> Void"),
+                        .init(type: "@escaping @Sendable (Bool) -> Void")
+                    ]),
                     .init(service: "ServiceF", name: nil, accessLevel: .public, getterConfig: [GetterConfig.identifiedGetter(nil)]),
                     .init(service: "(String, Int?)", name: nil, accessLevel: .public, getterConfig: [GetterConfig.identifiedGetter(nil)]),
                 ],
@@ -40,8 +43,8 @@ final class TypeSafetySourceFileTests: XCTestCase {
             public func serviceD(file: StaticString = #fileID, function: StaticString = #function, line: UInt = #line) -> ServiceD {
                 knitUnwrap(resolve(ServiceD.self), callsiteFile: file, callsiteFunction: function, callsiteLine: line)
             }
-            public func serviceE(closure: @escaping () -> Void, file: StaticString = #fileID, function: StaticString = #function, line: UInt = #line) -> ServiceE {
-                knitUnwrap(resolve(ServiceE.self, argument: closure), callsiteFile: file, callsiteFunction: function, callsiteLine: line)
+            public func serviceE(closure1: @escaping () -> Void, closure2: @escaping @Sendable (Bool) -> Void, file: StaticString = #fileID, function: StaticString = #function, line: UInt = #line) -> ServiceE {
+                knitUnwrap(resolve(ServiceE.self, arguments: closure1, closure2), callsiteFile: file, callsiteFunction: function, callsiteLine: line)
             }
             public func serviceF(file: StaticString = #fileID, function: StaticString = #function, line: UInt = #line) -> ServiceF {
                 knitUnwrap(resolve(ServiceF.self), callsiteFile: file, callsiteFunction: function, callsiteLine: line)
@@ -172,35 +175,65 @@ final class TypeSafetySourceFileTests: XCTestCase {
         )
     }
 
-    func testArgumentNames() {
-        let registration1 = Registration(service: "A", accessLevel: .public, arguments: [.init(type: "String?")])
+    func testArgumentIdentifiers() {
+        let registration1 = Registration(service: "A", arguments: [.init(type: "String?")])
         XCTAssertEqual(
-            registration1.namedArguments().map { $0.resolvedIdentifier() },
+            registration1.uniquelyIdentifiedArguments().map { $0.resolvedIdentifier() },
             ["string"]
         )
 
-        let registration2 = Registration(service: "A", accessLevel: .public, arguments: [.init(type: "Service.Argument")])
+        let registration2 = Registration(service: "A", arguments: [.init(type: "Service.Argument")])
         XCTAssertEqual(
-            registration2.namedArguments().map { $0.resolvedIdentifier() },
+            registration2.uniquelyIdentifiedArguments().map { $0.resolvedIdentifier() },
             ["argument"]
         )
 
-        let registration3 = Registration(service: "A", accessLevel: .public, arguments: [.init(type: "Result<String, Error>")])
+        let registration3 = Registration(service: "A", arguments: [.init(type: "Result<String, Error>")])
         XCTAssertEqual(
-            registration3.namedArguments().map { $0.resolvedIdentifier() },
+            registration3.uniquelyIdentifiedArguments().map { $0.resolvedIdentifier() },
             ["result"]
         )
 
         let registration4 = Registration(
             service: "A",
-            accessLevel: .public,
             arguments: [.init(type: "[Result<ServerResponse<Any>, Swift.Error>]")]
         )
         XCTAssertEqual(
-            registration4.namedArguments().map { $0.resolvedIdentifier() },
+            registration4.uniquelyIdentifiedArguments().map { $0.resolvedIdentifier() },
             ["result"]
         )
 
+        // Argument identifier uniqueness
+        let registration5 = Registration(
+            service: "A",
+            arguments: [
+                // First integer
+                .init(type: "Int"),
+                // Only one instance of String, no uniqueness needed
+                .init(type: "String"),
+                // First closure
+                .init(type: "@escaping () -> Void"),
+                // Second integer
+                .init(type: "Int"),
+                // Second closure
+                // Note the type is different to the first closure but the resolved identifier will be the same
+                // (i.e. "closure") so uniqueness will need to be added to avoid collision.
+                .init(type: "@escaping @MainActor (Bool) -> String"),
+                // Third integer
+                .init(type: "Int")
+            ]
+        )
+        XCTAssertEqual(
+            registration5.uniquelyIdentifiedArguments().map { $0.resolvedIdentifier() },
+            [
+                "int1",
+                "string",
+                "closure1",
+                "int2",
+                "closure2",
+                "int3"
+            ]
+        )
     }
 
     func test_fakeAssembly_defaultOverride_generation() throws {

--- a/CLI/Tests/KnitCodeGenTests/UnitTestSourceFileTests.swift
+++ b/CLI/Tests/KnitCodeGenTests/UnitTestSourceFileTests.swift
@@ -251,6 +251,7 @@ final class UnitTestSourceFileTests: XCTestCase {
             Registration(service: "A", accessLevel: .public, arguments: [.init(type: "String")]),
             Registration(service: "B", accessLevel: .public, arguments: [.init(identifier: "field", type: "String"), .init(type: "String")]),
             Registration(service: "A", accessLevel: .public, arguments: [.init(type: "Int"), .init(type: "String")]),
+            Registration(service: "C", accessLevel: .public, arguments: [.init(type: "@escaping () -> Void")]),
         ]
         let result = try UnitTestSourceFile.makeArgumentStruct(registrations: registrations, assemblyName: "MyModule")
 
@@ -262,6 +263,7 @@ final class UnitTestSourceFileTests: XCTestCase {
             let bField: String
             let bString: String
             let aInt: Int
+            let cClosure: () -> Void
         }
         """
 


### PR DESCRIPTION
Previously we were dropping `@escaping` when parsing the argument type declaration, but then adding it back upon writing the type safety source file. However this meant that an attributed typealias such as `@escaping ClosureActionTypeAlias` would drop the attribute on parsing, but we would have no way to know to add it back upon writing the type safety methods.

Now we do not make any modifications to the attributes on type declarations for arguments. When generating properties for those types, `@escaping` is always dropped as it is implicit (and including it explicitly is a compilation error).

This also uncovered an issue with argument identifier uniqueness for closures. We should use the identifier when determining uniqueness, not the type, as all closure types map to the same identifier.