### PR TITLE
Improve type name generation of prefixed names

### DIFF
--- a/Sources/KnitCodeGen/TypeNamer.swift
+++ b/Sources/KnitCodeGen/TypeNamer.swift
@@ -14,10 +14,13 @@ enum TypeNamer {
      */
     static func computedIdentifierName(type: String) -> String {
         let type = sanitizeType(type: type, keepGenerics: false)
-        if type.uppercased() == type {
+        let lowercaseIndex = type.firstIndex { $0.isLowercase }
+        if let lowercaseIndex {
+            let chars = max(type.distance(from: type.startIndex, to: lowercaseIndex) - 1, 1)
+            return type.prefix(chars).lowercased() + type.dropFirst(chars)
+        } else {
             return type.lowercased()
         }
-        return type.prefix(1).lowercased() + type.dropFirst()
     }
 
     /// Simplifies the type name and removes invalid characters

--- a/Tests/KnitCodeGenTests/TypeNamerTests.swift
+++ b/Tests/KnitCodeGenTests/TypeNamerTests.swift
@@ -87,6 +87,17 @@ final class TypeNamerTests: XCTestCase {
         )
     }
 
+    func testPrefixedName() {
+        assertComputedIdentifier(
+            type: "UIApplication",
+            expectedIdentifier: "uiApplication"
+        )
+        assertComputedIdentifier(
+            type: "NSURLSession",
+            expectedIdentifier: "nsurlSession"
+        )
+    }
+
 }
 
 private func assertComputedIdentifier(


### PR DESCRIPTION
This better objc style naming where there are multiple capital letters as a prefix `NSURLSession` isn't quite correct, but it's better than `nSURLSession`.