### PR TITLE
Improve performance of DependencyBuilder

### DIFF
--- a/Sources/Knit/Module/DependencyBuilder.swift
+++ b/Sources/Knit/Module/DependencyBuilder.swift
@@ -58,14 +58,14 @@ final class DependencyBuilder {
             return existingType
         }
         if let overrideType = try defaultOverride(moduleType, fromInput: inputModule != nil),
-           let autoInit = overrideType as? any AutoInitModuleAssembly.Type {
-            return autoInit.init()
+           let created = overrideType._autoInstantiate() {
+            return created
         }
         if let inputModule {
             return inputModule
         }
-        if let autoInit = moduleType as? any AutoInitModuleAssembly.Type {
-            return autoInit.init()
+        if let created = moduleType._autoInstantiate() {
+            return created
         }
 
         throw DependencyBuilderError.moduleNotProvided(moduleType, dependencyTree.sourcePathString(moduleType: moduleType))
@@ -230,7 +230,8 @@ internal extension DependencyBuilder {
                 // Collect AbstractAssemblies as they should all be instantiated and added to the container.
                 // This needs to happen before the filter below as they are all expected to be implemented by other assemblies
                 // and will therefore be filtered out.
-                if ref.type is any AbstractAssembly.Type {
+
+                if ref.type._assemblyFlags.contains(.abstract) {
                     return true
                 }
 

--- a/Tests/KnitCodeGenTests/ConfigurationSetTests.swift
+++ b/Tests/KnitCodeGenTests/ConfigurationSetTests.swift
@@ -32,6 +32,14 @@ final class ConfigurationSetTests: XCTestCase {
                     knitUnwrap(resolve(Service1.self), callsiteFile: file, callsiteFunction: function, callsiteLine: line)
                 }
             }
+            extension Module1Assembly {
+                public static var _assemblyFlags: [ModuleAssemblyFlags] {
+                    []
+                }
+                public static func _autoInstantiate() -> (any ModuleAssembly)? {
+                    nil
+                }
+            }
             /// Generated from ``Module2Assembly``
             extension Resolver {
                 public func callAsFunction(file: StaticString = #fileID, function: StaticString = #function, line: UInt = #line) -> Service2 {
@@ -41,10 +49,26 @@ final class ConfigurationSetTests: XCTestCase {
                     knitUnwrap(resolve(ArgumentService.self, argument: string), callsiteFile: file, callsiteFunction: function, callsiteLine: line)
                 }
             }
+            extension Module2Assembly {
+                public static var _assemblyFlags: [ModuleAssemblyFlags] {
+                    []
+                }
+                public static func _autoInstantiate() -> (any ModuleAssembly)? {
+                    nil
+                }
+            }
             /// Generated from ``Module3Assembly``
             extension Resolver {
                 public func service3(file: StaticString = #fileID, function: StaticString = #function, line: UInt = #line) -> Service3 {
                     knitUnwrap(resolve(Service3.self), callsiteFile: file, callsiteFunction: function, callsiteLine: line)
+                }
+            }
+            extension Module3Assembly {
+                public static var _assemblyFlags: [ModuleAssemblyFlags] {
+                    []
+                }
+                public static func _autoInstantiate() -> (any ModuleAssembly)? {
+                    nil
                 }
             }
             """

--- a/Tests/KnitCodeGenTests/TypeSafetySourceFileTests.swift
+++ b/Tests/KnitCodeGenTests/TypeSafetySourceFileTests.swift
@@ -62,6 +62,14 @@ final class TypeSafetySourceFileTests: XCTestCase {
                 case otherName
             }
         }
+        extension ModuleAssembly {
+            public static var _assemblyFlags: [ModuleAssemblyFlags] {
+                []
+            }
+            public static func _autoInstantiate() -> (any ModuleAssembly)? {
+                nil
+            }
+        }
         """
 
         XCTAssertEqual(expected, result.formatted().description)
@@ -257,6 +265,14 @@ final class TypeSafetySourceFileTests: XCTestCase {
         extension RealAssembly: Knit.DefaultModuleAssemblyOverride {
             public typealias OverrideType = MyFakeAssembly
         }
+        extension MyFakeAssembly {
+            public static var _assemblyFlags: [ModuleAssemblyFlags] {
+                [.autoInit]
+            }
+            public static func _autoInstantiate() -> (any ModuleAssembly)? {
+                MyFakeAssembly()
+            }
+        }
         """
 
         XCTAssertEqual(expected, result.formatted().description)
@@ -289,6 +305,43 @@ final class TypeSafetySourceFileTests: XCTestCase {
         extension OtherRealAssembly: Knit.DefaultModuleAssemblyOverride {
             public typealias OverrideType = MyFakeAssembly
         }
+        extension MyFakeAssembly {
+            public static var _assemblyFlags: [ModuleAssemblyFlags] {
+                [.autoInit]
+            }
+            public static func _autoInstantiate() -> (any ModuleAssembly)? {
+                MyFakeAssembly()
+            }
+        }
+        """
+
+        XCTAssertEqual(expected, result.formatted().description)
+    }
+
+    func test_abstract_generation() throws {
+        let result = try TypeSafetySourceFile.make(
+            from: Configuration(
+                assemblyName: "SomeAbstractAssembly",
+                moduleName: "Module",
+                assemblyType: .abstractAssembly,
+                registrations: [],
+                replaces: [],
+                targetResolver: "AccountResolver"
+            )
+        )
+
+        let expected = """
+        /// Generated from ``SomeAbstractAssembly``
+        extension AccountResolver {
+        }
+        extension SomeAbstractAssembly {
+            public static var _assemblyFlags: [ModuleAssemblyFlags] {
+                [.autoInit, .abstract]
+            }
+            public static func _autoInstantiate() -> (any ModuleAssembly)? {
+                SomeAbstractAssembly()
+            }
+        }
         """
 
         XCTAssertEqual(expected, result.formatted().description)
@@ -310,6 +363,14 @@ final class TypeSafetySourceFileTests: XCTestCase {
         extension Resolver {
             @MainActor func serviceA(file: StaticString = #fileID, function: StaticString = #function, line: UInt = #line) -> ServiceA {
                 knitUnwrap(resolve(ServiceA.self), callsiteFile: file, callsiteFunction: function, callsiteLine: line)
+            }
+        }
+        extension MainActorAssembly {
+            public static var _assemblyFlags: [ModuleAssemblyFlags] {
+                []
+            }
+            public static func _autoInstantiate() -> (any ModuleAssembly)? {
+                nil
             }
         }
         """


### PR DESCRIPTION
This removes the need for some casts like `if ref.type is any AbstractAssembly.Type` which it turns out have a heavy [performance penalty in large apps](https://www.emergetools.com/blog/posts/SwiftProtocolConformance). 
This makes the code a little bit more complex but for a large app saves ~100ms in startup time.