### PR TITLE
Remove getter-callAsFunction directive

### DIFF
--- a/Docs/CommentCommands.md
+++ b/Docs/CommentCommands.md
@@ -27,12 +27,9 @@ Make the generated type-safe accessor `public`:
 container.register(MyType.self, factory: { /*...*/ })
 ```
 
-#### Type Safe Generation Style
+#### Getter Named
 
-* `getter-named`: Generate a named accessor function. Knit will provide an automatic name based from the type. (This is the default behavior.)
 * `getter-named("myCustomName")`: Generate a named accessor function with a custom name where the default name is not appropriate. Provide the custom name as an argument to the command.
-* `getter-callAsFunction`: Generate `callAsFunction` accessor.
-* Both commands can be included to specify that both accessors should be generated. `// @knit getter-named getter-callAsFunction`
 
 ### SPI
 

--- a/Sources/KnitCodeGen/FunctionCallRegistrationParsing.swift
+++ b/Sources/KnitCodeGen/FunctionCallRegistrationParsing.swift
@@ -182,12 +182,6 @@ private func makeRegistrationFor(
     let name = try getName(arguments: arguments)
     let directives = try KnitDirectives.parse(leadingTrivia: leadingTrivia)
 
-    var getterConfig: Set<GetterConfig> = GetterConfig.default
-    if !directives.getterConfig.isEmpty {
-        getterConfig = directives.getterConfig
-    } else if !defaultDirectives.getterConfig.isEmpty {
-        getterConfig = defaultDirectives.getterConfig
-    }
     if let accessLevel = directives.accessLevel {
         if defaultDirectives.accessLevel == accessLevel || (defaultDirectives.accessLevel == nil && accessLevel == .default) {
             throw RegistrationParsingError.redundantAccessControl(syntax: syntax)
@@ -200,7 +194,7 @@ private func makeRegistrationFor(
         accessLevel: directives.accessLevel ?? defaultDirectives.accessLevel ?? .default,
         arguments: registrationArguments,
         concurrencyModifier: concurrencyModifier,
-        getterConfig: getterConfig,
+        getterAlias: directives.getterAlias,
         functionName: functionName,
         spi: directives.spi ?? defaultDirectives.spi
     )

--- a/Sources/KnitCodeGen/Registration.swift
+++ b/Sources/KnitCodeGen/Registration.swift
@@ -18,8 +18,8 @@ public struct Registration: Equatable, Codable, Sendable {
     /// Argument types required to resolve the registration
     public var arguments: [Argument]
 
-    /// This registration's getter setting.
-    public var getterConfig: Set<GetterConfig>
+    /// This alias for the registration's getter.
+    public var getterAlias: String?
 
     public var ifConfigCondition: ExprSyntax?
     
@@ -35,7 +35,7 @@ public struct Registration: Equatable, Codable, Sendable {
         accessLevel: AccessLevel = .internal,
         arguments: [Argument] = [],
         concurrencyModifier: String? = nil,
-        getterConfig: Set<GetterConfig> = GetterConfig.default,
+        getterAlias: String? = nil,
         functionName: FunctionName = .register,
         spi: String? = nil
     ) {
@@ -44,7 +44,7 @@ public struct Registration: Equatable, Codable, Sendable {
         self.accessLevel = accessLevel
         self.concurrencyModifier = concurrencyModifier
         self.arguments = arguments
-        self.getterConfig = getterConfig
+        self.getterAlias = getterAlias
         self.functionName = functionName
         self.spi = spi
     }
@@ -56,18 +56,14 @@ public struct Registration: Equatable, Codable, Sendable {
 
     private enum CodingKeys: CodingKey {
         // ifConfigCondition is not encoded since ExprSyntax does not conform to codable
-        case service, name, accessLevel, arguments, getterConfig, functionName, concurrencyModifier, spi
-    }
-
-    var namedGetterConfig: GetterConfig? {
-        getterConfig.first(where: { $0.isNamed })
+        case service, name, accessLevel, arguments, getterAlias, functionName, concurrencyModifier, spi
     }
 
     var hasRedundantGetter: Bool {
-        guard let namedGetterConfig, case let GetterConfig.identifiedGetter(name) = namedGetterConfig else {
+        guard let getterAlias else {
             return false
         }
-        return TypeNamer.computedIdentifierName(type: service) == name
+        return TypeNamer.computedIdentifierName(type: service) == getterAlias
     }
 
 }

--- a/Tests/KnitCodeGenTests/AssemblyParsingTests.swift
+++ b/Tests/KnitCodeGenTests/AssemblyParsingTests.swift
@@ -227,12 +227,12 @@ final class AssemblyParsingTests: XCTestCase {
 
     func testKnitDirectives() throws {
         let sourceFile: SourceFileSyntax = """
-            // @knit public getter-named
+            // @knit public
             class TestAssembly: ModuleAssembly {
                 typealias TargetResolver = TestResolver
                 func assemble(container: Container) {
                     container.register(A.self) { }
-                    // @knit internal getter-callAsFunction
+                    // @knit internal getter-named("bb")
                     container.register(B.self) { }
                 }
             }
@@ -242,8 +242,8 @@ final class AssemblyParsingTests: XCTestCase {
         XCTAssertEqual(
             config.registrations,
             [
-                .init(service: "A", accessLevel: .public, getterConfig: [.identifiedGetter(nil)]),
-                .init(service: "B", accessLevel: .internal, getterConfig: [.callAsFunction])
+                .init(service: "A", accessLevel: .public),
+                .init(service: "B", accessLevel: .internal, getterAlias: "bb")
             ]
         )
     }

--- a/Tests/KnitCodeGenTests/ConfigurationSetTests.swift
+++ b/Tests/KnitCodeGenTests/ConfigurationSetTests.swift
@@ -42,7 +42,7 @@ final class ConfigurationSetTests: XCTestCase {
             }
             /// Generated from ``Module2Assembly``
             extension Resolver {
-                public func callAsFunction(file: StaticString = #fileID, function: StaticString = #function, line: UInt = #line) -> Service2 {
+                public func service2(file: StaticString = #fileID, function: StaticString = #function, line: UInt = #line) -> Service2 {
                     knitUnwrap(resolve(Service2.self), callsiteFile: file, callsiteFunction: function, callsiteLine: line)
                 }
                 func argumentService(string: String, file: StaticString = #fileID, function: StaticString = #function, line: UInt = #line) -> ArgumentService {
@@ -424,7 +424,7 @@ private enum Factory {
         assemblyName: "Module2Assembly",
         moduleName: "Module2",
         registrations: [
-            .init(service: "Service2", accessLevel: .public, getterConfig: [.callAsFunction]),
+            .init(service: "Service2", accessLevel: .public),
             .init(service: "ArgumentService", accessLevel: .internal, arguments: [.init(type: "String")])
 
         ],

--- a/Tests/KnitCodeGenTests/KnitDirectivesTests.swift
+++ b/Tests/KnitCodeGenTests/KnitDirectivesTests.swift
@@ -11,29 +11,29 @@ final class KnitDirectivesTests: XCTestCase {
     func testAccessLevel() throws {
         XCTAssertEqual(
             try parse(" @knit public"),
-            .init(accessLevel: .public, getterConfig: [])
+            .init(accessLevel: .public)
         )
 
         XCTAssertEqual(
             try parse("@knit internal"),
-            .init(accessLevel: .internal, getterConfig: [])
+            .init(accessLevel: .internal)
         )
 
         XCTAssertEqual(
             try parse("@knit hidden"),
-            .init(accessLevel: .hidden, getterConfig: [])
+            .init(accessLevel: .hidden)
         )
 
         XCTAssertEqual(
             try parse("@knit ignore"),
-            .init(accessLevel: .ignore, getterConfig: [])
+            .init(accessLevel: .ignore)
         )
     }
 
     func testKnitPrefix() {
         XCTAssertEqual(
             try parse("// @knit public"),
-            .init(accessLevel: .public, getterConfig: [])
+            .init(accessLevel: .public)
         )
 
         XCTAssertEqual(
@@ -55,39 +55,19 @@ final class KnitDirectivesTests: XCTestCase {
     func testMultilLneComments() throws {
         XCTAssertEqual(
             try parse("// @knit public\n\n// another comment"),
-            .init(accessLevel: .public, getterConfig: [])
+            .init(accessLevel: .public)
         )
 
         XCTAssertEqual(
             try parse("// Comment\n// @knit public\n// another comment"),
-            .init(accessLevel: .public, getterConfig: [])
+            .init(accessLevel: .public)
         )
     }
 
-    func testGetterConfig() {
-        XCTAssertEqual(
-            try parse("// @knit getter-named"),
-            .init(accessLevel: nil, getterConfig: [.identifiedGetter(nil)])
-        )
-
+    func testGetterAlias() {
         XCTAssertEqual(
             try parse("// @knit getter-named(\"customName\")"),
-            .init(accessLevel: nil, getterConfig: [.identifiedGetter("customName")])
-        )
-
-        XCTAssertEqual(
-            try parse("// @knit getter-callAsFunction"),
-            .init(accessLevel: nil, getterConfig: [.callAsFunction])
-        )
-
-        XCTAssertEqual(
-            try parse("// @knit getter-callAsFunction getter-named"),
-            .init(accessLevel: nil, getterConfig: [.identifiedGetter(nil), .callAsFunction])
-        )
-
-        XCTAssertEqual(
-            try parse("// @knit getter-callAsFunction getter-named"),
-            .init(accessLevel: nil, getterConfig: [.identifiedGetter(nil), .callAsFunction])
+            .init(accessLevel: nil, getterAlias: "customName")
         )
     }
 
@@ -113,8 +93,8 @@ final class KnitDirectivesTests: XCTestCase {
         )
 
         XCTAssertEqual(
-            try parse("// @knit getter-callAsFunction module-name(\"A\")"),
-            .init(getterConfig: [.callAsFunction], moduleName: "A")
+            try parse("// @knit module-name(\"A\")"),
+            .init(moduleName: "A")
         )
 
         XCTAssertThrowsError(try parse("// @knit module-name"))

--- a/Tests/KnitCodeGenTests/RegistrationParsingTests.swift
+++ b/Tests/KnitCodeGenTests/RegistrationParsingTests.swift
@@ -90,31 +90,11 @@ final class RegistrationParsingTests: XCTestCase {
     func testGetterConfigRegistrations() throws {
         try assertMultipleRegistrationsString(
             """
-            // @knit public getter-named
+            // @knit public getter-named("alias")
             container.register(A.self) { }
             """,
             registrations: [
-                .init(service: "A", accessLevel: .public, getterConfig: [.identifiedGetter(nil)])
-            ]
-        )
-
-        try assertMultipleRegistrationsString(
-            """
-            // @knit public getter-callAsFunction
-            container.register(A.self) { }
-            """,
-            registrations: [
-                .init(service: "A", accessLevel: .public, getterConfig: [.callAsFunction])
-            ]
-        )
-
-        try assertMultipleRegistrationsString(
-            """
-            // @knit public getter-named getter-callAsFunction
-            container.register(A.self) { }
-            """,
-            registrations: [
-                .init(service: "A", accessLevel: .public, getterConfig: GetterConfig.both)
+                .init(service: "A", accessLevel: .public, getterAlias: "alias")
             ]
         )
     }
@@ -433,11 +413,11 @@ final class RegistrationParsingTests: XCTestCase {
 
         try assertMultipleRegistrationsString(
             """
-            // @knit getter-named
+            // @knit
             container.autoregister((String, Int?).self, initializer: Factory.make)
             """,
             registrations: [
-                .init(service: "(String, Int?)", getterConfig: [.identifiedGetter(nil)], functionName: .autoregister)
+                .init(service: "(String, Int?)", functionName: .autoregister)
             ]
         )
     }

--- a/Tests/KnitCodeGenTests/TypeSafetySourceFileTests.swift
+++ b/Tests/KnitCodeGenTests/TypeSafetySourceFileTests.swift
@@ -19,13 +19,13 @@ final class TypeSafetySourceFileTests: XCTestCase {
                     .init(service: "ServiceB", name: "name"),
                     .init(service: "ServiceB", name: "otherName"),
                     .init(service: "ServiceC", name: nil, accessLevel: .hidden), // No resolver is created
-                    .init(service: "ServiceD", name: nil, accessLevel: .public, getterConfig: GetterConfig.both, functionName: .implements),
+                    .init(service: "ServiceD", name: nil, accessLevel: .public, getterAlias: "serviceDAlias", functionName: .implements),
                     .init(service: "ServiceE", name: nil, accessLevel: .public, arguments: [
                         .init(type: "@escaping () -> Void"),
                         .init(type: "@escaping @Sendable (Bool) -> Void")
                     ]),
-                    .init(service: "ServiceF", name: nil, accessLevel: .public, getterConfig: [GetterConfig.identifiedGetter(nil)]),
-                    .init(service: "(String, Int?)", name: nil, accessLevel: .public, getterConfig: [GetterConfig.identifiedGetter(nil)]),
+                    .init(service: "ServiceF", name: nil, accessLevel: .public),
+                    .init(service: "(String, Int?)", name: nil, accessLevel: .public),
                 ],
                 targetResolver: "Resolve"
             )
@@ -37,10 +37,7 @@ final class TypeSafetySourceFileTests: XCTestCase {
             func serviceA(file: StaticString = #fileID, function: StaticString = #function, line: UInt = #line) -> ServiceA {
                 knitUnwrap(resolve(ServiceA.self), callsiteFile: file, callsiteFunction: function, callsiteLine: line)
             }
-            public func callAsFunction(file: StaticString = #fileID, function: StaticString = #function, line: UInt = #line) -> ServiceD {
-                knitUnwrap(resolve(ServiceD.self), callsiteFile: file, callsiteFunction: function, callsiteLine: line)
-            }
-            public func serviceD(file: StaticString = #fileID, function: StaticString = #function, line: UInt = #line) -> ServiceD {
+            public func serviceDAlias(file: StaticString = #fileID, function: StaticString = #function, line: UInt = #line) -> ServiceD {
                 knitUnwrap(resolve(ServiceD.self), callsiteFile: file, callsiteFunction: function, callsiteLine: line)
             }
             public func serviceE(closure1: @escaping () -> Void, closure2: @escaping @Sendable (Bool) -> Void, file: StaticString = #fileID, function: StaticString = #function, line: UInt = #line) -> ServiceE {
@@ -83,7 +80,7 @@ final class TypeSafetySourceFileTests: XCTestCase {
                 enumName: nil
             ).formatted().description,
             """
-            public func callAsFunction(string: String, url: URL, file: StaticString = #fileID, function: StaticString = #function, line: UInt = #line) -> A {
+            public func a(string: String, url: URL, file: StaticString = #fileID, function: StaticString = #function, line: UInt = #line) -> A {
                 knitUnwrap(resolve(A.self, arguments: string, url), callsiteFile: file, callsiteFunction: function, callsiteLine: line)
             }
             """
@@ -98,7 +95,7 @@ final class TypeSafetySourceFileTests: XCTestCase {
                 enumName: nil
             ).formatted().description,
             """
-            public func callAsFunction(string: String, file: StaticString = #fileID, function: StaticString = #function, line: UInt = #line) -> A {
+            public func a(string: String, file: StaticString = #fileID, function: StaticString = #function, line: UInt = #line) -> A {
                 knitUnwrap(resolve(A.self, argument: string), callsiteFile: file, callsiteFunction: function, callsiteLine: line)
             }
             """
@@ -113,7 +110,7 @@ final class TypeSafetySourceFileTests: XCTestCase {
                 enumName: nil
             ).formatted().description,
             """
-            public func callAsFunction(string1: String, string2: String, file: StaticString = #fileID, function: StaticString = #function, line: UInt = #line) -> A {
+            public func a(string1: String, string2: String, file: StaticString = #fileID, function: StaticString = #function, line: UInt = #line) -> A {
                 knitUnwrap(resolve(A.self, arguments: string1, string2), callsiteFile: file, callsiteFunction: function, callsiteLine: line)
             }
             """
@@ -128,7 +125,7 @@ final class TypeSafetySourceFileTests: XCTestCase {
                 enumName: "MyAssembly.A_ResolutionKey"
             ).formatted().description,
             """
-            public func callAsFunction(name: MyAssembly.A_ResolutionKey, string: String, file: StaticString = #fileID, function: StaticString = #function, line: UInt = #line) -> A {
+            public func a(name: MyAssembly.A_ResolutionKey, string: String, file: StaticString = #fileID, function: StaticString = #function, line: UInt = #line) -> A {
                 knitUnwrap(resolve(A.self, name: name.rawValue, argument: string), callsiteFile: file, callsiteFunction: function, callsiteLine: line)
             }
             """
@@ -143,7 +140,7 @@ final class TypeSafetySourceFileTests: XCTestCase {
                 enumName: nil
             ).formatted().description,
             """
-            public func callAsFunction(arg: String, file: StaticString = #fileID, function: StaticString = #function, line: UInt = #line) -> A {
+            public func a(arg: String, file: StaticString = #fileID, function: StaticString = #function, line: UInt = #line) -> A {
                 knitUnwrap(resolve(A.self, argument: arg), callsiteFile: file, callsiteFunction: function, callsiteLine: line)
             }
             """
@@ -160,7 +157,7 @@ final class TypeSafetySourceFileTests: XCTestCase {
             ).formatted().description,
             """
             #if SOME_FLAG
-            public func callAsFunction(file: StaticString = #fileID, function: StaticString = #function, line: UInt = #line) -> A {
+            public func a(file: StaticString = #fileID, function: StaticString = #function, line: UInt = #line) -> A {
                 knitUnwrap(resolve(A.self), callsiteFile: file, callsiteFunction: function, callsiteLine: line)
             }
             #endif
@@ -176,7 +173,7 @@ final class TypeSafetySourceFileTests: XCTestCase {
                 enumName: nil
             ).formatted().description,
             """
-            @_spi(Testing) public func callAsFunction(file: StaticString = #fileID, function: StaticString = #function, line: UInt = #line) -> A {
+            @_spi(Testing) public func a(file: StaticString = #fileID, function: StaticString = #function, line: UInt = #line) -> A {
                 knitUnwrap(resolve(A.self), callsiteFile: file, callsiteFunction: function, callsiteLine: line)
             }
             """


### PR DESCRIPTION
Nowhere is currently using the `getter-callAsFunction` directive and removing it simplifies the code and the documentation. I've left it called getter-named but it may change to getter-alias in the future.