### PR TITLE
Add TypeNamer handling for multiple generics

### DIFF
--- a/Sources/KnitCodeGen/TypeNamer.swift
+++ b/Sources/KnitCodeGen/TypeNamer.swift
@@ -52,7 +52,7 @@ public enum TypeNamer {
                     with: .init(location: range.location + 1, length: range.length - 2)
                 )
                 if let mainGeneric = genericName.components(separatedBy: .init(charactersIn: ",")).first {
-                    type = mainGeneric + suffix
+                    type = sanitizeType(type: mainGeneric, keepGenerics: false) + suffix
                 } else {
                     type = mainType
                 }
@@ -77,7 +77,7 @@ public enum TypeNamer {
         return type
     }
 
-    private static let suffixedGenericTypes = ["Publisher", "Subject", "Provider"]
+    private static let suffixedGenericTypes = ["Publisher", "Subject", "Provider", "Set"]
 
     static func isClosure(type: String) -> Bool {
         return type.contains("->")

--- a/Tests/KnitCodeGenTests/TypeNamerTests.swift
+++ b/Tests/KnitCodeGenTests/TypeNamerTests.swift
@@ -149,6 +149,23 @@ final class TypeNamerTests: XCTestCase {
         )
     }
 
+    func testMultipleGenerics() {
+        assertComputedIdentifier(
+            type: "AnyPublisher<Set<AppletId>, Never>",
+            expectedIdentifier: "appletIdSetPublisher"
+        )
+
+        assertComputedIdentifier(
+            type: "Outer<Inner<Content>>",
+            expectedIdentifier: "outer"
+        )
+
+        assertComputedIdentifier(
+            type: "Set<Inner<Content>>",
+            expectedIdentifier: "innerSet"
+        )
+    }
+
 }
 
 private func assertComputedIdentifier(


### PR DESCRIPTION
Fixes some incorrect naming that became an issue due to always generating the non aliased resolver function.