### PR TITLE
Add support for optional parameters to the Resolvable macro

### DIFF
--- a/Docs/Macros.md
+++ b/Docs/Macros.md
@@ -12,3 +12,7 @@ Examples of the macro output can be seen in the tests [ResolvableTests.swift](..
 * `@Named("name")` - The parameter will be resolved from the DI graph using the given name.
 * `@Argument` - The parameter will not be resolved from the DI graph. An additional parameter will be added to the generated function.
 * `@UseDefault` - The parameter will not be resolved from the DI graph and will use the deafault value provided instead.
+
+### Optional parameters
+
+The `@Resolvable` macro uses the same naming system to access the knit generated fuctions. In that naming system optionals are not included in the name so an optional parameter will correctly access the non optional value from the DI graph while allowing an optional value for testing. It is also possible to register an optional type in the DI graph which will also work in this situation. 

--- a/Sources/KnitMacrosImplementations/ResolvableMacro.swift
+++ b/Sources/KnitMacrosImplementations/ResolvableMacro.swift
@@ -105,6 +105,8 @@ public struct ResolvableMacro: PeerMacro {
             return TypeInformation(name: baseType.name)
         } else if let type = typeSyntax.as(FunctionTypeSyntax.self) {
             return TypeInformation(name: "(\(type.description))")
+        } else if let type = typeSyntax.as(OptionalTypeSyntax.self) {
+            return TypeInformation(name: "\(type.wrappedType.description)?")
         }
         throw DiagnosticsError(
             diagnostics: [.init(node: typeSyntax, message:  Error.invalidParamType(typeSyntax.description))]

--- a/Tests/KnitMacrosTests/ResolvableTests.swift
+++ b/Tests/KnitMacrosTests/ResolvableTests.swift
@@ -32,7 +32,27 @@ final class ResolvableTests: XCTestCase {
             macros: testMacros
         )
     }
-    
+
+    func test_optional_parameter() throws {
+        assertMacroExpansion(
+            """
+            @Resolvable<Resolver>
+            init(arg1: String?) {}
+            """,
+            expandedSource: """
+            
+            init(arg1: String?) {}
+
+            static func make(resolver: Resolver) -> Self {
+                 return .init(
+                     arg1: resolver.string()
+                 )
+            }
+            """,
+            macros: testMacros
+        )
+    }
+
     func test_closure_param() throws {
         assertMacroExpansion(
             """


### PR DESCRIPTION
`@Resolvable` was failing on optional parameters. This adds support so they work as expected. `https://github.com/cashapp/knit/pull/254` clarifies how defaults work with optional values. 