### PR TITLE
Revert "Improve Swift 6 toolchain support"

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
         with:
           swift-version: "5.10"
       - name: Checkout
-        uses: actions/checkout@v4.2.2
+        uses: actions/checkout@v4.1.7
       - name: Create Release
         run: |
           set -euo pipefail

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -10,12 +10,12 @@ on:
     branches: [ "main" ]
 
 jobs:
-  build-knit-swift-5:
+  build-knit:
 
     runs-on: macos-latest
 
     steps:
-    - uses: actions/checkout@v4.2.2
+    - uses: actions/checkout@v4.1.7
     - uses: swift-actions/setup-swift@v2.1.0
       with:
         swift-version: "5.10"
@@ -23,19 +23,3 @@ jobs:
       run: swift build -v
     - name: Run Knit tests
       run: swift test -v
-
-# Enable below when issue is resolved: https://github.com/swift-actions/setup-swift/issues/683
-
-#  build-knit-swift-6:
-#
-#    runs-on: macos-latest
-#
-#    steps:
-#    - uses: actions/checkout@v4.2.2
-#    - uses: swift-actions/setup-swift@v2.1.0
-#      with:
-#        swift-version: "6.0"
-#    - name: Build Knit
-#      run: swift build -v
-#    - name: Run Knit tests
-#      run: swift test -v

--- a/Package.swift
+++ b/Package.swift
@@ -66,9 +66,5 @@ let package = Package(
                 "KnitCodeGen",
             ]
         ),
-    ],
-    swiftLanguageVersions: [
-        // When this SPM package is imported by a Swift 6 toolchain it should still be used in the v5 language mode
-        .v5,
     ]
 )

--- a/Sources/KnitCodeGen/AssemblyParsing.swift
+++ b/Sources/KnitCodeGen/AssemblyParsing.swift
@@ -3,8 +3,8 @@
 //
 
 import Foundation
-@preconcurrency import SwiftSyntax
-@preconcurrency import SwiftParser
+import SwiftSyntax
+import SwiftParser
 
 class AssemblyFileVisitor: SyntaxVisitor, IfConfigVisitor {
 

--- a/Sources/KnitCodeGen/Configuration.swift
+++ b/Sources/KnitCodeGen/Configuration.swift
@@ -5,14 +5,14 @@
 import Foundation
 import SwiftSyntax
 
-public struct Configuration: Encodable, Sendable {
+public struct Configuration: Encodable {
 
     /// Name of the module for this configuration.
     public var assemblyName: String
     public let moduleName: String
     public var directives: KnitDirectives
 
-    public enum AssemblyType: String, Encodable, Sendable {
+    public enum AssemblyType: String, Encodable {
         /// `Swinject.Assembly`
         case moduleAssembly = "ModuleAssembly"
         case autoInitAssembly = "AutoInitModuleAssembly"

--- a/Sources/KnitCodeGen/FunctionCallRegistrationParsing.swift
+++ b/Sources/KnitCodeGen/FunctionCallRegistrationParsing.swift
@@ -3,7 +3,7 @@
 //
 
 import Foundation
-@preconcurrency import SwiftSyntax
+import SwiftSyntax
 
 struct CalledMethod {
 

--- a/Sources/KnitCodeGen/KnitDirectives.swift
+++ b/Sources/KnitCodeGen/KnitDirectives.swift
@@ -5,7 +5,7 @@
 import Foundation
 import SwiftSyntax
 
-public struct KnitDirectives: Codable, Equatable, Sendable {
+public struct KnitDirectives: Codable, Equatable {
     var accessLevel: AccessLevel?
     var getterConfig: Set<GetterConfig>
     var moduleName: String?
@@ -131,16 +131,16 @@ extension KnitDirectives {
     }
 }
 
-public enum GetterConfig: Codable, Equatable, Hashable, Sendable {
+public enum GetterConfig: Codable, Equatable, Hashable {
     /// Only the `callAsFunction()` accessor is generated.
     case callAsFunction
     /// Only the identified getter is generated.
     case identifiedGetter(_ name: String?)
 
     /// Centralized control of the default behavior.
-    public static let `default`: Set<GetterConfig> = [.identifiedGetter(nil)]
+    public static var `default`: Set<GetterConfig> = [.identifiedGetter(nil)]
 
-    public static let both: Set<GetterConfig> = [.callAsFunction, .identifiedGetter(nil)]
+    public static var both: Set<GetterConfig> = [.callAsFunction, .identifiedGetter(nil)]
 
     public var isNamed: Bool {
         switch self {
@@ -150,12 +150,12 @@ public enum GetterConfig: Codable, Equatable, Hashable, Sendable {
     }
 }
 
-public enum AccessLevel: String, CaseIterable, Codable, Sendable {
+public enum AccessLevel: String, CaseIterable, Codable {
     case `public`
     case `internal`
     case hidden
     case ignore
 
     /// Centralized control of the default behavior.
-    public static let `default`: AccessLevel = .internal
+    public static var `default`: AccessLevel = .internal
 }

--- a/Sources/KnitCodeGen/ModuleImport.swift
+++ b/Sources/KnitCodeGen/ModuleImport.swift
@@ -3,9 +3,9 @@
 //
 
 import Foundation
-@preconcurrency import SwiftSyntax
+import SwiftSyntax
 
-public struct ModuleImport: Sendable {
+public struct ModuleImport {
     let decl: ImportDeclSyntax
     let ifConfigCondition: ExprSyntax?
     let name: String

--- a/Sources/KnitCodeGen/Registration.swift
+++ b/Sources/KnitCodeGen/Registration.swift
@@ -2,9 +2,9 @@
 // Copyright © Block, Inc. All rights reserved.
 //
 
-@preconcurrency import SwiftSyntax
+import SwiftSyntax
 
-public struct Registration: Equatable, Codable, Sendable {
+public struct Registration: Equatable, Codable {
 
     public var service: String
 
@@ -63,7 +63,7 @@ public struct Registration: Equatable, Codable, Sendable {
 
 extension Registration {
 
-    public struct Argument: Equatable, Codable, Sendable {
+    public struct Argument: Equatable, Codable {
 
         let identifier: Identifier
         let type: String
@@ -77,7 +77,7 @@ extension Registration {
             self.type = type
         }
 
-        public enum Identifier: Codable, Equatable, Sendable {
+        public enum Identifier: Codable, Equatable {
             /// Used for arguments defined in `.register` registrations.
             case fixed(String)
 
@@ -87,7 +87,7 @@ extension Registration {
 
     }
 
-    public enum FunctionName: String, Codable, Sendable {
+    public enum FunctionName: String, Codable {
         case register
         case autoregister
         case registerAbstract

--- a/Sources/KnitCodeGen/RegistrationIntoCollection.swift
+++ b/Sources/KnitCodeGen/RegistrationIntoCollection.swift
@@ -4,7 +4,7 @@
 
 /// Represents a single concrete factory registered into a collection
 /// A separate instance will be created for each call to `{auto}registerIntoCollection`
-public struct RegistrationIntoCollection: Equatable, Sendable {
+public struct RegistrationIntoCollection: Equatable {
 
     public var service: String
 


### PR DESCRIPTION
Reverts cashapp/knit#211

Seeing issues with the SPM build plugin after this change, reverting for now.