### PR TITLE
Fix Resolver hierarchy + shadowed registration resolution

### DIFF
--- a/Sources/Swinject/Container.Arguments.erb
+++ b/Sources/Swinject/Container.Arguments.erb
@@ -85,7 +85,12 @@ extension Container {
         <%= arg_param_def %>) -> Service?
     {
         typealias FactoryType = ((Resolver, <%= arg_types %>)) -> Any
-        return _resolve(name: name) { (factory: FactoryType) in factory((self, <%= arg_param_call %>)) }
+        return _resolve(
+            name: name,
+            invoker: { (resolver: Resolver, factory: FactoryType) in
+                factory((resolver, <%= arg_param_call %>))
+            }
+        )
     }
 
 <% end %>

--- a/Sources/Swinject/Container.Arguments.swift
+++ b/Sources/Swinject/Container.Arguments.swift
@@ -241,7 +241,12 @@ extension Container {
         argument: Arg1) -> Service?
     {
         typealias FactoryType = ((Resolver, Arg1)) -> Any
-        return _resolve(name: name) { (factory: FactoryType) in factory((self, argument)) }
+        return _resolve(
+            name: name,
+            invoker: { (resolver: Resolver, factory: FactoryType) in
+                factory((resolver, argument))
+            }
+        )
     }
 
     /// Retrieves the instance with the specified service type and list of 2 arguments to the factory closure.
@@ -274,7 +279,12 @@ extension Container {
         arguments arg1: Arg1, _ arg2: Arg2) -> Service?
     {
         typealias FactoryType = ((Resolver, Arg1, Arg2)) -> Any
-        return _resolve(name: name) { (factory: FactoryType) in factory((self, arg1, arg2)) }
+        return _resolve(
+            name: name,
+            invoker: { (resolver: Resolver, factory: FactoryType) in
+                factory((resolver, arg1, arg2))
+            }
+        )
     }
 
     /// Retrieves the instance with the specified service type and list of 3 arguments to the factory closure.
@@ -307,7 +317,12 @@ extension Container {
         arguments arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3) -> Service?
     {
         typealias FactoryType = ((Resolver, Arg1, Arg2, Arg3)) -> Any
-        return _resolve(name: name) { (factory: FactoryType) in factory((self, arg1, arg2, arg3)) }
+        return _resolve(
+            name: name,
+            invoker: { (resolver: Resolver, factory: FactoryType) in
+                factory((resolver, arg1, arg2, arg3))
+            }
+        )
     }
 
     /// Retrieves the instance with the specified service type and list of 4 arguments to the factory closure.
@@ -340,7 +355,12 @@ extension Container {
         arguments arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3, _ arg4: Arg4) -> Service?
     {
         typealias FactoryType = ((Resolver, Arg1, Arg2, Arg3, Arg4)) -> Any
-        return _resolve(name: name) { (factory: FactoryType) in factory((self, arg1, arg2, arg3, arg4)) }
+        return _resolve(
+            name: name,
+            invoker: { (resolver: Resolver, factory: FactoryType) in
+                factory((resolver, arg1, arg2, arg3, arg4))
+            }
+        )
     }
 
     /// Retrieves the instance with the specified service type and list of 5 arguments to the factory closure.
@@ -373,7 +393,12 @@ extension Container {
         arguments arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3, _ arg4: Arg4, _ arg5: Arg5) -> Service?
     {
         typealias FactoryType = ((Resolver, Arg1, Arg2, Arg3, Arg4, Arg5)) -> Any
-        return _resolve(name: name) { (factory: FactoryType) in factory((self, arg1, arg2, arg3, arg4, arg5)) }
+        return _resolve(
+            name: name,
+            invoker: { (resolver: Resolver, factory: FactoryType) in
+                factory((resolver, arg1, arg2, arg3, arg4, arg5))
+            }
+        )
     }
 
     /// Retrieves the instance with the specified service type and list of 6 arguments to the factory closure.
@@ -406,7 +431,12 @@ extension Container {
         arguments arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3, _ arg4: Arg4, _ arg5: Arg5, _ arg6: Arg6) -> Service?
     {
         typealias FactoryType = ((Resolver, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6)) -> Any
-        return _resolve(name: name) { (factory: FactoryType) in factory((self, arg1, arg2, arg3, arg4, arg5, arg6)) }
+        return _resolve(
+            name: name,
+            invoker: { (resolver: Resolver, factory: FactoryType) in
+                factory((resolver, arg1, arg2, arg3, arg4, arg5, arg6))
+            }
+        )
     }
 
     /// Retrieves the instance with the specified service type and list of 7 arguments to the factory closure.
@@ -439,7 +469,12 @@ extension Container {
         arguments arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3, _ arg4: Arg4, _ arg5: Arg5, _ arg6: Arg6, _ arg7: Arg7) -> Service?
     {
         typealias FactoryType = ((Resolver, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7)) -> Any
-        return _resolve(name: name) { (factory: FactoryType) in factory((self, arg1, arg2, arg3, arg4, arg5, arg6, arg7)) }
+        return _resolve(
+            name: name,
+            invoker: { (resolver: Resolver, factory: FactoryType) in
+                factory((resolver, arg1, arg2, arg3, arg4, arg5, arg6, arg7))
+            }
+        )
     }
 
     /// Retrieves the instance with the specified service type and list of 8 arguments to the factory closure.
@@ -472,7 +507,12 @@ extension Container {
         arguments arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3, _ arg4: Arg4, _ arg5: Arg5, _ arg6: Arg6, _ arg7: Arg7, _ arg8: Arg8) -> Service?
     {
         typealias FactoryType = ((Resolver, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8)) -> Any
-        return _resolve(name: name) { (factory: FactoryType) in factory((self, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8)) }
+        return _resolve(
+            name: name,
+            invoker: { (resolver: Resolver, factory: FactoryType) in
+                factory((resolver, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8))
+            }
+        )
     }
 
     /// Retrieves the instance with the specified service type and list of 9 arguments to the factory closure.
@@ -505,7 +545,12 @@ extension Container {
         arguments arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3, _ arg4: Arg4, _ arg5: Arg5, _ arg6: Arg6, _ arg7: Arg7, _ arg8: Arg8, _ arg9: Arg9) -> Service?
     {
         typealias FactoryType = ((Resolver, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8, Arg9)) -> Any
-        return _resolve(name: name) { (factory: FactoryType) in factory((self, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9)) }
+        return _resolve(
+            name: name,
+            invoker: { (resolver: Resolver, factory: FactoryType) in
+                factory((resolver, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9))
+            }
+        )
     }
 
 }

--- a/Sources/Swinject/_Resolver.swift
+++ b/Sources/Swinject/_Resolver.swift
@@ -13,12 +13,14 @@ public protocol _Resolver {
     /// - Parameter name: The registration name.
     /// - Parameter option: A service key option for an extension/plugin.
     /// - Parameter invoker: A closure to execute service resolution.
+    ///     The primary responsibility of the invoker is to close over the values
+    ///     of any arguments passed in during the resolve call.
     ///
     /// - Returns: The resolved service type instance, or nil if no service is found.
     // swiftlint:disable:next identifier_name
     func _resolve<Service, Arguments>(
         name: String?,
         option: ServiceKeyOption?,
-        invoker: @escaping ((Arguments) -> Any) -> Any
+        invoker: @escaping (Resolver, (Arguments) -> Any) -> Any
     ) -> Service?
 }

--- a/Tests/SwinjectTests/ContainerTests.DebugHelper.swift
+++ b/Tests/SwinjectTests/ContainerTests.DebugHelper.swift
@@ -17,7 +17,7 @@ class ContainerTests_DebugHelper: XCTestCase {
     func testContainerShouldCallDebugHelperWithFailingServiceAndKey() {
         let container = Container(debugHelper: spy)
 
-        _ = container._resolve(name: "name") { (_: (Int) -> Any) in 1 as Double } as Double?
+        _ = container._resolve(name: "name") { (_: Resolver, _: (Int) -> Any) in 1 as Double } as Double?
 
         XCTAssertEqual("\(spy.serviceType)", "Double")
         XCTAssertEqual(spy.key, ServiceKey(

--- a/Tests/SwinjectTests/ContainerTests.swift
+++ b/Tests/SwinjectTests/ContainerTests.swift
@@ -90,6 +90,39 @@ class ContainerTests: XCTestCase {
         XCTAssertNil(weakCat)
     }
 
+    func testShadowedRegistration_owningContainerHierarchyAccess() {
+        let parent = Container()
+        let child = Container(parent: parent)
+
+        parent.register(Animal.self, factory: { _ in Dog()})
+        child.register(Animal.self, factory: { _ in Cat()})
+
+        // Parent registration should not be able to see into any child registrations
+        parent.register(Animal.self, name: "Spot", factory: { resolver in
+            resolver.resolve(Animal.self)!
+        })
+
+        XCTAssert(child.resolve(Animal.self, name: "Spot") is Dog)
+        XCTAssert(parent.resolve(Animal.self, name: "Spot") is Dog)
+    }
+
+    func testShadowedRegistration_owningContainerHierarchyAccess_inObjectScopeContainer() {
+        let parent = Container()
+        let child = Container(parent: parent)
+
+        parent.register(Animal.self, factory: { _ in Dog()})
+        child.register(Animal.self, factory: { _ in Cat()})
+
+        // Parent registration should not be able to see into any child registrations
+        parent.register(Animal.self, name: "Spot", factory: { resolver in
+            resolver.resolve(Animal.self)!
+        })
+        .inObjectScope(.container)
+
+        XCTAssert(child.resolve(Animal.self, name: "Spot") is Dog)
+        XCTAssert(parent.resolve(Animal.self, name: "Spot") is Dog)
+    }
+
     #if !SWIFT_PACKAGE
     func testContainerDoesNotTerminateGraphPrematurely() {
         let parent = Container()


### PR DESCRIPTION
There is a potential bug with resolution when using parent-child containers and shadowed registrations. This fix ensures that when performing resolution that a parent container can never have access to registrations in a child container. Previously, the container that received the `resolve()` call was captured and used for later factory invocations, and if that receiver was a child that also had a shadowed registration of the parent then the bug could emerge.

This implements the same change as https://github.com/Swinject/Swinject/pull/567 but does not retain an option to use the old behavior. Instead, we are considering the old Swinject behavior to be a bug, and are directly fixing for Knit.