### PR TITLE
Remove Autoregister support from Knit

### DIFF
--- a/Sources/KnitCodeGen/FunctionCallRegistrationParsing.swift
+++ b/Sources/KnitCodeGen/FunctionCallRegistrationParsing.swift
@@ -36,7 +36,7 @@ extension FunctionCallExprSyntax {
         let registrationIntoCollection = calledMethods
             .first { method in
                 let name = method.calledExpression.declName.baseName.text
-                return name == "registerIntoCollection" || name == "autoregisterIntoCollection"
+                return name == "registerIntoCollection"
             }
             .flatMap { method in
                 makeRegistrationIntoCollection(arguments: method.arguments)
@@ -225,36 +225,6 @@ private func getArguments(
     arguments: LabeledExprListSyntax,
     trailingClosure: ClosureExprSyntax?
 ) throws -> [Registration.Argument] {
-    // `autoregister` parsing
-
-    // Check for a single argument param when using autoregister
-    if let argumentParam = arguments.first(where: {$0.label?.text == "argument"}),
-       let argumentType = getArgumentType(arg: argumentParam)
-    {
-        if TypeNamer.isClosure(type: argumentType) {
-            // Make all auto register closures @escaping
-            return [.init(type: "@escaping \(argumentType)")]
-        } else {
-            return [.init(type: argumentType)]
-        }
-    }
-
-    // Autoregister can provide multiple arguments.
-    // Everything between the `arguments` and `initializer` params is an argument
-    if let argumentsParamIndex = arguments.firstIndex(where: {$0.label?.text == "arguments"}),
-       let initIndex = arguments.firstIndex(where: {$0.label?.text == "initializer"}) {
-        return arguments[argumentsParamIndex..<initIndex].compactMap { element in
-            guard let type = getArgumentType(arg: element) else {
-                return nil
-            }
-            if TypeNamer.isClosure(type: type) {
-                return .init(type: "@escaping \(type)")
-            } else {
-                return .init(type: type)
-            }
-        }
-    }
-
     // `register` parsing
 
     // The factory closure if it exists, either as a named parameter or a trailing closure

--- a/Sources/KnitCodeGen/Registration.swift
+++ b/Sources/KnitCodeGen/Registration.swift
@@ -96,7 +96,7 @@ extension Registration {
             if let identifier {
                 self.identifier = .fixed(identifier)
             } else {
-                self.identifier = .computed
+                self.identifier = .wildcard
             }
             self.type = type
         }
@@ -105,19 +105,18 @@ extension Registration {
             /// Used for arguments defined in `.register` registrations.
             case fixed(String)
 
-            /// Used for arguments provided to `.autoregister` registrations, as those do not receive explicit identifiers.
-            case computed
+            /// Unnamed parameters
+            case wildcard
         }
 
     }
 
     public enum FunctionName: String, Codable, Sendable {
         case register
-        case autoregister
         case registerAbstract
         case implements
 
-        static let standaloneFunctions: Set<FunctionName> = [.register, .autoregister, .registerAbstract]
+        static let standaloneFunctions: Set<FunctionName> = [.register, .registerAbstract]
         static let standaloneNames: Set<String> = Set(standaloneFunctions.map { $0.rawValue })
     }
 }

--- a/Sources/KnitCodeGen/TypeSafetySourceFile.swift
+++ b/Sources/KnitCodeGen/TypeSafetySourceFile.swift
@@ -265,7 +265,7 @@ extension Registration.Argument {
         switch identifier {
         case let .fixed(value):
             return value
-        case .computed:
+        case .wildcard:
             return TypeNamer.computedIdentifierName(type: type)
         }
     }

--- a/Tests/KnitCodeGenTests/AssemblyParsingTests.swift
+++ b/Tests/KnitCodeGenTests/AssemblyParsingTests.swift
@@ -429,9 +429,9 @@ final class AssemblyParsingTests: XCTestCase {
                 typealias TargetResolver = TestResolver
                 func assemble(container: Container) {
                     #if SOME_FLAG
-                    container.autoregister(B.self, initializer: B.init)
+                    container.register(B.self, factory: B.init)
                     #else
-                    container.autoregister(C.self, initializer: C.init)
+                    container.register(C.self, factory: C.init)
                     #endif
                 }
             }
@@ -456,12 +456,12 @@ final class AssemblyParsingTests: XCTestCase {
                 typealias TargetResolver = TestResolver
                 func assemble(container: Container) {
                     #if SOME_FLAG
-                    container.autoregister(A.self, initializer: A.init)
+                    container.register(A.self, factory: A.init)
                     #endif
 
                     #if SOME_FLAG && !ANOTHER_FLAG
-                    container.autoregister(B.self, initializer: B.init)
-                    container.autoregister(C.self, initializer: C.init)
+                    container.register(B.self, factory: B.init)
+                    container.register(C.self, factory: C.init)
                     #endif
                 }
             }
@@ -487,7 +487,7 @@ final class AssemblyParsingTests: XCTestCase {
                 typealias TargetResolver = TestResolver
                 func assemble(container: Container) {
                     #if targetEnvironment(simulator)
-                    container.autoregister(A.self, initializer: A.init)
+                    container.register(A.self, factory: A.init)
                     #endif
                 }
             }
@@ -508,7 +508,7 @@ final class AssemblyParsingTests: XCTestCase {
                 func assemble(container: Container) {
                     #if DEBUG
                     #if FEATURE
-                    container.autoregister(A.self, initializer: A.init)
+                    container.register(A.self, factory: A.init)
                     #endif
                     #endif
                 }


### PR DESCRIPTION
SwinjectAutoregistration was already removed in https://github.com/cashapp/knit/pull/259. This removes the parsing support from Knit.