### PR TITLE
Remove “use target resolver” flag

### DIFF
--- a/Sources/KnitCodeGen/AssemblyParser.swift
+++ b/Sources/KnitCodeGen/AssemblyParser.swift
@@ -9,16 +9,13 @@ import SwiftParser
 public struct AssemblyParser {
 
     private let defaultTargetResolver: String
-    private let useTargetResolver: Bool
     private let nameExtractor: ModuleNameExtractor
 
     public init(
         defaultTargetResolver: String = "Resolver",
-        useTargetResolver: Bool = false,
         moduleNameRegex: String? = nil
     ) throws {
         self.defaultTargetResolver = defaultTargetResolver
-        self.useTargetResolver = useTargetResolver
         self.nameExtractor = try ModuleNameExtractor(moduleNamePattern: moduleNameRegex)
     }
 
@@ -30,15 +27,13 @@ public struct AssemblyParser {
         let configs = try paths.flatMap { path in
             return try parse(
                 path: path,
-                defaultTargetResolver: defaultTargetResolver,
-                useTargetResolver: useTargetResolver
+                defaultTargetResolver: defaultTargetResolver
             )
         }
         let additionalConfigs = try externalTestingAssemblies.flatMap { path in
             return try parse(
                 path: path,
-                defaultTargetResolver: defaultTargetResolver,
-                useTargetResolver: useTargetResolver
+                defaultTargetResolver: defaultTargetResolver
             )
         }
 
@@ -49,7 +44,7 @@ public struct AssemblyParser {
         )
     }
 
-    private func parse(path: String, defaultTargetResolver: String, useTargetResolver: Bool) throws -> [Configuration] {
+    private func parse(path: String, defaultTargetResolver: String) throws -> [Configuration] {
         let url = URL(fileURLWithPath: path, isDirectory: false)
         var errorsToPrint = [Error]()
 
@@ -119,12 +114,7 @@ public struct AssemblyParser {
         }
         let moduleName = classDeclVisitor.directives.moduleName ?? extractedModuleName ?? classDeclVisitor.moduleName
 
-        let targetResolver: String
-        if useTargetResolver {
-            targetResolver = classDeclVisitor.targetResolver ?? defaultTargetResolver
-        } else {
-            targetResolver = defaultTargetResolver
-        }
+        let targetResolver: String = classDeclVisitor.targetResolver ?? defaultTargetResolver
 
         guard let assemblyType = classDeclVisitor.assemblyType else {
             throw AssemblyParsingError.missingAssemblyType

--- a/Sources/KnitCommand/GenCommand.swift
+++ b/Sources/KnitCommand/GenCommand.swift
@@ -58,10 +58,6 @@ struct GenCommand: ParsableCommand {
                   """)
     var jsonDataOutputPath: String?
 
-    // This flag was added to allow backwards compatibility. This may prove to be unnecessary.
-    @Flag(help: "When parsing assembly files, generate type safe methods against the target resolver")
-    var useTargetResolver: Bool = false
-
     @Option(help: "Default type to extend when generating Resolver type safety methods")
     var defaultExtensionTargetResolver = "Resolver"
 
@@ -82,8 +78,8 @@ struct GenCommand: ParsableCommand {
 
             let assemblyParser = try AssemblyParser(
                 defaultTargetResolver: defaultExtensionTargetResolver,
-                useTargetResolver: useTargetResolver,
-                moduleNameRegex: moduleNameRegex)
+                moduleNameRegex: moduleNameRegex
+            )
             parsedConfig = try assemblyParser.parseAssemblies(
                 at: expandedAssemblyPaths,
                 externalTestingAssemblies: expandedTestingPaths,

--- a/Tests/KnitCodeGenTests/AssemblyParsingTests.swift
+++ b/Tests/KnitCodeGenTests/AssemblyParsingTests.swift
@@ -377,18 +377,6 @@ final class AssemblyParsingTests: XCTestCase {
         XCTAssertEqual(config.targetResolver, "TestResolver")
     }
 
-    func testCustomResolverWhenDisabled() throws {
-        let sourceFile: SourceFileSyntax = """
-            class MyAssembly: Assembly {
-                typealias TargetResolver = TestResolver
-            }
-        """
-
-        let config = try assertParsesSyntaxTree(sourceFile, useTargetResolver: false)
-        XCTAssertEqual(config.assemblyName, "MyAssembly")
-        XCTAssertEqual(config.targetResolver, "Resolver")
-    }
-
     func testIfDefElseFailure() throws {
         let sourceFile: SourceFileSyntax = """
             class ExampleAssembly: Assembly {
@@ -499,7 +487,7 @@ final class AssemblyParsingTests: XCTestCase {
         """
         var errorsToPrint = [Error]()
 
-        let parser = try AssemblyParser(defaultTargetResolver: "Resolver", useTargetResolver: true)
+        let parser = try AssemblyParser(defaultTargetResolver: "Resolver")
 
         let configurations = try parser.parseSyntaxTree(
             sourceFile,
@@ -529,7 +517,7 @@ final class AssemblyParsingTests: XCTestCase {
         """
         var errorsToPrint = [Error]()
 
-        let parser = try AssemblyParser(defaultTargetResolver: "Resolver", useTargetResolver: true)
+        let parser = try AssemblyParser(defaultTargetResolver: "Resolver")
 
         let configurations = try parser.parseSyntaxTree(
             sourceFile,
@@ -808,13 +796,12 @@ final class AssemblyParsingTests: XCTestCase {
 private func assertParsesSyntaxTree(
     _ sourceFile: SourceFileSyntax,
     assertErrorsToPrint assertErrorsCallback: (([Error]) throws -> Void)? = nil,
-    useTargetResolver: Bool = true,
     file: StaticString = #filePath,
     line: UInt = #line
 ) throws -> Configuration {
     var errorsToPrint = [Error]()
 
-    let parser = try AssemblyParser(defaultTargetResolver: "Resolver", useTargetResolver: useTargetResolver)
+    let parser = try AssemblyParser(defaultTargetResolver: "Resolver")
 
     let configuration = try parser.parseSyntaxTree(
         sourceFile,


### PR DESCRIPTION
We now always use Knit with TargetResolver parsing so remove the flag and use the behavior that always respects TargetResolvers.