### PR TITLE
Add Knit directive to disable code gen of performance functions

### DIFF
--- a/Sources/KnitCodeGen/KnitDirectives.swift
+++ b/Sources/KnitCodeGen/KnitDirectives.swift
@@ -11,13 +11,18 @@ public struct KnitDirectives: Codable, Equatable, Sendable {
     var moduleName: String?
     var spi: String?
 
+    /// When true the code gen will not create the additional methods to improve assembler performance
+    var disablePerformanceGen: Bool
+
     public init(
         accessLevel: AccessLevel? = nil,
+        disablePerformanceGen: Bool = false,
         getterConfig: Set<GetterConfig> = [],
         moduleName: String? = nil,
         spi: String? = nil
     ) {
         self.accessLevel = accessLevel
+        self.disablePerformanceGen = disablePerformanceGen
         self.getterConfig = getterConfig
         self.moduleName = moduleName
         self.spi = spi
@@ -56,6 +61,9 @@ public struct KnitDirectives: Codable, Equatable, Sendable {
             if let name = parsed.moduleName {
                 result.moduleName = name
             }
+            if parsed.disablePerformanceGen {
+                result.disablePerformanceGen = true
+            }
             for getter in parsed.getterConfig {
                 result.getterConfig.insert(getter)
             }
@@ -76,6 +84,9 @@ public struct KnitDirectives: Codable, Equatable, Sendable {
         }
         if token == "getter-callAsFunction" {
             return KnitDirectives(getterConfig: [.callAsFunction])
+        }
+        if token == "disable-performance-gen" {
+            return KnitDirectives(disablePerformanceGen: true)
         }
         if let nameMatch = getterNamedRegex.firstMatch(in: token, range: NSMakeRange(0, token.count)) {
             if nameMatch.numberOfRanges >= 2, nameMatch.range(at: 1).location != NSNotFound {

--- a/Sources/KnitCodeGen/TypeSafetySourceFile.swift
+++ b/Sources/KnitCodeGen/TypeSafetySourceFile.swift
@@ -46,7 +46,9 @@ public enum TypeSafetySourceFile {
             if let defaultOverrides = try makeDefaultOverrideExtensions(config: config) {
                 defaultOverrides
             }
-            try makePerformanceExtension(config: config)
+            if !config.directives.disablePerformanceGen {
+                try makePerformanceExtension(config: config)
+            }
         }
     }
 

--- a/Tests/KnitCodeGenTests/KnitDirectivesTests.swift
+++ b/Tests/KnitCodeGenTests/KnitDirectivesTests.swift
@@ -121,6 +121,13 @@ final class KnitDirectivesTests: XCTestCase {
         XCTAssertThrowsError(try parse("// @knit module-name()"))
     }
 
+    func testPerformanceGen() {
+        XCTAssertEqual(
+            try parse("// @knit disable-performance-gen"),
+            .init(disablePerformanceGen: true)
+        )
+    }
+
     private func parse(_ comment: String) throws -> KnitDirectives {
         let trivia = Trivia(pieces: [.lineComment(comment)])
         return try KnitDirectives.parse(leadingTrivia: trivia)


### PR DESCRIPTION
The `_autoInstantiate` and `_assemblyFlags` functions are generated in order to improve assembler performance for large projects. In some assemblies these functions may be generated incorrectly due to an extension conforming to `AutoInitModuleAssembly`. 
`// @knit disable-performance-gen` can be used to disable this code gen so it can be done manually or use the default implementation fallback.