### PR TITLE
Apply custom tags at the assembly level to all registrations

### DIFF
--- a/Sources/KnitCodeGen/FunctionCallRegistrationParsing.swift
+++ b/Sources/KnitCodeGen/FunctionCallRegistrationParsing.swift
@@ -194,7 +194,7 @@ private func makeRegistrationFor(
         accessLevel: directives.accessLevel ?? defaultDirectives.accessLevel ?? .default,
         arguments: registrationArguments,
         concurrencyModifier: concurrencyModifier,
-        customTags: directives.custom,
+        customTags: defaultDirectives.custom + directives.custom,
         getterAlias: directives.getterAlias,
         functionName: functionName,
         spi: directives.spi ?? defaultDirectives.spi

--- a/Tests/KnitCodeGenTests/AssemblyParsingTests.swift
+++ b/Tests/KnitCodeGenTests/AssemblyParsingTests.swift
@@ -983,6 +983,23 @@ final class AssemblyParsingTests: XCTestCase {
         })
     }
 
+    func testCustomAssemblyTags() throws {
+        let sourceFile: SourceFileSyntax = """
+            // @knit tag("shared")
+            class FooAssembly: ModuleAssembly {
+                typealias TargetResolver = Resolver
+                func assemble(container: Container) {
+                    // @knit tag("single")
+                    container.register(A.self) { }
+                }
+            }
+            """
+
+        let config = try assertParsesSyntaxTree(sourceFile)
+        XCTAssertEqual(config.registrations.count, 1)
+        XCTAssertEqual(config.registrations[0].customTags, ["shared", "single"] )
+    }
+
 }
 
 private func assertParsesSyntaxTree(


### PR DESCRIPTION
I didn't think about this during the initial implementation, but when I went to add tags this didn't work how I expected.