### PR TITLE
Prevent duplicate assemblies being created

### DIFF
--- a/Sources/Knit/Module/DependencyBuilder.swift
+++ b/Sources/Knit/Module/DependencyBuilder.swift
@@ -41,11 +41,19 @@ final class DependencyBuilder {
         let toAssemble = assemblyCache.toAssemble
 
         // Instantiate all types
+        var createdTypes = Set<String>()
         for ref in toAssemble {
             guard !self.isRegisteredInParent(ref) else {
                 continue
             }
-            assemblies.append(try instantiate(moduleType: ref.type))
+            let assembly = try instantiate(moduleType: ref.type)
+            // Ensure the same assembly isn't added twice
+            let typeName = String(describing: type(of: assembly))
+            guard !createdTypes.contains(typeName) else {
+                continue
+            }
+            assemblies.append(assembly)
+            createdTypes.insert(typeName)
         }
     }
 


### PR DESCRIPTION
This solves an edge cases where an assembly may end up being instantiated more than once due to how the graph is built. 
I can't figure out a small case to replicate this, but this safety prevents crashes when adding validation for overridden registrations.