### PR TITLE
Rename `getter-named` command to `alias`

### DIFF
--- a/Docs/CommentCommands.md
+++ b/Docs/CommentCommands.md
@@ -27,9 +27,9 @@ Make the generated type-safe accessor `public`:
 container.register(MyType.self, factory: { /*...*/ })
 ```
 
-#### Getter Named
+#### Getter Alias
 
-* `getter-named("myCustomName")`: Generate a named accessor function with a custom name where the default name is not appropriate. Provide the custom name as an argument to the command.
+* `alias("myCustomName")`: Generate an additional accessor function with a custom alias when the default name is not ideal. Provide the custom name as an argument to the command.
 
 ### SPI
 

--- a/Example/KnitExample/KnitExampleAssembly.swift
+++ b/Example/KnitExample/KnitExampleAssembly.swift
@@ -17,7 +17,7 @@ final class KnitExampleAssembly: ModuleAssembly {
 
         container.autoregister(ExampleService.self, initializer: ExampleService.init)
 
-        // @knit getter-named("example")
+        // @knit alias("example")
         container.register(ExampleArgumentService.self) { (_, arg: String) in
             ExampleArgumentService.init(string: arg)
         }

--- a/Sources/KnitCodeGen/FunctionCallRegistrationParsing.swift
+++ b/Sources/KnitCodeGen/FunctionCallRegistrationParsing.swift
@@ -374,7 +374,7 @@ enum RegistrationParsingError: LocalizedError, SyntaxError {
         case .nonAbstract:
             return "AbstractAssemblys may only contain Abstract registrations"
         case .redundantGetter:
-            return "getter-named matches the default accessor name and can be removed"
+            return "alias matches the default accessor name and can be removed"
         case .redundantAccessControl:
             return "Access control matches the default and can be removed"
         }

--- a/Sources/KnitCodeGen/KnitDirectives.swift
+++ b/Sources/KnitCodeGen/KnitDirectives.swift
@@ -88,7 +88,7 @@ public struct KnitDirectives: Codable, Equatable, Sendable {
         if token == "disable-performance-gen" {
             return KnitDirectives(disablePerformanceGen: true)
         }
-        if let nameMatch = getterNamedRegex.firstMatch(in: token, range: NSMakeRange(0, token.count)) {
+        if let nameMatch = getterAliasRegex.firstMatch(in: token, range: NSMakeRange(0, token.count)) {
             if nameMatch.numberOfRanges >= 2, nameMatch.range(at: 1).location != NSNotFound {
                 var range = nameMatch.range(at: 1)
                 range = NSRange(location: range.location + 2, length: range.length - 4)
@@ -128,7 +128,7 @@ public struct KnitDirectives: Codable, Equatable, Sendable {
         return .init()
     }
 
-    private static let getterNamedRegex = try! NSRegularExpression(pattern: "getter-named(\\(\"\\w*\"\\))")
+    private static let getterAliasRegex = try! NSRegularExpression(pattern: "alias(\\(\"\\w*\"\\))")
     private static let moduleNameRegex = try! NSRegularExpression(pattern: "module-name(\\(\"\\w*\"\\))")
     private static let spiRegex = try! NSRegularExpression(pattern: "@_spi(\\(\\w*\\))")
     private static let tagRegex = try! NSRegularExpression(pattern: "tag(\\(\"\\w*\"\\))?")

--- a/Tests/KnitCodeGenTests/AssemblyParsingTests.swift
+++ b/Tests/KnitCodeGenTests/AssemblyParsingTests.swift
@@ -232,7 +232,7 @@ final class AssemblyParsingTests: XCTestCase {
                 typealias TargetResolver = TestResolver
                 func assemble(container: Container) {
                     container.register(A.self) { }
-                    // @knit internal getter-named("bb")
+                    // @knit internal alias("bb")
                     container.register(B.self) { }
                 }
             }
@@ -860,7 +860,7 @@ final class AssemblyParsingTests: XCTestCase {
                 typealias ReplacedAssembly = RealAssembly
 
                 func assemble(container: Container) {
-                    // @knit getter-named("a")
+                    // @knit alias("a")
                     container.register(A.self) { }
                 }
             }
@@ -967,7 +967,7 @@ final class AssemblyParsingTests: XCTestCase {
 
                 func assemble(container: Container) {
                     container.register(A.self) { }
-                        // @knit getter-named("b")
+                        // @knit alias("b")
                         .implements(B.self)
                 }
             }

--- a/Tests/KnitCodeGenTests/KnitDirectivesTests.swift
+++ b/Tests/KnitCodeGenTests/KnitDirectivesTests.swift
@@ -66,7 +66,7 @@ final class KnitDirectivesTests: XCTestCase {
 
     func testGetterAlias() {
         XCTAssertEqual(
-            try parse("// @knit getter-named(\"customName\")"),
+            try parse("// @knit alias(\"customName\")"),
             .init(accessLevel: nil, getterAlias: "customName")
         )
     }

--- a/Tests/KnitCodeGenTests/RegistrationParsingTests.swift
+++ b/Tests/KnitCodeGenTests/RegistrationParsingTests.swift
@@ -90,7 +90,7 @@ final class RegistrationParsingTests: XCTestCase {
     func testGetterConfigRegistrations() throws {
         try assertMultipleRegistrationsString(
             """
-            // @knit public getter-named("alias")
+            // @knit public alias("alias")
             container.register(A.self) { }
             """,
             registrations: [


### PR DESCRIPTION
Better describes the behavior of this feature.