### PR TITLE
Add custom directive to be consumed by external scripts

### DIFF
--- a/Docs/CommentCommands.md
+++ b/Docs/CommentCommands.md
@@ -42,3 +42,7 @@ Knit makes some assumptions during code generation about the name of the module 
 ### DisablePerformanceGen
 
 `// @knit disable-performance-gen` disables the generation of the `_assemblyFlags` and `_autoInstantiate` functions which are important for large projects to cut down on the number of `as` and `is` calls.
+
+### Custom Tags
+
+`// @knit tag("Foo")` can be used to add a command that is not used directly inside of knit but can be used by external scripts which are performing logic based on the JSON output of the knit parser.

--- a/Sources/KnitCodeGen/FunctionCallRegistrationParsing.swift
+++ b/Sources/KnitCodeGen/FunctionCallRegistrationParsing.swift
@@ -194,6 +194,7 @@ private func makeRegistrationFor(
         accessLevel: directives.accessLevel ?? defaultDirectives.accessLevel ?? .default,
         arguments: registrationArguments,
         concurrencyModifier: concurrencyModifier,
+        customTags: directives.custom,
         getterAlias: directives.getterAlias,
         functionName: functionName,
         spi: directives.spi ?? defaultDirectives.spi

--- a/Sources/KnitCodeGen/Registration.swift
+++ b/Sources/KnitCodeGen/Registration.swift
@@ -15,6 +15,8 @@ public struct Registration: Equatable, Codable, Sendable {
 
     public let concurrencyModifier: String?
 
+    public let customTags: [String]
+
     /// Argument types required to resolve the registration
     public var arguments: [Argument]
 
@@ -45,6 +47,7 @@ public struct Registration: Equatable, Codable, Sendable {
         accessLevel: AccessLevel = .internal,
         arguments: [Argument] = [],
         concurrencyModifier: String? = nil,
+        customTags: [String] = [],
         getterAlias: String? = nil,
         functionName: FunctionName = .register,
         ifConfigCondition: ExprSyntax? = nil,
@@ -54,6 +57,7 @@ public struct Registration: Equatable, Codable, Sendable {
         self.name = name
         self.accessLevel = accessLevel
         self.concurrencyModifier = concurrencyModifier
+        self.customTags = customTags
         self.arguments = arguments
         self.getterAlias = getterAlias
         self.functionName = functionName
@@ -68,7 +72,7 @@ public struct Registration: Equatable, Codable, Sendable {
 
     private enum CodingKeys: String, CodingKey {
         // ifConfigCondition is not encoded since ExprSyntax does not conform to codable
-        case service, name, accessLevel, arguments, getterAlias, functionName, concurrencyModifier, spi
+        case service, name, accessLevel, arguments, getterAlias, functionName, concurrencyModifier, spi, customTags
         case ifConfigString = "ifConfig"
     }
 

--- a/Tests/KnitCodeGenTests/KnitDirectivesTests.swift
+++ b/Tests/KnitCodeGenTests/KnitDirectivesTests.swift
@@ -108,6 +108,13 @@ final class KnitDirectivesTests: XCTestCase {
         )
     }
 
+    func testCustom() {
+        XCTAssertEqual(
+            try parse("// @knit tag(\"Foo\") tag(\"Bar\")"),
+            .init(custom: ["Foo", "Bar"])
+        )
+    }
+
     private func parse(_ comment: String) throws -> KnitDirectives {
         let trivia = Trivia(pieces: [.lineComment(comment)])
         return try KnitDirectives.parse(leadingTrivia: trivia)

--- a/Tests/KnitCodeGenTests/RegistrationEncodingTests.swift
+++ b/Tests/KnitCodeGenTests/RegistrationEncodingTests.swift
@@ -13,6 +13,7 @@ final class RegistrationEncodingTests: XCTestCase {
         accessLevel: .public,
         arguments: [.init(identifier: "ABC", type: "Int")],
         concurrencyModifier: "MainActor",
+        customTags: ["tag1", "tag2"],
         getterAlias: "alias",
         functionName: .register,
         ifConfigCondition: ExprSyntax("SOME_FLAG"),
@@ -39,6 +40,10 @@ final class RegistrationEncodingTests: XCTestCase {
             }
           ],
           "concurrencyModifier" : "MainActor",
+          "customTags" : [
+            "tag1",
+            "tag2"
+          ],
           "functionName" : "register",
           "getterAlias" : "alias",
           "ifConfig" : "SOME_FLAG",

--- a/Tests/KnitCodeGenTests/RegistrationParsingTests.swift
+++ b/Tests/KnitCodeGenTests/RegistrationParsingTests.swift
@@ -611,6 +611,18 @@ final class RegistrationParsingTests: XCTestCase {
         )
     }
 
+    func testCustomTags() throws {
+        try assertMultipleRegistrationsString(
+            """
+            // @knit @tag("Foo")
+            container.registerAbstract(MyType.self)
+            """,
+            registrations: [
+                Registration(service: "MyType", customTags: ["Foo"], functionName: .registerAbstract),
+            ]
+        )
+    }
+
     func testIncorrectRegistrations() throws {
         try assertNoRegistrationsString("container.someOtherMethod(AType.self)", message: "Incorrect method name")
         try assertNoRegistrationsString("container.register(A)", message: "First param is not a metatype")


### PR DESCRIPTION
This adds a `// @knit custom("...")` directive which knit simply passes through into the JSON output. This allows external apps to define custom tags that can be consumed by scripts.
The current planned usage is to have something like `// @knit custom("skip_validation")` which will be consumed by an external validate command to provide an escape hatch for edge cases.

I'm not particularly wedded to the name `custom` so if anyone has a suggestion please let me know.