### PR TITLE
Add @UseDefault property wrapper for Resolvable macro

### DIFF
--- a/Docs/Macros.md
+++ b/Docs/Macros.md
@@ -5,7 +5,10 @@
 `@Resolvable<ResolverType>` can be applied to any init or static function. It will generate a new static function which takes the resolver as a parameter and resolves all the original parameters and then passes the resolved dependencies into the original function.
 The generated code will use the Knit generated resolvers so it gets the same compile time safety as if the code was written manually.
 
-Parameters which resolve named registrations can use the `@Named("name")` property wrapper.
-Parameters which should be used as arguments instead can use the `@Argument` property wrapper. They will be added as parameters to the generated function.
-
 Examples of the macro output can be seen in the tests [ResolvableTests.swift](../Tests/KnitMacrosTests/ResolvableTests.swift)
+
+### Property Wrappers
+
+* `@Named("name")` - The parameter will be resolved from the DI graph using the given name.
+* `@Argument` - The parameter will not be resolved from the DI graph. An additional parameter will be added to the generated function.
+* `@UseDefault` - The parameter will not be resolved from the DI graph and will use the deafault value provided instead.

--- a/Sources/KnitMacros/MacroPropertyWrappers.swift
+++ b/Sources/KnitMacros/MacroPropertyWrappers.swift
@@ -23,3 +23,14 @@ public struct Argument<Value> {
         self.wrappedValue = wrappedValue
     }
 }
+
+/// Defines that the parameter should not be resolved from the DI graph but should use the default value provided
+/// The property wrapper is only used as a hint to the Resolvable macro and has no effect outside of the macro
+@propertyWrapper
+public struct UseDefault<Value> {
+    public var wrappedValue: Value
+
+    public init(wrappedValue: Value) {
+        self.wrappedValue = wrappedValue
+    }
+}

--- a/Tests/KnitMacrosTests/ResolvableTests.swift
+++ b/Tests/KnitMacrosTests/ResolvableTests.swift
@@ -57,6 +57,26 @@ final class ResolvableTests: XCTestCase {
         assertMacroExpansion(
             """
             @Resolvable<Resolver>
+            init(@UseDefault value: Int = 5) {}
+            """,
+            expandedSource: """
+            
+            init(@UseDefault value: Int = 5) {}
+
+            static func make(resolver: Resolver) -> Self {
+                 return .init(
+                     value: 5
+                 )
+            }
+            """,
+            macros: testMacros
+        )
+    }
+
+    func test_default_param_unused() throws {
+        assertMacroExpansion(
+            """
+            @Resolvable<Resolver>
             init(value: Int = 5) {}
             """,
             expandedSource: """
@@ -65,7 +85,7 @@ final class ResolvableTests: XCTestCase {
 
             static func make(resolver: Resolver) -> Self {
                  return .init(
-                     value: 5
+                     value: resolver.int()
                  )
             }
             """,

--- a/Tests/KnitMacrosTests/SwinjectResolutionTests.swift
+++ b/Tests/KnitMacrosTests/SwinjectResolutionTests.swift
@@ -73,7 +73,7 @@ private struct Service3 {
     let value: Int
     
     @Resolvable<Resolver>
-    init(defaultedValue: Int = 2) {
+    init(@UseDefault defaultedValue: Int = 2) {
         self.value = defaultedValue
     }
 }


### PR DESCRIPTION
I added this because I couldn't think of a way this would work in all cases. Take these 2 parameters as an example
```
logger: Logger? = nil,
notificationCenter: NotificationCenter = .default
```

In the case of the `logger` I probably want the DI graph to resolve the logger and the default is to make testing easier. 
In the case of `notificationCenter` I probably want to use the default in the real app and change it for testing.

`@UseDefault` removes this ambiguity. I originally thought about doing the inverse and explicitly disabling defaults but that means the developer error will show up at runtime while this way should cause a compile time error