### PR TITLE
Add support for macro conditions to named enums

### DIFF
--- a/Sources/KnitCodeGen/HeaderSourceFile.swift
+++ b/Sources/KnitCodeGen/HeaderSourceFile.swift
@@ -23,24 +23,11 @@ public enum HeaderSourceFile {
             leadingTrivia: TriviaProvider.headerTrivia,
             statementsBuilder:  {
                 for moduleImport in imports {
-                    importDecl(moduleImport: moduleImport)
+                    moduleImport.decl
+                        .maybeWithCondition(ifConfigCondition: moduleImport.ifConfigCondition)
                 }
             },
             trailingTrivia: trivia
         )
-    }
-
-    private static func importDecl(moduleImport: ModuleImport) -> DeclSyntaxProtocol {
-        // Wrap the output in an #if where needed
-        guard let ifConfigCondition = moduleImport.ifConfigCondition else {
-            return moduleImport.decl
-        }
-        let codeBlock = CodeBlockItemListSyntax([.init(item: .init(moduleImport.decl))])
-        let clause = IfConfigClauseSyntax(
-            poundKeyword: .poundIfToken(),
-            condition: ifConfigCondition,
-            elements: .statements(codeBlock)
-        )
-        return IfConfigDeclSyntax(clauses: [clause])
     }
 }

--- a/Sources/KnitCodeGen/NamedRegistrationGroup.swift
+++ b/Sources/KnitCodeGen/NamedRegistrationGroup.swift
@@ -3,6 +3,7 @@
 //
 
 import Foundation
+import SwiftSyntax
 
 /// Collection of named registrations for a single service.
 struct NamedRegistrationGroup {
@@ -17,6 +18,7 @@ struct NamedRegistrationGroup {
         return dict.map { key, value in
             return NamedRegistrationGroup(service: key, registrations: value)
         }
+        .sorted(by: { $0.service < $1.service})
     }
 
     var accessLevel: AccessLevel {
@@ -29,6 +31,16 @@ struct NamedRegistrationGroup {
     var enumName: String {
         let sanitizedType = TypeNamer.sanitizeType(type: service, keepGenerics: true)
         return "\(sanitizedType)_ResolutionKey"
+    }
+
+    // The if config condition wrapping the entire group
+    var ifConfigCondition: ExprSyntax? {
+        guard let firstCondition = registrations.first?.ifConfigCondition else {
+            return nil
+        }
+        // Only wrap the entire group if all conditions within the group match
+        let allMatch = registrations.allSatisfy { $0.ifConfigCondition?.description == firstCondition.description }
+        return allMatch ? firstCondition : nil
     }
 
 }

--- a/Sources/KnitCodeGen/SourceGen/NamedRegistrationGroup+SourceCode.swift
+++ b/Sources/KnitCodeGen/SourceGen/NamedRegistrationGroup+SourceCode.swift
@@ -1,0 +1,21 @@
+//
+// Copyright © Block, Inc. All rights reserved.
+//
+
+import Foundation
+import SwiftSyntax
+
+extension NamedRegistrationGroup {
+    // Generate the enum for this group of named registrations
+    func enumSourceCode(assemblyName: String) throws -> DeclSyntaxProtocol {
+        let modifier = accessLevel == .public ? "public " : ""
+        let enumSyntax = try EnumDeclSyntax("\(raw: modifier)enum \(raw: enumName): String, CaseIterable") {
+            for reg in registrations {
+                ("case \(raw: reg.name!)" as DeclSyntax).maybeWithCondition(
+                    ifConfigCondition: ifConfigCondition == nil ? reg.ifConfigCondition : nil
+                )
+            }
+        }
+        return enumSyntax.maybeWithCondition(ifConfigCondition: ifConfigCondition)
+    }
+}

--- a/Sources/KnitCodeGen/SwiftSyntax+Helpers.swift
+++ b/Sources/KnitCodeGen/SwiftSyntax+Helpers.swift
@@ -52,3 +52,20 @@ extension VariableDeclSyntax {
         )
     }
 }
+
+extension DeclSyntaxProtocol {
+
+    // Wrap the declaration in an #if where needed
+    func maybeWithCondition(ifConfigCondition: ExprSyntax?) -> DeclSyntaxProtocol {
+        guard let ifConfigCondition else {
+            return self
+        }
+        let codeBlock = CodeBlockItemListSyntax([.init(item: .init(self))])
+        let clause = IfConfigClauseSyntax(
+            poundKeyword: .poundIfToken(),
+            condition: ifConfigCondition,
+            elements: .statements(codeBlock)
+        )
+        return IfConfigDeclSyntax(clauses: [clause])
+    }
+}

--- a/Tests/KnitCodeGenTests/NamedRegistrationGroupSourceTests.swift
+++ b/Tests/KnitCodeGenTests/NamedRegistrationGroupSourceTests.swift
@@ -1,0 +1,49 @@
+//
+// Copyright © Block, Inc. All rights reserved.
+//
+
+@testable import KnitCodeGen
+import XCTest
+import SwiftSyntax
+
+final class NamedRegistrationGroupSourceTests: XCTestCase {
+
+    func testResolutionKeyWithInternalMacro() throws {
+        let registration1 = Registration(service: "ServiceB", name: "name", ifConfigCondition: ExprSyntax("DEBUG"))
+        let registration2 = Registration(service: "ServiceB", name: "name2")
+        let registration3 = Registration(service: "ServiceB", name: "name3", ifConfigCondition: ExprSyntax("DEBUG"))
+        let group = NamedRegistrationGroup.make(from: [registration1, registration2, registration3])[0]
+        let result = try group.enumSourceCode(assemblyName: "Assembly")
+
+        let expected = """
+        enum ServiceB_ResolutionKey: String, CaseIterable {
+            #if DEBUG
+            case name
+            #endif
+            case name2
+            #if DEBUG
+            case name3
+            #endif
+        }
+        """
+
+        XCTAssertEqual(expected, result.formatted().description)
+
+    }
+
+    func testResolutionKeyWithExternalMacro() throws {
+        let registration1 = Registration(service: "ServiceB", name: "name2", ifConfigCondition: ExprSyntax("DEBUG"))
+        let group = NamedRegistrationGroup.make(from: [registration1])[0]
+        let result = try group.enumSourceCode(assemblyName: "Assembly")
+
+        let expected = """
+        #if DEBUG
+        enum ServiceB_ResolutionKey: String, CaseIterable {
+            case name2
+        }
+        #endif
+        """
+
+        XCTAssertEqual(expected, result.formatted().description)
+    }
+}

--- a/Tests/KnitCodeGenTests/NamedRegistrationGroupTests.swift
+++ b/Tests/KnitCodeGenTests/NamedRegistrationGroupTests.swift
@@ -4,6 +4,7 @@
 
 @testable import KnitCodeGen
 import Foundation
+import SwiftSyntax
 import XCTest
 
 final class NamedRegistrationGroupTests: XCTestCase {
@@ -41,6 +42,21 @@ final class NamedRegistrationGroupTests: XCTestCase {
             namedGroup.enumName,
             "AnyProfileValueProvider_BalanceSnapshot_ResolutionKey"
         )
+    }
+
+    func testIfConfigCondition() throws {
+        let registration1 = Registration(service: "ServiceA", name: "name1", ifConfigCondition: ExprSyntax("DEBUG"))
+        let registration2 = Registration(service: "ServiceA", name: "name2")
+        let registration3 = Registration(service: "ServiceA", name: "name3", ifConfigCondition: ExprSyntax("RELEASE"))
+
+        let namedGroup1 = NamedRegistrationGroup.make(from: [registration1])[0]
+        XCTAssertEqual(namedGroup1.ifConfigCondition?.description, ExprSyntax("DEBUG").description)
+
+        let namedGroup2 = NamedRegistrationGroup.make(from: [registration1, registration2])[0]
+        XCTAssertNil(namedGroup2.ifConfigCondition)
+
+        let namedGroup3 = NamedRegistrationGroup.make(from: [registration1, registration3])[0]
+        XCTAssertNil(namedGroup3.ifConfigCondition)
     }
 
 }


### PR DESCRIPTION
* If a group of named registrations all have the same `#if` condition then the resolver and the enum are both wrapped in the same condition.
* If registrations in the group have different `#if` conditions, the resolver will not have a condition and the enum cases will be wrapped in `#if` conditions from the individual registrations.