### PR TITLE
Create OptionalAbstractRegistration type

### DIFF
--- a/Sources/Knit/Module/Container+AbstractRegistration.swift
+++ b/Sources/Knit/Module/Container+AbstractRegistration.swift
@@ -19,7 +19,10 @@ extension Container {
     }
 
     /// Register that a service is expected to exist but no implementation is currently available
-    /// If no concrete registration is available then nil will be resolved
+    /// The concrete implementation must be registered or the dependency graph is considered invalid
+    /// - NOTE: We don't currently support abstract registrations with arguments
+    /// As this is an `Optional` Service type this allows special handling of the abstract registration for test environments:
+    /// If during testing and no concrete registration is available, then `nil` will be resolved automatically.
     public func registerAbstract<Service>(
         _ serviceType: Optional<Service>.Type,
         name: String? = nil,

--- a/Tests/KnitTests/AbstractRegistrationTests.swift
+++ b/Tests/KnitTests/AbstractRegistrationTests.swift
@@ -73,6 +73,16 @@ final class AbstractRegistrationTests: XCTestCase {
         )
     }
 
+    @MainActor
+    func testOptionalAbstractRegistrations() {
+        let assembler = ModuleAssembler([Assembly3()])
+        let string = assembler.resolver.resolve(String?.self) ?? nil
+        XCTAssertNil(string)
+
+        let int = assembler.resolver.resolve(Optional<Int>.self) ?? nil
+        XCTAssertNil(int)
+    }
+
 }
 
 private struct Assembly1: AutoInitModuleAssembly {
@@ -84,5 +94,13 @@ private struct Assembly2: AutoInitModuleAssembly {
     static var dependencies: [any ModuleAssembly.Type] { [] }
     func assemble(container: Container) {
         container.registerAbstract(String.self)
+    }
+}
+
+private struct Assembly3: AutoInitModuleAssembly {
+    static var dependencies: [any ModuleAssembly.Type] { [] }
+    func assemble(container: Container) {
+        container.registerAbstract(Optional<String>.self)
+        container.registerAbstract(Int?.self)
     }
 }


### PR DESCRIPTION
Normally when we an abstract registration is created a placeholder during testing that will cause a fatal error making it easier to understand what has gone wrong. But for optional services it's possible to simply return nil and allow tests to continue along normally without the service.