### PR TITLE
Create ContainerManager to prevent needing to directly check for Container registrations

### DIFF
--- a/Sources/Knit/Container.swift
+++ b/Sources/Knit/Container.swift
@@ -40,25 +40,6 @@ public class Container<TargetResolver>: Knit.Resolver {
     fileprivate init(_swinjectContainer: Swinject.Container) {
         self._swinjectContainer = _swinjectContainer
     }
-
-    // **NOTE**: The only place this should be called is from the ModuleAssembler which
-    // is responsible for creating Containers.
-    // This should not be promoted from `internal` access level.
-    @discardableResult
-    internal static func _instantiateAndRegister(_swinjectContainer: Swinject.Container) -> Container {
-        let container = Container(_swinjectContainer: _swinjectContainer)
-
-        // We don't want to make multiple copies of this Knit.Container wrapper,
-        // so store an instance of it in the wrapped container.
-        // This class only holds a weak reference to the wrapped container so no retain cycle is created.
-        _swinjectContainer.register(
-            Container<TargetResolver>.self,
-            factory: { _ in container }
-        )
-
-        return container
-    }
-
 }
 
 extension Container {
@@ -71,4 +52,73 @@ extension Container {
         return _swinjectContainer
     }
 
+}
+
+// **NOTE**: The only place this should be created is from the ModuleAssembler which
+// is responsible for creating Containers.
+// This should not be promoted from `internal` access level.
+internal final class ContainerManager {
+
+    // swinjectContainer is weak since the container will own this manager
+    private weak var swinjectContainer: Swinject.Container!
+
+    // ContainerManager from the parent of the SwinjectContainer
+    private let parent: ContainerManager?
+
+    /// Dictionary of Containers that have been registered
+    private var containers: [ObjectIdentifier: Any] = [:]
+
+    /// Whether to automatically create Containers which are not registered
+    private let autoConfigureContainers: Bool
+
+    init(
+        parent: ContainerManager? = nil,
+        swinjectContainer: Swinject.Container,
+        autoConfigureContainers: Bool = false
+    ) {
+        self.parent = parent
+        self.autoConfigureContainers = autoConfigureContainers
+        self.swinjectContainer = swinjectContainer
+
+        // Set this as the manager for the container
+        swinjectContainer.register(ContainerManager.self) { _ in
+            self
+        }
+    }
+
+    func get<TargetResolver>(_ targetResolver: TargetResolver.Type = TargetResolver.self) -> Container<TargetResolver> {
+        if let container = getOptional(TargetResolver.self) {
+            return container
+        }
+        if autoConfigureContainers {
+            return register()
+        }
+        fatalError("ModuleAssembler failed to locate appropriate Container for \(String(describing: TargetResolver.self))")
+    }
+
+    private func getOptional<TargetResolver>(
+        _ targetResolver: TargetResolver.Type = TargetResolver.self
+    ) -> Container<TargetResolver>? {
+        // Check if this manager already has the Container
+        if let container = containers[ObjectIdentifier(TargetResolver.self)] as? Container<TargetResolver> {
+            return container
+        }
+
+        // See if the parent manager has the Container
+        if let parentContainer = parent?.getOptional(TargetResolver.self) {
+            return parentContainer
+        }
+        return nil
+    }
+
+    @discardableResult func register<TargetResolver>(
+        _ targetResolver: TargetResolver.Type = TargetResolver.self
+    ) -> Container<TargetResolver> {
+        let container = Container<TargetResolver>(_swinjectContainer: swinjectContainer)
+        self.containers[ObjectIdentifier(TargetResolver.self)] = container
+        swinjectContainer.register(Container<TargetResolver>.self) { _ in
+            container
+        }
+        return container
+    }
 }

--- a/Sources/Knit/Module/ScopedModuleAssembler.swift
+++ b/Sources/Knit/Module/ScopedModuleAssembler.swift
@@ -86,7 +86,7 @@ public final class ScopedModuleAssembler<TargetResolver> {
             behaviors: behaviors,
             preAssemble: { container in
                 // Register a Container for the the current-scoped `TargetResolver`
-                Knit.Container<TargetResolver>._instantiateAndRegister(_swinjectContainer: container)
+                container.resolve(ContainerManager.self)!.register(TargetResolver.self)
             },
             postAssemble: { swinjectContainer in
                 let container = swinjectContainer.resolve(Container<TargetResolver>.self)!

--- a/Tests/KnitTests/AbstractRegistrationTests.swift
+++ b/Tests/KnitTests/AbstractRegistrationTests.swift
@@ -11,7 +11,7 @@ final class AbstractRegistrationTests: XCTestCase {
 
     func testMissingRegistration() {
         let swinjectContainer = Swinject.Container()
-        let container = Knit.Container<TestResolver>._instantiateAndRegister(_swinjectContainer: swinjectContainer)
+        let container = ContainerManager(swinjectContainer: swinjectContainer).register(TestResolver.self)
         let abstractRegistrations = container._unwrappedSwinjectContainer.registerAbstractContainer()
         container.registerAbstract(String.self)
         container.registerAbstract(String.self, name: "test")
@@ -31,7 +31,7 @@ final class AbstractRegistrationTests: XCTestCase {
 
     func testFilledRegistrations() {
         let swinjectContainer = Swinject.Container()
-        let container = Knit.Container<TestResolver>._instantiateAndRegister(_swinjectContainer: swinjectContainer)
+        let container = ContainerManager(swinjectContainer: swinjectContainer).register(TestResolver.self)
         let abstractRegistrations = container._unwrappedSwinjectContainer.registerAbstractContainer()
         container.registerAbstract(String.self)
         container.register(String.self) { _ in "Test" }
@@ -47,7 +47,7 @@ final class AbstractRegistrationTests: XCTestCase {
 
     func testNamedRegistrations() {
         let swinjectContainer = Swinject.Container()
-        let container = Knit.Container<TestResolver>._instantiateAndRegister(_swinjectContainer: swinjectContainer)
+        let container = ContainerManager(swinjectContainer: swinjectContainer).register(TestResolver.self)
         let abstractRegistrations = container._unwrappedSwinjectContainer.registerAbstractContainer()
         container.registerAbstract(String.self)
         container.registerAbstract(String.self, name: "test")
@@ -64,7 +64,7 @@ final class AbstractRegistrationTests: XCTestCase {
 
     func testPreRegistered() {
         let swinjectContainer = Swinject.Container()
-        let container = Knit.Container<TestResolver>._instantiateAndRegister(_swinjectContainer: swinjectContainer)
+        let container = ContainerManager(swinjectContainer: swinjectContainer).register(TestResolver.self)
         let abstractRegistrations = container._unwrappedSwinjectContainer.registerAbstractContainer()
         container.register(String.self) { _ in "Test" }
         container.registerAbstract(String.self)

--- a/Tests/KnitTests/ModuleAssemblerTests.swift
+++ b/Tests/KnitTests/ModuleAssemblerTests.swift
@@ -44,7 +44,7 @@ final class ModuleAssemblerTests: XCTestCase {
         let parent = try ModuleAssembler(
             _modules: [Assembly1()],
             preAssemble: { container in
-                Knit.Container<TestResolver>._instantiateAndRegister(_swinjectContainer: container)
+                container.resolve(ContainerManager.self)!.register(TestResolver.self)
             },
             autoConfigureContainers: false
         )
@@ -52,7 +52,7 @@ final class ModuleAssemblerTests: XCTestCase {
             parent: parent,
             _modules: [Assembly3()],
             preAssemble: { container in
-                Knit.Container<TestResolver>._instantiateAndRegister(_swinjectContainer: container)
+                container.resolve(ContainerManager.self)!.register(TestResolver.self)
             },
             autoConfigureContainers: false
         )
@@ -103,7 +103,7 @@ final class ModuleAssemblerTests: XCTestCase {
         var services = assembler._swinjectContainer.services.filter { (key, value) in
             // Filter out registrations for `AbstractRegistrationContainer` and `DependencyTree`
             return key.serviceType != Container.AbstractRegistrationContainer.self &&
-            key.serviceType != DependencyTree.self
+            key.serviceType != DependencyTree.self && key.serviceType != ContainerManager.self
         }
         XCTAssertEqual(services.count, 3)
 

--- a/Tests/KnitTests/ServiceCollectorTests.swift
+++ b/Tests/KnitTests/ServiceCollectorTests.swift
@@ -87,7 +87,7 @@ final class ServiceCollectorTests: XCTestCase {
     @MainActor
     func test_registerIntoCollection() {
         let swinjectContainer = Swinject.Container()
-        let container = Knit.Container<Any>._instantiateAndRegister(_swinjectContainer: swinjectContainer)
+        let container = ContainerManager(swinjectContainer: swinjectContainer).register(Any.self)
         container._unwrappedSwinjectContainer.addBehavior(ServiceCollector())
 
         // Register some services into a collection
@@ -114,7 +114,7 @@ final class ServiceCollectorTests: XCTestCase {
     @MainActor
     func test_registerIntoCollection_emptyWithBehavior() {
         let swinjectContainer = Swinject.Container()
-        let container = Knit.Container<Any>._instantiateAndRegister(_swinjectContainer: swinjectContainer)
+        let container = ContainerManager(swinjectContainer: swinjectContainer).register(Any.self)
         container._unwrappedSwinjectContainer.addBehavior(ServiceCollector())
 
         let collection = container.resolveCollection(ServiceProtocol.self)
@@ -124,7 +124,7 @@ final class ServiceCollectorTests: XCTestCase {
     @MainActor
     func test_registerIntoCollection_emptyWithoutBehavior() {
         let swinjectContainer = Swinject.Container()
-        let container = Knit.Container<Any>._instantiateAndRegister(_swinjectContainer: swinjectContainer)
+        let container = ContainerManager(swinjectContainer: swinjectContainer).register(Any.self)
 
         let collection = container.resolveCollection(ServiceProtocol.self)
         XCTAssertEqual(collection.entries.count, 0)
@@ -135,7 +135,7 @@ final class ServiceCollectorTests: XCTestCase {
     @MainActor
     func test_registerIntoCollection_doesntConflictWithArray() throws {
         let swinjectContainer = Swinject.Container()
-        let container = Knit.Container<Any>._instantiateAndRegister(_swinjectContainer: swinjectContainer)
+        let container = ContainerManager(swinjectContainer: swinjectContainer).register(Any.self)
         container._unwrappedSwinjectContainer.addBehavior(ServiceCollector())
 
         // Register A into a collection
@@ -158,7 +158,7 @@ final class ServiceCollectorTests: XCTestCase {
     @MainActor
     func test_registerIntoCollection_doesntImplicitlyAggregateInstances() throws {
         let swinjectContainer = Swinject.Container()
-        let container = Knit.Container<Any>._instantiateAndRegister(_swinjectContainer: swinjectContainer)
+        let container = ContainerManager(swinjectContainer: swinjectContainer).register(Any.self)
         container._unwrappedSwinjectContainer.addBehavior(ServiceCollector())
 
         // Register A and B into a collection
@@ -181,7 +181,7 @@ final class ServiceCollectorTests: XCTestCase {
     @MainActor
     func test_registerIntoCollection_allowsDuplicates() {
         let swinjectContainer = Swinject.Container()
-        let container = Knit.Container<Any>._instantiateAndRegister(_swinjectContainer: swinjectContainer)
+        let container = ContainerManager(swinjectContainer: swinjectContainer).register(Any.self)
         container._unwrappedSwinjectContainer.addBehavior(ServiceCollector())
 
         // Register some duplicate services
@@ -202,7 +202,7 @@ final class ServiceCollectorTests: XCTestCase {
     @MainActor
     func test_registerIntoCollection_supportsTransientScopedObjects() throws {
         let swinjectContainer = Swinject.Container()
-        let container = Knit.Container<Any>._instantiateAndRegister(_swinjectContainer: swinjectContainer)
+        let container = ContainerManager(swinjectContainer: swinjectContainer).register(Any.self)
         container._unwrappedSwinjectContainer.addBehavior(ServiceCollector())
 
         // Register a service with the `transient` scope.
@@ -223,7 +223,7 @@ final class ServiceCollectorTests: XCTestCase {
     @MainActor
     func test_registerIntoCollection_supportsContainerScopedObjects() throws {
         let swinjectContainer = Swinject.Container()
-        let container = Knit.Container<Any>._instantiateAndRegister(_swinjectContainer: swinjectContainer)
+        let container = ContainerManager(swinjectContainer: swinjectContainer).register(Any.self)
         container._unwrappedSwinjectContainer.addBehavior(ServiceCollector())
 
         // Register a service with the `container` scope.
@@ -244,7 +244,7 @@ final class ServiceCollectorTests: XCTestCase {
     @MainActor
     func test_registerIntoCollection_supportsWeakScopedObjects() throws {
         let swinjectContainer = Swinject.Container()
-        let container = Knit.Container<Any>._instantiateAndRegister(_swinjectContainer: swinjectContainer)
+        let container = ContainerManager(swinjectContainer: swinjectContainer).register(Any.self)
         container._unwrappedSwinjectContainer.addBehavior(ServiceCollector())
 
         // Register a service with the `weak` scope.


### PR DESCRIPTION
This change is to prevent the following errors coming up during testing. The containers get automatically created but since it checks the resolver first an error is raised in the logs which increases noise when looking for real issues.
```
Swinject: Resolution failed. Expected registration:
  { Service: Container<AccountResolver>, Factory: Resolver -> Container<AccountResolver> }
```