### PR TITLE
Create KnitTesting module to prevent generating assertResolve functions

### DIFF
--- a/Example/KnitExample.xcodeproj/project.pbxproj
+++ b/Example/KnitExample.xcodeproj/project.pbxproj
@@ -15,6 +15,7 @@
 		C43334FA2A3FDD44003BA9E3 /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = C43334F92A3FDD44003BA9E3 /* Preview Assets.xcassets */; };
 		C43335062A3FDDD3003BA9E3 /* KnitExampleAssembly.swift in Sources */ = {isa = PBXBuildFile; fileRef = C43335052A3FDDD3003BA9E3 /* KnitExampleAssembly.swift */; };
 		C44755192A3FEA740072333A /* TestModuleAssembler.swift in Sources */ = {isa = PBXBuildFile; fileRef = C44755182A3FEA740072333A /* TestModuleAssembler.swift */; };
+		C4DB9D212D6FE9B300EC01A6 /* KnitTesting in Frameworks */ = {isa = PBXBuildFile; productRef = C4DB9D202D6FE9B300EC01A6 /* KnitTesting */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -53,6 +54,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				C4DB9D212D6FE9B300EC01A6 /* KnitTesting in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -155,6 +157,7 @@
 			);
 			name = KnitExampleTests;
 			packageProductDependencies = (
+				C4DB9D202D6FE9B300EC01A6 /* KnitTesting */,
 			);
 			productName = KnitExampleTests;
 			productReference = C447550D2A3FEA120072333A /* KnitExampleTests.xctest */;
@@ -526,6 +529,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 2CF2570C2CACB3300017B59A /* XCLocalSwiftPackageReference "../../knit" */;
 			productName = "plugin:KnitBuildPlugin";
+		};
+		C4DB9D202D6FE9B300EC01A6 /* KnitTesting */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 2CF2570C2CACB3300017B59A /* XCLocalSwiftPackageReference "../../knit" */;
+			productName = KnitTesting;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/Package.swift
+++ b/Package.swift
@@ -13,6 +13,7 @@ let package = Package(
     products: [
         .library(name: "Knit", targets: ["Knit"]),
         .library(name: "KnitMacros", targets: ["KnitMacros"] ),
+        .library(name: "KnitTesting", targets: ["KnitTesting"]),
         .plugin(name: "KnitBuildPlugin", targets: ["KnitBuildPlugin"]),
         .executable(name: "knit-cli", targets: ["knit-cli"]),
     ],
@@ -40,6 +41,13 @@ let package = Package(
             capability: .buildTool,
             dependencies: [
                 .target(name: "knit-cli"),
+            ]
+        ),
+        .target(
+            name: "KnitTesting",
+            dependencies: [
+                .target(name: "Swinject"),
+                .target(name: "Knit"),
             ]
         ),
 

--- a/Sources/KnitCodeGen/ConfigurationSet.swift
+++ b/Sources/KnitCodeGen/ConfigurationSet.swift
@@ -69,21 +69,12 @@ public extension ConfigurationSet {
         return Self.join(sourceFiles: sourceFiles)
     }
 
-    func makeUnitTestSourceFile(includeExtensions: Bool = true) throws -> String {
+    func makeUnitTestSourceFile() throws -> String {
         let header = HeaderSourceFile.make(imports: unitTestImports().sorted, comment: nil)
         var body = try assemblies
             .map { try $0.makeUnitTestSourceFile() }
         body.append(contentsOf: try makeAdditionalTestsSources())
-        let allRegistrations = allAssemblies.flatMap { $0.registrations }
-        let allRegistrationsIntoCollections = allAssemblies.flatMap { $0.registrationsIntoCollections }
-        var sourceFiles = [header] + body
-        if includeExtensions {
-            let resolverExtensions = try UnitTestSourceFile.resolverExtensions(
-                registrations: allRegistrations,
-                registrationsIntoCollections: allRegistrationsIntoCollections
-            )
-            sourceFiles.append(resolverExtensions)
-        }
+        let sourceFiles = [header] + body
 
         return Self.join(sourceFiles: sourceFiles)
     }
@@ -124,6 +115,7 @@ public extension ConfigurationSet {
     func unitTestImports() -> ModuleImportSet {
         var imports = ModuleImportSet(imports: allAssemblies.flatMap { $0.imports })
         imports.insert(ModuleImport.testable(name: primaryAssembly.moduleName))
+        imports.insert(.named("KnitTesting"))
         imports.insert(.named("XCTest"))
 
         let additionalImports = externalTestingAssemblies

--- a/Sources/KnitTesting/Resolver+Asserts.swift
+++ b/Sources/KnitTesting/Resolver+Asserts.swift
@@ -1,0 +1,66 @@
+//
+// Copyright © Block, Inc. All rights reserved.
+//
+
+import Knit
+import Swinject
+import XCTest
+
+public extension Resolver {
+
+    func assertTypeResolved<T>(
+        _ result: T?,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        XCTAssertNotNil(
+            result,
+            """
+            The container did not resolve the type: \(T.self). Check that this type is registered correctly.
+            Dependency Graph:
+            \(_dependencyTree())
+            """,
+            file: file,
+            line: line
+        )
+    }
+
+    func assertTypeResolves<T>(
+        _ type: T.Type,
+        name: String? = nil,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        XCTAssertNotNil(
+            resolve(type, name: name),
+            """
+            The container did not resolve the type: \(type). Check that this type is registered correctly.
+            Dependency Graph:
+            \(_dependencyTree())
+            """,
+            file: file,
+            line: line
+        )
+    }
+
+    @MainActor
+    func assertCollectionResolves<T>(
+        _ type: T.Type,
+        count expectedCount: Int,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        let actualCount = resolveCollection(type).entries.count
+        XCTAssert(
+            actualCount >= expectedCount,
+            """
+            The resolved ServiceCollection<\(type)> did not contain the expected number of services \
+            (resolved \(actualCount), expected \(expectedCount)).
+            Make sure your assembler contains a ServiceCollector behavior.
+            """,
+            file: file,
+            line: line
+        )
+    }
+
+}

--- a/Tests/KnitCodeGenTests/ConfigurationSetTests.swift
+++ b/Tests/KnitCodeGenTests/ConfigurationSetTests.swift
@@ -87,6 +87,7 @@ final class ConfigurationSetTests: XCTestCase {
             [
                 "import Dependency1",
                 "import Dependency2",
+                "import KnitTesting",
                 "@testable import Module1",
                 "import XCTest",
             ]
@@ -100,6 +101,7 @@ final class ConfigurationSetTests: XCTestCase {
 
             import Dependency1
             import Dependency2
+            import KnitTesting
             @testable import Module1
             import XCTest
             final class Module1RegistrationTests: XCTestCase {
@@ -129,60 +131,6 @@ final class ConfigurationSetTests: XCTestCase {
             }
             struct Module2RegistrationTestArguments {
                 let argumentServiceString: String
-            }
-            private extension Resolver {
-                func assertTypeResolves<T>(
-                    _ type: T.Type,
-                    name: String? = nil,
-                    file: StaticString = #filePath,
-                    line: UInt = #line
-                ) {
-                    XCTAssertNotNil(
-                        resolve(type, name: name),
-                        """
-                        The container did not resolve the type: \(type). Check that this type is registered correctly.
-                        Dependency Graph:
-                        \(_dependencyTree())
-                        """,
-                        file: file,
-                        line: line
-                    )
-                }
-                func assertTypeResolved<T>(
-                    _ result: T?,
-                    file: StaticString = #filePath,
-                    line: UInt = #line
-                ) {
-                    XCTAssertNotNil(
-                        result,
-                        """
-                        The container did not resolve the type: \(T.self). Check that this type is registered correctly.
-                        Dependency Graph:
-                        \(_dependencyTree())
-                        """,
-                        file: file,
-                        line: line
-                    )
-                }
-                @MainActor
-                func assertCollectionResolves<T>(
-                    _ type: T.Type,
-                    count expectedCount: Int,
-                    file: StaticString = #filePath,
-                    line: UInt = #line
-                ) {
-                    let actualCount = resolveCollection(type).entries.count
-                    XCTAssert(
-                        actualCount >= expectedCount,
-                        """
-                        The resolved ServiceCollection<\(type)> did not contain the expected number of services \
-                        (resolved \(actualCount), expected \(expectedCount)).
-                        Make sure your assembler contains a ServiceCollector behavior.
-                        """,
-                        file: file,
-                        line: line
-                    )
-                }
             }
             """#
         )
@@ -248,6 +196,7 @@ final class ConfigurationSetTests: XCTestCase {
             [
                 "import Dependency1",
                 "import Dependency2",
+                "import KnitTesting",
                 "@testable import Module1",
                 "import Module2",
                 "import XCTest",

--- a/Tests/KnitCodeGenTests/UnitTestSourceFileTests.swift
+++ b/Tests/KnitCodeGenTests/UnitTestSourceFileTests.swift
@@ -85,7 +85,8 @@ final class UnitTestSourceFileTests: XCTestCase {
         let expected = #"""
         // Generated using Knit
         // Do not edit directly!
-
+        
+        import KnitTesting
         @testable import My
         import XCTest
         final class MyRegistrationTests: XCTestCase {
@@ -123,7 +124,7 @@ final class UnitTestSourceFileTests: XCTestCase {
         }
         """#
 
-        XCTAssertEqual(try set.makeUnitTestSourceFile(includeExtensions: false), expected)
+        XCTAssertEqual(try set.makeUnitTestSourceFile(), expected)
     }
 
     func test_abstract_unit_tests() throws {
@@ -148,6 +149,7 @@ final class UnitTestSourceFileTests: XCTestCase {
         // Generated using Knit
         // Do not edit directly!
 
+        import KnitTesting
         @testable import Module
         import XCTest
         final class ModuleAbstractRegistrationTests: XCTestCase {
@@ -158,7 +160,7 @@ final class UnitTestSourceFileTests: XCTestCase {
             }
         }
         """#
-        XCTAssertEqual(try set.makeUnitTestSourceFile(includeExtensions: false), expected)
+        XCTAssertEqual(try set.makeUnitTestSourceFile(), expected)
 
     }
 


### PR DESCRIPTION
Rather than generating these functions in the modules that use them they move into the KnitTesting module and are imported.
I've updated the example app to use this as well as putting up a POC in cash-ios https://github.com/squareup/cash-ios/pull/60190