### PR TITLE
Break CommentCommands into a separate documentation file and update

### DIFF
--- a/Docs/CommentCommands.md
+++ b/Docs/CommentCommands.md
@@ -1,0 +1,47 @@
+# Knit Comment Commmands
+
+Knit is designed to consume the Swinject syntax in your Assembly file. However there are some important aspects of
+a registration that are not represented in the Swinject syntax. `@knit` comment commands allow you to configure
+your registrations with that additional information.
+
+This is accomplished by adding a comment directly above the registration starting with `// @knit` and then
+followed with the configuration command.
+
+Commands can be applied at either the Assembly level or the registration level. Options set at the registration level will override any from the Assembly.
+
+### Registration Visibility
+
+Knit can change the visibility of the generated type-safe accessors.
+The following commands are available:
+
+* `public`: Make the type safe function(s) public (default is internal). Defines the public API exposed from the DI graph for an assembly.
+* `internal`: Make the type safe function(s) internal. This is a useful override when the assembly is set to `public`.
+* `hidden`: Do not generate any type safe function. This is useful when for implementations where the public API is already defined.
+* `ignore`: Completely ignore this assembly or registration. Primarily for cases that are not supported by the Knit parser.
+
+#### Example:
+
+Make the generated type-safe accessor `public`:
+``` swift
+// @knit public
+container.register(MyType.self, factory: { /*...*/ })
+```
+
+#### Type Safe Generation Style
+
+* `getter-named`: Generate a named accessor function. Knit will provide an automatic name based from the type. (This is the default behavior.)
+* `getter-named("myCustomName")`: Generate a named accessor function with a custom name where the default name is not appropriate. Provide the custom name as an argument to the command.
+* `getter-callAsFunction`: Generate `callAsFunction` accessor.
+* Both commands can be included to specify that both accessors should be generated. `// @knit getter-named getter-callAsFunction`
+
+### SPI
+
+If a registration is using a type that is protected by a swift System Programming Interface (SPI) then the generated resolver can be generated with the same SPI protection `// @knit @_spi(Testing)`.
+
+### ModuleName
+
+Knit makes some assumptions during code generation about the name of the module which can be controlled via the `--module-name-regex` flag provided to the gen command. Alternatively `// @knit module-name("MyModule")` can be used to override the default.
+
+### DisablePerformanceGen
+
+`// @knit disable-performance-gen` disables the generation of the `_assemblyFlags` and `_autoInstantiate` functions which are important for large projects to cut down on the number of `as` and `is` calls.

--- a/README.md
+++ b/README.md
@@ -12,30 +12,11 @@ your registrations with that additional information.
 This is accomplished by adding a comment directly above the registration starting with `// @knit` and then
 followed with the configuration command.
 
-Commands can be applied at either the Assembly level or the registration level. Options set at the registration level will override any from the Assembly.
-
-### Registration Visibility
-
-Knit can change the visibility of the generated type-safe accessors.
-The following commands are available:
-
-* `public`: Make the type safe function(s) public (default is internal).
-* `internal`: Make the type safe function(s) internal. This is a useful override when the assembly is set to `public`.
-* `hidden`: Do not generate any type safe function.
-* `ignore`: Completely ignore this assembly or registration
-
-#### Examples:
-
-Make the generated type-safe accessor `public`:
-``` swift
-// @knit public
-container.register(MyType.self, factory: { /*...*/ })
-```
+See the [Comment Commands](Docs/CommentCommands.md) documentation for a list of commands.
 
 ### Type Safe Getters
 
-One of the core capabilities of Knit is to generate type safe getters/accessors for your registrations.
-There are some additional options to control and configure this behavior.
+One of the core capabilities of Knit is to generate type safe getters/accessors for your registrations. Each registration inside an assembly will be parsed and a type safe function will be added to a generated Resolver extension.
 
 #### Call as Function Getter
 
@@ -55,11 +36,7 @@ In both situations the method call is type-safe.
 
 #### Commands
 
-The following commands are available:
-* `getter-named`: Generate a named accessor function. Knit will provide an automatic name based from the type.
-* `getter-named("myCustomName")`: Generate a named accessor function with a custom name. Provide the custom name as an argument to the command.
-* `getter-callAsFunction`: Generate `callAsFunction` accessor.
-* Both commands can be included to specify that both accessors should be generated. `// @knit getter-named getter-callAsFunction`
+See the [Type Safety Comment Commands](Docs/CommentCommands.md#Type-Safe-Generation-Style) documentation for examples
 
 #### Default Setting
 


### PR DESCRIPTION
It seemed like there were enough knit comment options for it to live in a separate doc.