### PR TITLE
Fix error messages for comment commands

### DIFF
--- a/Sources/KnitCodeGen/FunctionCallRegistrationParsing.swift
+++ b/Sources/KnitCodeGen/FunctionCallRegistrationParsing.swift
@@ -113,7 +113,7 @@ extension FunctionCallExprSyntax {
                 registrationArguments: registrationArguments,
                 leadingTrivia: leadingTrivia,
                 functionName: .implements,
-                syntax: implementsCalledMethod.arguments
+                syntax: implementsCalledMethod.calledExpression.period
             ) {
                 if forwardedRegistration.hasRedundantGetter {
                     throw RegistrationParsingError.redundantGetter(
@@ -397,6 +397,17 @@ enum RegistrationParsingError: LocalizedError, SyntaxError {
             let .redundantGetter(syntax),
             let .redundantAccessControl(syntax):
             return syntax
+        }
+    }
+
+    var positionAboveNode: Bool {
+        switch self {
+        case .redundantGetter,
+                .redundantAccessControl:
+            // These cases are errors regarding the comment command in the trivia above the syntax
+            return true
+        default:
+            return false
         }
     }
 

--- a/Sources/KnitCodeGen/SyntaxError.swift
+++ b/Sources/KnitCodeGen/SyntaxError.swift
@@ -6,6 +6,9 @@ import Foundation
 import SwiftSyntax
 
 // An error that is related to a piece of syntax
-protocol SyntaxError {
+protocol SyntaxError: Error {
     var syntax: SyntaxProtocol { get }
+
+    /// Report the error position on the line above the syntax node.
+    var positionAboveNode: Bool { get }
 }


### PR DESCRIPTION
They should be attached to the trivia line above the syntax node.