### PR TITLE
Only allow for synchronized containers when using Knit

### DIFF
--- a/Sources/Knit/Module/ModuleAssembler.swift
+++ b/Sources/Knit/Module/ModuleAssembler.swift
@@ -12,7 +12,7 @@ public final class ModuleAssembler {
     let serviceCollector: ServiceCollector
 
     /// The resolver for this ModuleAssemblers container
-    public let resolver: Resolver
+    public var resolver: Resolver { _container }
 
     // Module types that were registered into the container owned by this ModuleAssembler
     var registeredModules: [any ModuleAssembly.Type] {
@@ -115,9 +115,6 @@ public final class ModuleAssembler {
         }
 
         abstractRegistrations.reset()
-
-        // https://github.com/Swinject/Swinject/blob/master/Documentation/ThreadSafety.md
-        self.resolver = _container.synchronize()
     }
 
     func isRegistered<T: ModuleAssembly>(_ type: T.Type) -> Bool {

--- a/Sources/Swinject/Container.TypeForwarding.swift
+++ b/Sources/Swinject/Container.TypeForwarding.swift
@@ -25,7 +25,7 @@ extension Container {
             name: name,
             option: nil
         )
-        syncIfEnabled {
+        sync {
             services[key] = service
             behaviors.forEach { $0.container(self, didRegisterType: type, toService: service, withName: name) }
         }

--- a/Tests/SwinjectTests/ContainerTests.Speed.swift
+++ b/Tests/SwinjectTests/ContainerTests.Speed.swift
@@ -31,8 +31,6 @@ class ContainerSpeedTests: XCTestCase {
     }    
 
     func testContainerSyncResolvesByArguments() {
-        container = container.synchronize() as? Container
-
         let measureOptions = XCTMeasureOptions()
         measureOptions.iterationCount = 1
 


### PR DESCRIPTION
All containers will now be synchronized with a lock. This also gets rid of the behavior of having a secondary “view” container that is synchronized while the container that holds all the registrations is unsynchronized.