### PR TITLE
Prevent fakes from being pulled in when a real implementation was provided

### DIFF
--- a/Sources/Knit/Module/DependencyBuilder.swift
+++ b/Sources/Knit/Module/DependencyBuilder.swift
@@ -138,6 +138,11 @@ final class DependencyBuilder {
         else {
             return nil
         }
+        for module in inputModules {
+            if type(of: module).doesReplace(type: moduleType) {
+                return type(of: module)
+            }
+        }
 
         let type = defaultType.erasedType
         guard type.doesReplace(type: moduleType) else {


### PR DESCRIPTION
This solves a niche issue where an assembler has multiple inputs and is using default fake implementations.

This issue occurs with the following conditions

* AssemblyA depends on the abstract AssemblyB
* RealAssemblyB is the implementation for AssemblyB
* FakeAssemblyB exists in the graph and the assembler is setup to allow fakes
* AssemblyA and RealAssemblyB are provided as input modules to the assembly and AssemblyA is first

In this case the expectation is that since RealAssemblyB is provided as an input module the fake shouldn't be automatically used since an explicit implementation is provided. But since AssemblyA pulls AssemblyB in as a dependency before RealAssemblyB is processed the graph ends up with both the fake and the real implementation.

