### PR TITLE
Remove support for `Swinject.Assembly` as the base assembly type

### DIFF
--- a/Sources/KnitCodeGen/AssemblyParsing.swift
+++ b/Sources/KnitCodeGen/AssemblyParsing.swift
@@ -84,7 +84,7 @@ class AssemblyFileVisitor: SyntaxVisitor, IfConfigVisitor {
             }
         }
         let assemblyType = inheritedTypes?
-            .first { $0.hasSuffix(Configuration.AssemblyType.baseAssembly.rawValue) }
+            .first { $0.hasSuffix(Configuration.AssemblyType.suffix) }
             .flatMap { Configuration.AssemblyType(rawValue: $0) }
 
         let classDeclVisitor = ClassDeclVisitor(

--- a/Sources/KnitCodeGen/Configuration.swift
+++ b/Sources/KnitCodeGen/Configuration.swift
@@ -14,11 +14,13 @@ public struct Configuration: Encodable {
 
     public enum AssemblyType: String, Encodable {
         /// `Swinject.Assembly`
-        case baseAssembly = "Assembly"
         case moduleAssembly = "ModuleAssembly"
         case autoInitAssembly = "AutoInitModuleAssembly"
         case abstractAssembly = "AbstractAssembly"
         case fakeAssembly = "FakeAssembly"
+
+        /// The suffix shared by all assembly types.
+        static let suffix = "Assembly"
     }
     public var assemblyType: AssemblyType
 
@@ -33,7 +35,7 @@ public struct Configuration: Encodable {
         assemblyName: String,
         moduleName: String,
         directives: KnitDirectives = .init(),
-        assemblyType: AssemblyType = .baseAssembly,
+        assemblyType: AssemblyType = .moduleAssembly,
         registrations: [Registration],
         registrationsIntoCollections: [RegistrationIntoCollection] = [],
         imports: [ModuleImport] = [],


### PR DESCRIPTION
The base type for assemblies is now `ModuleAssembly`.