### PR TITLE
Fix line attachment for syntax error

### DIFF
--- a/Sources/KnitCodeGen/FunctionCallRegistrationParsing.swift
+++ b/Sources/KnitCodeGen/FunctionCallRegistrationParsing.swift
@@ -114,7 +114,10 @@ extension FunctionCallExprSyntax {
                 functionName: .implements
             ) {
                 if forwardedRegistration.hasRedundantGetter {
-                    throw RegistrationParsingError.redundantGetter(syntax: implementsCalledMethod.calledExpression)
+                    throw RegistrationParsingError.redundantGetter(
+                        // Place the error on the `.implements` decl
+                        syntax: implementsCalledMethod.calledExpression.declName
+                    )
                 }
                 forwardedRegistrations.append(forwardedRegistration)
             }


### PR DESCRIPTION
Previously it was placing the error on the parent `register` call rather than on the `.implements` call which was actually at issue.