### PR TITLE
Revert "Remove @MainActor annotation from assemble"

### DIFF
--- a/Sources/Knit/Module/ModuleAssembly.swift
+++ b/Sources/Knit/Module/ModuleAssembly.swift
@@ -13,9 +13,7 @@ public protocol ModuleAssembly<TargetResolver> {
 
     static var dependencies: [any ModuleAssembly.Type] { get }
 
-    // Knit will always call assemble on the MainActor. The annotation is not included because Swift is unable to
-    // correctly check the concurrency of closures inside a @MainActor function
-    func assemble(container: Container<TargetResolver>)
+    @MainActor func assemble(container: Container<TargetResolver>)
 
     /// A ModuleAssembly can replace any number of other module assemblies.
     /// If this assembly replaces another it is expected to provide all registrations from the replaced assemblies.


### PR DESCRIPTION
Temporary revert so this change can be part of the next release

This reverts commit 23468ec5bd33a58311a2bd2e8cf8461fa626a4ac.