### PR TITLE
Sanitize the Service name used for Argument unit tests

### DIFF
--- a/Sources/KnitCodeGen/UnitTestSourceFile.swift
+++ b/Sources/KnitCodeGen/UnitTestSourceFile.swift
@@ -245,7 +245,8 @@ private extension Registration {
     /// Argument identifiers prefixed with the service name. Provides additional collision safety.
     func serviceIdentifiedArguments() -> [Argument] {
         return uniquelyIdentifiedArguments().map { arg in
-            let serviceName = self.service.prefix(1).lowercased() + self.service.dropFirst()
+            let sanitizedServiceName = TypeNamer.sanitizeType(type: service, keepGenerics: true)
+            let serviceName = sanitizedServiceName.prefix(1).lowercased() + sanitizedServiceName.dropFirst()
             let capitalizedName = arg.resolvedIdentifier().prefix(1).uppercased() + arg.resolvedIdentifier().dropFirst()
             // When generating the test arguments struct, the `@escaping` attribute should always be removed from the
             // argument type, as assigning a closure type to a property is inherently escaping

--- a/Tests/KnitCodeGenTests/UnitTestSourceFileTests.swift
+++ b/Tests/KnitCodeGenTests/UnitTestSourceFileTests.swift
@@ -252,6 +252,8 @@ final class UnitTestSourceFileTests: XCTestCase {
             Registration(service: "B", accessLevel: .public, arguments: [.init(identifier: "field", type: "String"), .init(type: "String")]),
             Registration(service: "A", accessLevel: .public, arguments: [.init(type: "Int"), .init(type: "String")]),
             Registration(service: "C", accessLevel: .public, arguments: [.init(type: "@escaping () -> Void")]),
+            Registration(service: "D?", accessLevel: .public, arguments: [.init(type: "String")]),
+            Registration(service: "Optional<E>", accessLevel: .public, arguments: [.init(type: "String")]),
         ]
         let result = try UnitTestSourceFile.makeArgumentStruct(registrations: registrations, assemblyName: "MyModule")
 
@@ -264,6 +266,8 @@ final class UnitTestSourceFileTests: XCTestCase {
             let bString: String
             let aInt: Int
             let cClosure: () -> Void
+            let dString: String
+            let optional_EString: String
         }
         """
 


### PR DESCRIPTION
The service name is used as part of naming the properties on the generated unit test struct, so it also needs to be sanitized.