### PR TITLE
Automatically make autoregister closures @escaping

### DIFF
--- a/Sources/KnitCodeGen/FunctionCallRegistrationParsing.swift
+++ b/Sources/KnitCodeGen/FunctionCallRegistrationParsing.swift
@@ -218,7 +218,12 @@ private func getArguments(
     if let argumentParam = arguments.first(where: {$0.label?.text == "argument"}),
        let argumentType = getArgumentType(arg: argumentParam)
     {
-        return [.init(type: argumentType)]
+        if TypeNamer.isClosure(type: argumentType) {
+            // Make all auto register closures @escaping
+            return [.init(type: "@escaping \(argumentType)")]
+        } else {
+            return [.init(type: argumentType)]
+        }
     }
 
     // Autoregister can provide multiple arguments.
@@ -229,7 +234,11 @@ private func getArguments(
             guard let type = getArgumentType(arg: element) else {
                 return nil
             }
-            return .init(type: type)
+            if TypeNamer.isClosure(type: type) {
+                return .init(type: "@escaping \(type)")
+            } else {
+                return .init(type: type)
+            }
         }
     }
 

--- a/Tests/KnitCodeGenTests/RegistrationParsingTests.swift
+++ b/Tests/KnitCodeGenTests/RegistrationParsingTests.swift
@@ -436,7 +436,7 @@ final class RegistrationParsingTests: XCTestCase {
         try assertMultipleRegistrationsString(
             "container.autoregister(A.self, argument: (() -> Void).self, initializer: A.init)",
             registrations: [
-                Registration(service: "A", arguments: [.init(type: "(() -> Void)")], functionName: .autoregister),
+                Registration(service: "A", arguments: [.init(type: "@escaping (() -> Void)")], functionName: .autoregister),
             ]
         )
 


### PR DESCRIPTION
This fixes the build failure in the example app. 