### PR TITLE
Add support for generic types to the Resolvable macro

### DIFF
--- a/Sources/KnitMacrosImplementations/ResolvableMacro.swift
+++ b/Sources/KnitMacrosImplementations/ResolvableMacro.swift
@@ -99,7 +99,7 @@ public struct ResolvableMacro: PeerMacro {
 
     private static func extractType(typeSyntax: TypeSyntax) throws -> TypeInformation {
         if let type = typeSyntax.as(IdentifierTypeSyntax.self) {
-            return TypeInformation(name: type.name.text)
+            return TypeInformation(name: type.description)
         } else if let type = typeSyntax.as(AttributedTypeSyntax.self) {
             let baseType = try extractType(typeSyntax: type.baseType)
             return TypeInformation(name: baseType.name)

--- a/Tests/KnitMacrosTests/ResolvableTests.swift
+++ b/Tests/KnitMacrosTests/ResolvableTests.swift
@@ -204,4 +204,24 @@ final class ResolvableTests: XCTestCase {
             macros: testMacros
         )
     }
+
+    func test_publisher_type() throws {
+        assertMacroExpansion(
+            """
+            @Resolvable<Resolver>
+            init(profileValueProvider: AnyCurrentValuePublisher<GlobalAddress?, Never>) {}
+            """,
+            expandedSource: """
+            
+            init(profileValueProvider: AnyCurrentValuePublisher<GlobalAddress?, Never>) {}
+
+            static func make(resolver: Resolver) -> Self {
+                 return .init(
+                     profileValueProvider: resolver.globalAddressPublisher()
+                 )
+            }
+            """,
+            macros: testMacros
+        )
+    }
 }


### PR DESCRIPTION
`type.name.text` was only pulling out the base type and not the generic parameters which caused a mismatch when generating the name for the resolver call.