### PR TITLE
Reporting improvements for released container error

### DIFF
--- a/Sources/Knit/Container+MainActorRegistration.swift
+++ b/Sources/Knit/Container+MainActorRegistration.swift
@@ -27,7 +27,7 @@ extension Knit.Container {
         name: String? = nil,
         mainActorFactory: @escaping @MainActor (TargetResolver) -> Service
     ) -> ServiceEntry<Service> {
-        return _unwrappedSwinjectContainer.register(serviceType, name: name) { r in
+        return _unwrappedSwinjectContainer().register(serviceType, name: name) { r in
             let resolver = r.resolve(Container<TargetResolver>.self)!.resolver
             return MainActor.assumeIsolated {
                 return mainActorFactory(resolver)
@@ -58,7 +58,7 @@ extension Knit.Container {
         name: String? = nil,
         mainActorFactory: @escaping @MainActor (TargetResolver, Arg1) -> Service
     ) -> ServiceEntry<Service> {
-        return _unwrappedSwinjectContainer.register(serviceType, name: name) { (r: Swinject.Resolver, arg1: Arg1) in
+        return _unwrappedSwinjectContainer().register(serviceType, name: name) { (r: Swinject.Resolver, arg1: Arg1) in
             let resolver = r.resolve(Container<TargetResolver>.self)!.resolver
             return MainActor.assumeIsolated {
                 return mainActorFactory(resolver, arg1)
@@ -85,7 +85,7 @@ extension Knit.Container {
         name: String? = nil,
         mainActorFactory: @escaping @MainActor (TargetResolver, Arg1, Arg2) -> Service
     ) -> ServiceEntry<Service> {
-        return _unwrappedSwinjectContainer.register(serviceType, name: name) { (r: Swinject.Resolver, arg1: Arg1, arg2: Arg2) in
+        return _unwrappedSwinjectContainer().register(serviceType, name: name) { (r: Swinject.Resolver, arg1: Arg1, arg2: Arg2) in
             let resolver = r.resolve(Container<TargetResolver>.self)!.resolver
             return MainActor.assumeIsolated {
                 return mainActorFactory(resolver, arg1, arg2)
@@ -112,7 +112,7 @@ extension Knit.Container {
         name: String? = nil,
         mainActorFactory: @escaping @MainActor (TargetResolver, Arg1, Arg2, Arg3) -> Service
     ) -> ServiceEntry<Service> {
-        return _unwrappedSwinjectContainer.register(serviceType, name: name) { (r: Swinject.Resolver, arg1: Arg1, arg2: Arg2, arg3: Arg3) in
+        return _unwrappedSwinjectContainer().register(serviceType, name: name) { (r: Swinject.Resolver, arg1: Arg1, arg2: Arg2, arg3: Arg3) in
             let resolver = r.resolve(Container<TargetResolver>.self)!.resolver
             return MainActor.assumeIsolated {
                 return mainActorFactory(resolver, arg1, arg2, arg3)
@@ -139,7 +139,7 @@ extension Knit.Container {
         name: String? = nil,
         mainActorFactory: @escaping @MainActor (TargetResolver, Arg1, Arg2, Arg3, Arg4) -> Service
     ) -> ServiceEntry<Service> {
-        return _unwrappedSwinjectContainer.register(serviceType, name: name) { (r: Swinject.Resolver, arg1: Arg1, arg2: Arg2, arg3: Arg3, arg4: Arg4) in
+        return _unwrappedSwinjectContainer().register(serviceType, name: name) { (r: Swinject.Resolver, arg1: Arg1, arg2: Arg2, arg3: Arg3, arg4: Arg4) in
             let resolver = r.resolve(Container<TargetResolver>.self)!.resolver
             return MainActor.assumeIsolated {
                 return mainActorFactory(resolver, arg1, arg2, arg3, arg4)
@@ -166,7 +166,7 @@ extension Knit.Container {
         name: String? = nil,
         mainActorFactory: @escaping @MainActor (TargetResolver, Arg1, Arg2, Arg3, Arg4, Arg5) -> Service
     ) -> ServiceEntry<Service> {
-        return _unwrappedSwinjectContainer.register(serviceType, name: name) { (r: Swinject.Resolver, arg1: Arg1, arg2: Arg2, arg3: Arg3, arg4: Arg4, arg5: Arg5) in
+        return _unwrappedSwinjectContainer().register(serviceType, name: name) { (r: Swinject.Resolver, arg1: Arg1, arg2: Arg2, arg3: Arg3, arg4: Arg4, arg5: Arg5) in
             let resolver = r.resolve(Container<TargetResolver>.self)!.resolver
             return MainActor.assumeIsolated {
                 return mainActorFactory(resolver, arg1, arg2, arg3, arg4, arg5)
@@ -193,7 +193,7 @@ extension Knit.Container {
         name: String? = nil,
         mainActorFactory: @escaping @MainActor (TargetResolver, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6) -> Service
     ) -> ServiceEntry<Service> {
-        return _unwrappedSwinjectContainer.register(serviceType, name: name) { (r: Swinject.Resolver, arg1: Arg1, arg2: Arg2, arg3: Arg3, arg4: Arg4, arg5: Arg5, arg6: Arg6) in
+        return _unwrappedSwinjectContainer().register(serviceType, name: name) { (r: Swinject.Resolver, arg1: Arg1, arg2: Arg2, arg3: Arg3, arg4: Arg4, arg5: Arg5, arg6: Arg6) in
             let resolver = r.resolve(Container<TargetResolver>.self)!.resolver
             return MainActor.assumeIsolated {
                 return mainActorFactory(resolver, arg1, arg2, arg3, arg4, arg5, arg6)
@@ -220,7 +220,7 @@ extension Knit.Container {
         name: String? = nil,
         mainActorFactory: @escaping @MainActor (TargetResolver, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7) -> Service
     ) -> ServiceEntry<Service> {
-        return _unwrappedSwinjectContainer.register(serviceType, name: name) { (r: Swinject.Resolver, arg1: Arg1, arg2: Arg2, arg3: Arg3, arg4: Arg4, arg5: Arg5, arg6: Arg6, arg7: Arg7) in
+        return _unwrappedSwinjectContainer().register(serviceType, name: name) { (r: Swinject.Resolver, arg1: Arg1, arg2: Arg2, arg3: Arg3, arg4: Arg4, arg5: Arg5, arg6: Arg6, arg7: Arg7) in
             let resolver = r.resolve(Container<TargetResolver>.self)!.resolver
             return MainActor.assumeIsolated {
                 return mainActorFactory(resolver, arg1, arg2, arg3, arg4, arg5, arg6, arg7)
@@ -247,7 +247,7 @@ extension Knit.Container {
         name: String? = nil,
         mainActorFactory: @escaping @MainActor (TargetResolver, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8) -> Service
     ) -> ServiceEntry<Service> {
-        return _unwrappedSwinjectContainer.register(serviceType, name: name) { (r: Swinject.Resolver, arg1: Arg1, arg2: Arg2, arg3: Arg3, arg4: Arg4, arg5: Arg5, arg6: Arg6, arg7: Arg7, arg8: Arg8) in
+        return _unwrappedSwinjectContainer().register(serviceType, name: name) { (r: Swinject.Resolver, arg1: Arg1, arg2: Arg2, arg3: Arg3, arg4: Arg4, arg5: Arg5, arg6: Arg6, arg7: Arg7, arg8: Arg8) in
             let resolver = r.resolve(Container<TargetResolver>.self)!.resolver
             return MainActor.assumeIsolated {
                 return mainActorFactory(resolver, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8)
@@ -274,7 +274,7 @@ extension Knit.Container {
         name: String? = nil,
         mainActorFactory: @escaping @MainActor (TargetResolver, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8, Arg9) -> Service
     ) -> ServiceEntry<Service> {
-        return _unwrappedSwinjectContainer.register(serviceType, name: name) { (r: Swinject.Resolver, arg1: Arg1, arg2: Arg2, arg3: Arg3, arg4: Arg4, arg5: Arg5, arg6: Arg6, arg7: Arg7, arg8: Arg8, arg9: Arg9) in
+        return _unwrappedSwinjectContainer().register(serviceType, name: name) { (r: Swinject.Resolver, arg1: Arg1, arg2: Arg2, arg3: Arg3, arg4: Arg4, arg5: Arg5, arg6: Arg6, arg7: Arg7, arg8: Arg8, arg9: Arg9) in
             let resolver = r.resolve(Container<TargetResolver>.self)!.resolver
             return MainActor.assumeIsolated {
                 return mainActorFactory(resolver, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9)

--- a/Sources/Knit/Container+Registration.swift
+++ b/Sources/Knit/Container+Registration.swift
@@ -27,7 +27,7 @@ extension Knit.Container {
         name: String? = nil,
         factory: @escaping (TargetResolver) -> Service
     ) -> ServiceEntry<Service> {
-        return _unwrappedSwinjectContainer.register(serviceType, name: name) { r in
+        return _unwrappedSwinjectContainer().register(serviceType, name: name) { r in
             let resolver = r.resolve(Container<TargetResolver>.self)!.resolver
             return factory(resolver)
         }
@@ -56,7 +56,7 @@ extension Container {
         name: String? = nil,
         factory: @escaping (TargetResolver, Arg1) -> Service
     ) -> ServiceEntry<Service> {
-        return _unwrappedSwinjectContainer.register(serviceType, name: name) { (r: Swinject.Resolver, arg1: Arg1) in
+        return _unwrappedSwinjectContainer().register(serviceType, name: name) { (r: Swinject.Resolver, arg1: Arg1) in
             let resolver = r.resolve(Container<TargetResolver>.self)!.resolver
             return factory(resolver, arg1)
         }
@@ -81,7 +81,7 @@ extension Container {
         name: String? = nil,
         factory: @escaping (TargetResolver, Arg1, Arg2) -> Service
     ) -> ServiceEntry<Service> {
-        return _unwrappedSwinjectContainer.register(serviceType, name: name) { (r: Swinject.Resolver, arg1: Arg1, arg2: Arg2) in
+        return _unwrappedSwinjectContainer().register(serviceType, name: name) { (r: Swinject.Resolver, arg1: Arg1, arg2: Arg2) in
             let resolver = r.resolve(Container<TargetResolver>.self)!.resolver
             return factory(resolver, arg1, arg2)
         }
@@ -106,7 +106,7 @@ extension Container {
         name: String? = nil,
         factory: @escaping (TargetResolver, Arg1, Arg2, Arg3) -> Service
     ) -> ServiceEntry<Service> {
-        return _unwrappedSwinjectContainer.register(serviceType, name: name) { (r: Swinject.Resolver, arg1: Arg1, arg2: Arg2, arg3: Arg3) in
+        return _unwrappedSwinjectContainer().register(serviceType, name: name) { (r: Swinject.Resolver, arg1: Arg1, arg2: Arg2, arg3: Arg3) in
             let resolver = r.resolve(Container<TargetResolver>.self)!.resolver
             return factory(resolver, arg1, arg2, arg3)
         }
@@ -131,7 +131,7 @@ extension Container {
         name: String? = nil,
         factory: @escaping (TargetResolver, Arg1, Arg2, Arg3, Arg4) -> Service
     ) -> ServiceEntry<Service> {
-        return _unwrappedSwinjectContainer.register(serviceType, name: name) { (r: Swinject.Resolver, arg1: Arg1, arg2: Arg2, arg3: Arg3, arg4: Arg4) in
+        return _unwrappedSwinjectContainer().register(serviceType, name: name) { (r: Swinject.Resolver, arg1: Arg1, arg2: Arg2, arg3: Arg3, arg4: Arg4) in
             let resolver = r.resolve(Container<TargetResolver>.self)!.resolver
             return factory(resolver, arg1, arg2, arg3, arg4)
         }
@@ -156,7 +156,7 @@ extension Container {
         name: String? = nil,
         factory: @escaping (TargetResolver, Arg1, Arg2, Arg3, Arg4, Arg5) -> Service
     ) -> ServiceEntry<Service> {
-        return _unwrappedSwinjectContainer.register(serviceType, name: name) { (r: Swinject.Resolver, arg1: Arg1, arg2: Arg2, arg3: Arg3, arg4: Arg4, arg5: Arg5) in
+        return _unwrappedSwinjectContainer().register(serviceType, name: name) { (r: Swinject.Resolver, arg1: Arg1, arg2: Arg2, arg3: Arg3, arg4: Arg4, arg5: Arg5) in
             let resolver = r.resolve(Container<TargetResolver>.self)!.resolver
             return factory(resolver, arg1, arg2, arg3, arg4, arg5)
         }
@@ -181,7 +181,7 @@ extension Container {
         name: String? = nil,
         factory: @escaping (TargetResolver, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6) -> Service
     ) -> ServiceEntry<Service> {
-        return _unwrappedSwinjectContainer.register(serviceType, name: name) { (r: Swinject.Resolver, arg1: Arg1, arg2: Arg2, arg3: Arg3, arg4: Arg4, arg5: Arg5, arg6: Arg6) in
+        return _unwrappedSwinjectContainer().register(serviceType, name: name) { (r: Swinject.Resolver, arg1: Arg1, arg2: Arg2, arg3: Arg3, arg4: Arg4, arg5: Arg5, arg6: Arg6) in
             let resolver = r.resolve(Container<TargetResolver>.self)!.resolver
             return factory(resolver, arg1, arg2, arg3, arg4, arg5, arg6)
         }
@@ -206,7 +206,7 @@ extension Container {
         name: String? = nil,
         factory: @escaping (TargetResolver, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7) -> Service
     ) -> ServiceEntry<Service> {
-        return _unwrappedSwinjectContainer.register(serviceType, name: name) { (r: Swinject.Resolver, arg1: Arg1, arg2: Arg2, arg3: Arg3, arg4: Arg4, arg5: Arg5, arg6: Arg6, arg7: Arg7) in
+        return _unwrappedSwinjectContainer().register(serviceType, name: name) { (r: Swinject.Resolver, arg1: Arg1, arg2: Arg2, arg3: Arg3, arg4: Arg4, arg5: Arg5, arg6: Arg6, arg7: Arg7) in
             let resolver = r.resolve(Container<TargetResolver>.self)!.resolver
             return factory(resolver, arg1, arg2, arg3, arg4, arg5, arg6, arg7)
         }
@@ -231,7 +231,7 @@ extension Container {
         name: String? = nil,
         factory: @escaping (TargetResolver, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8) -> Service
     ) -> ServiceEntry<Service> {
-        return _unwrappedSwinjectContainer.register(serviceType, name: name) { (r: Swinject.Resolver, arg1: Arg1, arg2: Arg2, arg3: Arg3, arg4: Arg4, arg5: Arg5, arg6: Arg6, arg7: Arg7, arg8: Arg8) in
+        return _unwrappedSwinjectContainer().register(serviceType, name: name) { (r: Swinject.Resolver, arg1: Arg1, arg2: Arg2, arg3: Arg3, arg4: Arg4, arg5: Arg5, arg6: Arg6, arg7: Arg7, arg8: Arg8) in
             let resolver = r.resolve(Container<TargetResolver>.self)!.resolver
             return factory(resolver, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8)
         }
@@ -256,7 +256,7 @@ extension Container {
         name: String? = nil,
         factory: @escaping (TargetResolver, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8, Arg9) -> Service
     ) -> ServiceEntry<Service> {
-        return _unwrappedSwinjectContainer.register(serviceType, name: name) { (r: Swinject.Resolver, arg1: Arg1, arg2: Arg2, arg3: Arg3, arg4: Arg4, arg5: Arg5, arg6: Arg6, arg7: Arg7, arg8: Arg8, arg9: Arg9) in
+        return _unwrappedSwinjectContainer().register(serviceType, name: name) { (r: Swinject.Resolver, arg1: Arg1, arg2: Arg2, arg3: Arg3, arg4: Arg4, arg5: Arg5, arg6: Arg6, arg7: Arg7, arg8: Arg8, arg9: Arg9) in
             let resolver = r.resolve(Container<TargetResolver>.self)!.resolver
             return factory(resolver, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9)
         }

--- a/Sources/Knit/Container.swift
+++ b/Sources/Knit/Container.swift
@@ -26,8 +26,8 @@ public class Container<TargetResolver>: Knit.Resolver {
 
     // MARK: - Swinject.Resolver
 
-    public var unsafeResolver: Swinject.Resolver {
-        _unwrappedSwinjectContainer
+    public func unsafeResolver(file: StaticString, function: StaticString, line: UInt) -> Swinject.Resolver {
+        _unwrappedSwinjectContainer(file: file, function: function, line: line)
     }
 
     // MARK: - Private Properties
@@ -45,9 +45,17 @@ public class Container<TargetResolver>: Knit.Resolver {
 extension Container {
 
     // Force unwraps the weak Container
-    var _unwrappedSwinjectContainer: Swinject.Container {
+    func _unwrappedSwinjectContainer(
+        file: StaticString = #fileID,
+        function: StaticString = #function,
+        line: UInt = #line
+    ) -> Swinject.Container {
         guard let _swinjectContainer else {
-            fatalError("Attempting to resolve using the container for \(TargetResolver.self) which has been released")
+            fatalError(
+                "\(function) incorrectly accessed the container for \(TargetResolver.self) which has already been released",
+                file: file,
+                line: line
+            )
         }
         return _swinjectContainer
     }

--- a/Sources/Knit/Module/Container+AbstractRegistration.swift
+++ b/Sources/Knit/Module/Container+AbstractRegistration.swift
@@ -17,7 +17,7 @@ extension Container {
         file: String = #fileID
     ) {
         let registration = RealAbstractRegistration<Service>(name: name, file: file, concurrency: concurrency)
-        _unwrappedSwinjectContainer.addAbstractRegistration(registration)
+        _unwrappedSwinjectContainer().addAbstractRegistration(registration)
     }
 
     /// Register that a service is expected to exist but no implementation is currently available
@@ -32,7 +32,7 @@ extension Container {
         file: String = #fileID
     ) {
         let registration = OptionalAbstractRegistration<Service>(name: name, file: file, concurrency: concurrency)
-        _unwrappedSwinjectContainer.addAbstractRegistration(registration)
+        _unwrappedSwinjectContainer().addAbstractRegistration(registration)
     }
 
 }

--- a/Sources/Knit/Resolver+Additions.swift
+++ b/Sources/Knit/Resolver+Additions.swift
@@ -47,15 +47,17 @@ public extension Knit.Resolver {
         callsiteFunction: StaticString,
         callsiteLine: UInt
     ) -> T {
-        self.unsafeResolver.knitUnwrap(
-            value,
-            file: file,
-            function: function,
-            line: line,
-            callsiteFile: callsiteFile,
-            callsiteFunction: callsiteFunction,
-            callsiteLine: callsiteLine
-        )
+        self
+            .unsafeResolver(file: callsiteFile, function: callsiteFunction, line: callsiteLine)
+            .knitUnwrap(
+                value,
+                file: file,
+                function: function,
+                line: line,
+                callsiteFile: callsiteFile,
+                callsiteFunction: callsiteFunction,
+                callsiteLine: callsiteLine
+            )
     }
 
 }

--- a/Sources/Knit/Resolver.swift
+++ b/Sources/Knit/Resolver.swift
@@ -11,6 +11,6 @@ public protocol Resolver: AnyObject {
     /// Returns `true` if the backing container is still available in memory, otherwise `false`.
     var isAvailable: Bool { get }
 
-    var unsafeResolver: Swinject.Resolver { get }
+    func unsafeResolver(file: StaticString, function: StaticString, line: UInt) -> Swinject.Resolver
 
 }

--- a/Sources/Knit/ServiceCollection/Container+ServiceCollection.swift
+++ b/Sources/Knit/ServiceCollection/Container+ServiceCollection.swift
@@ -25,7 +25,7 @@ extension Container {
         _ service: Service.Type,
         factory: @escaping @MainActor (TargetResolver) -> Service
     ) -> ServiceEntry<Service> {
-        self._unwrappedSwinjectContainer.register(
+        self._unwrappedSwinjectContainer().register(
             service,
             name: makeUniqueCollectionRegistrationName(),
             factory: { r in

--- a/Sources/Knit/ServiceCollection/Resolver+ServiceCollection.swift
+++ b/Sources/Knit/ServiceCollection/Resolver+ServiceCollection.swift
@@ -46,8 +46,14 @@ extension Knit.Resolver {
     /// - Returns: A ``ServiceCollection`` containing all registered services,
     ///            or an empty collection if no services were registered.
     @MainActor
-    public func resolveCollection<Service>(_ serviceType: Service.Type) -> ServiceCollection<Service> {
-        unsafeResolver.resolveCollection(serviceType)
+    public func resolveCollection<Service>(
+        _ serviceType: Service.Type,
+        file: StaticString = #fileID,
+        function: StaticString = #function,
+        line: UInt = #line
+    ) -> ServiceCollection<Service> {
+        unsafeResolver(file: file, function: function, line: line)
+            .resolveCollection(serviceType)
     }
 
 }

--- a/Sources/KnitCodeGen/TypeSafetySourceFile.swift
+++ b/Sources/KnitCodeGen/TypeSafetySourceFile.swift
@@ -114,7 +114,8 @@ public enum TypeSafetySourceFile {
         usages: String
     ) throws -> FunctionDeclSyntax {
         try FunctionDeclSyntax("\(raw: modifier)func \(raw: functionName)(\(raw: inputs)) -> \(raw: registration.service)") {
-            "knitUnwrap(unsafeResolver.resolve(\(raw: usages)), callsiteFile: file, callsiteFunction: function, callsiteLine: line)"
+            "let resolver = unsafeResolver(file: file, function: function, line: line)"
+            "return knitUnwrap(resolver.resolve(\(raw: usages)), callsiteFile: file, callsiteFunction: function, callsiteLine: line)"
         }
     }
 

--- a/Sources/KnitTesting/Resolver+Asserts.swift
+++ b/Sources/KnitTesting/Resolver+Asserts.swift
@@ -72,18 +72,22 @@ public extension Knit.Resolver {
     func assertTypeResolved<T>(
         _ result: T?,
         file: StaticString = #filePath,
+        function: StaticString = #function,
         line: UInt = #line
     ) {
-        unsafeResolver.assertTypeResolved(result, file: file, line: line)
+        unsafeResolver(file: file, function: function, line: line)
+            .assertTypeResolved(result, file: file, line: line)
     }
 
     func assertTypeResolves<T>(
         _ type: T.Type,
         name: String? = nil,
         file: StaticString = #filePath,
+        function: StaticString = #function,
         line: UInt = #line
     ) {
-        unsafeResolver.assertTypeResolves(type, name: name, file: file, line: line)
+        unsafeResolver(file: file, function: function, line: line)
+            .assertTypeResolves(type, name: name, file: file, line: line)
     }
 
     @MainActor
@@ -91,9 +95,11 @@ public extension Knit.Resolver {
         _ type: T.Type,
         count expectedCount: Int,
         file: StaticString = #filePath,
+        function: StaticString = #function,
         line: UInt = #line
     ) {
-        unsafeResolver.assertCollectionResolves(type, count: expectedCount, file: file, line: line)
+        unsafeResolver(file: file, function: function, line: line)
+            .assertCollectionResolves(type, count: expectedCount, file: file, line: line)
     }
 
 }

--- a/Tests/KnitCodeGenTests/ConfigurationSetTests.swift
+++ b/Tests/KnitCodeGenTests/ConfigurationSetTests.swift
@@ -29,7 +29,8 @@ final class ConfigurationSetTests: XCTestCase {
             /// Generated from ``Module1Assembly``
             extension Resolver {
                 public func service1(file: StaticString = #fileID, function: StaticString = #function, line: UInt = #line) -> Service1 {
-                    knitUnwrap(unsafeResolver.resolve(Service1.self), callsiteFile: file, callsiteFunction: function, callsiteLine: line)
+                    let resolver = unsafeResolver(file: file, function: function, line: line)
+                    return knitUnwrap(resolver.resolve(Service1.self), callsiteFile: file, callsiteFunction: function, callsiteLine: line)
                 }
             }
             extension Module1Assembly {
@@ -43,10 +44,12 @@ final class ConfigurationSetTests: XCTestCase {
             /// Generated from ``Module2Assembly``
             extension Resolver {
                 public func service2(file: StaticString = #fileID, function: StaticString = #function, line: UInt = #line) -> Service2 {
-                    knitUnwrap(unsafeResolver.resolve(Service2.self), callsiteFile: file, callsiteFunction: function, callsiteLine: line)
+                    let resolver = unsafeResolver(file: file, function: function, line: line)
+                    return knitUnwrap(resolver.resolve(Service2.self), callsiteFile: file, callsiteFunction: function, callsiteLine: line)
                 }
                 func argumentService(string: String, file: StaticString = #fileID, function: StaticString = #function, line: UInt = #line) -> ArgumentService {
-                    knitUnwrap(unsafeResolver.resolve(ArgumentService.self, argument: string), callsiteFile: file, callsiteFunction: function, callsiteLine: line)
+                    let resolver = unsafeResolver(file: file, function: function, line: line)
+                    return knitUnwrap(resolver.resolve(ArgumentService.self, argument: string), callsiteFile: file, callsiteFunction: function, callsiteLine: line)
                 }
             }
             extension Module2Assembly {
@@ -60,7 +63,8 @@ final class ConfigurationSetTests: XCTestCase {
             /// Generated from ``Module3Assembly``
             extension Resolver {
                 public func service3(file: StaticString = #fileID, function: StaticString = #function, line: UInt = #line) -> Service3 {
-                    knitUnwrap(unsafeResolver.resolve(Service3.self), callsiteFile: file, callsiteFunction: function, callsiteLine: line)
+                    let resolver = unsafeResolver(file: file, function: function, line: line)
+                    return knitUnwrap(resolver.resolve(Service3.self), callsiteFile: file, callsiteFunction: function, callsiteLine: line)
                 }
             }
             extension Module3Assembly {
@@ -343,7 +347,8 @@ final class ConfigurationSetTests: XCTestCase {
             /// Generated from ``CustomAssembly``
             extension Resolver {
                 func service1(file: StaticString = #fileID, function: StaticString = #function, line: UInt = #line) -> Service1 {
-                    knitUnwrap(unsafeResolver.resolve(Service1.self), callsiteFile: file, callsiteFunction: function, callsiteLine: line)
+                    let resolver = unsafeResolver(file: file, function: function, line: line)
+                    return knitUnwrap(resolver.resolve(Service1.self), callsiteFile: file, callsiteFunction: function, callsiteLine: line)
                 }
             }
             """

--- a/Tests/KnitCodeGenTests/TypeSafetySourceFileTests.swift
+++ b/Tests/KnitCodeGenTests/TypeSafetySourceFileTests.swift
@@ -35,25 +35,32 @@ final class TypeSafetySourceFileTests: XCTestCase {
         /// Generated from ``ModuleAssembly``
         extension Resolve {
             func serviceA(file: StaticString = #fileID, function: StaticString = #function, line: UInt = #line) -> ServiceA {
-                knitUnwrap(unsafeResolver.resolve(ServiceA.self), callsiteFile: file, callsiteFunction: function, callsiteLine: line)
+                let resolver = unsafeResolver(file: file, function: function, line: line)
+                return knitUnwrap(resolver.resolve(ServiceA.self), callsiteFile: file, callsiteFunction: function, callsiteLine: line)
             }
             public func serviceD(file: StaticString = #fileID, function: StaticString = #function, line: UInt = #line) -> ServiceD {
-                knitUnwrap(unsafeResolver.resolve(ServiceD.self), callsiteFile: file, callsiteFunction: function, callsiteLine: line)
+                let resolver = unsafeResolver(file: file, function: function, line: line)
+                return knitUnwrap(resolver.resolve(ServiceD.self), callsiteFile: file, callsiteFunction: function, callsiteLine: line)
             }
             public func serviceDAlias(file: StaticString = #fileID, function: StaticString = #function, line: UInt = #line) -> ServiceD {
-                knitUnwrap(unsafeResolver.resolve(ServiceD.self), callsiteFile: file, callsiteFunction: function, callsiteLine: line)
+                let resolver = unsafeResolver(file: file, function: function, line: line)
+                return knitUnwrap(resolver.resolve(ServiceD.self), callsiteFile: file, callsiteFunction: function, callsiteLine: line)
             }
             public func serviceE(closure1: @escaping () -> Void, closure2: @escaping @Sendable (Bool) -> Void, file: StaticString = #fileID, function: StaticString = #function, line: UInt = #line) -> ServiceE {
-                knitUnwrap(unsafeResolver.resolve(ServiceE.self, arguments: closure1, closure2), callsiteFile: file, callsiteFunction: function, callsiteLine: line)
+                let resolver = unsafeResolver(file: file, function: function, line: line)
+                return knitUnwrap(resolver.resolve(ServiceE.self, arguments: closure1, closure2), callsiteFile: file, callsiteFunction: function, callsiteLine: line)
             }
             public func serviceF(file: StaticString = #fileID, function: StaticString = #function, line: UInt = #line) -> ServiceF {
-                knitUnwrap(unsafeResolver.resolve(ServiceF.self), callsiteFile: file, callsiteFunction: function, callsiteLine: line)
+                let resolver = unsafeResolver(file: file, function: function, line: line)
+                return knitUnwrap(resolver.resolve(ServiceF.self), callsiteFile: file, callsiteFunction: function, callsiteLine: line)
             }
             public func stringInt(file: StaticString = #fileID, function: StaticString = #function, line: UInt = #line) -> (String, Int?) {
-                knitUnwrap(unsafeResolver.resolve((String, Int?).self), callsiteFile: file, callsiteFunction: function, callsiteLine: line)
+                let resolver = unsafeResolver(file: file, function: function, line: line)
+                return knitUnwrap(resolver.resolve((String, Int?).self), callsiteFile: file, callsiteFunction: function, callsiteLine: line)
             }
             func serviceB(name: ModuleAssembly.ServiceB_ResolutionKey, file: StaticString = #fileID, function: StaticString = #function, line: UInt = #line) -> ServiceB {
-                knitUnwrap(unsafeResolver.resolve(ServiceB.self, name: name.rawValue), callsiteFile: file, callsiteFunction: function, callsiteLine: line)
+                let resolver = unsafeResolver(file: file, function: function, line: line)
+                return knitUnwrap(resolver.resolve(ServiceB.self, name: name.rawValue), callsiteFile: file, callsiteFunction: function, callsiteLine: line)
             }
         }
         extension ModuleAssembly {
@@ -84,7 +91,8 @@ final class TypeSafetySourceFileTests: XCTestCase {
             ),
             """
             public func a(string: String, url: URL, file: StaticString = #fileID, function: StaticString = #function, line: UInt = #line) -> A {
-                knitUnwrap(unsafeResolver.resolve(A.self, arguments: string, url), callsiteFile: file, callsiteFunction: function, callsiteLine: line)
+                let resolver = unsafeResolver(file: file, function: function, line: line)
+                return knitUnwrap(resolver.resolve(A.self, arguments: string, url), callsiteFile: file, callsiteFunction: function, callsiteLine: line)
             }
             """
         )
@@ -99,7 +107,8 @@ final class TypeSafetySourceFileTests: XCTestCase {
             ),
             """
             public func a(string: String, file: StaticString = #fileID, function: StaticString = #function, line: UInt = #line) -> A {
-                knitUnwrap(unsafeResolver.resolve(A.self, argument: string), callsiteFile: file, callsiteFunction: function, callsiteLine: line)
+                let resolver = unsafeResolver(file: file, function: function, line: line)
+                return knitUnwrap(resolver.resolve(A.self, argument: string), callsiteFile: file, callsiteFunction: function, callsiteLine: line)
             }
             """
         )
@@ -114,7 +123,8 @@ final class TypeSafetySourceFileTests: XCTestCase {
             ),
             """
             public func a(string1: String, string2: String, file: StaticString = #fileID, function: StaticString = #function, line: UInt = #line) -> A {
-                knitUnwrap(unsafeResolver.resolve(A.self, arguments: string1, string2), callsiteFile: file, callsiteFunction: function, callsiteLine: line)
+                let resolver = unsafeResolver(file: file, function: function, line: line)
+                return knitUnwrap(resolver.resolve(A.self, arguments: string1, string2), callsiteFile: file, callsiteFunction: function, callsiteLine: line)
             }
             """
         )
@@ -129,7 +139,8 @@ final class TypeSafetySourceFileTests: XCTestCase {
             ),
             """
             public func a(name: MyAssembly.A_ResolutionKey, string: String, file: StaticString = #fileID, function: StaticString = #function, line: UInt = #line) -> A {
-                knitUnwrap(unsafeResolver.resolve(A.self, name: name.rawValue, argument: string), callsiteFile: file, callsiteFunction: function, callsiteLine: line)
+                let resolver = unsafeResolver(file: file, function: function, line: line)
+                return knitUnwrap(resolver.resolve(A.self, name: name.rawValue, argument: string), callsiteFile: file, callsiteFunction: function, callsiteLine: line)
             }
             """
         )
@@ -144,7 +155,8 @@ final class TypeSafetySourceFileTests: XCTestCase {
             ),
             """
             public func a(arg: String, file: StaticString = #fileID, function: StaticString = #function, line: UInt = #line) -> A {
-                knitUnwrap(unsafeResolver.resolve(A.self, argument: arg), callsiteFile: file, callsiteFunction: function, callsiteLine: line)
+                let resolver = unsafeResolver(file: file, function: function, line: line)
+                return knitUnwrap(resolver.resolve(A.self, argument: arg), callsiteFile: file, callsiteFunction: function, callsiteLine: line)
             }
             """
         )
@@ -161,7 +173,8 @@ final class TypeSafetySourceFileTests: XCTestCase {
             """
             #if SOME_FLAG
             public func a(file: StaticString = #fileID, function: StaticString = #function, line: UInt = #line) -> A {
-                knitUnwrap(unsafeResolver.resolve(A.self), callsiteFile: file, callsiteFunction: function, callsiteLine: line)
+                let resolver = unsafeResolver(file: file, function: function, line: line)
+                return knitUnwrap(resolver.resolve(A.self), callsiteFile: file, callsiteFunction: function, callsiteLine: line)
             }
             #endif
             """
@@ -179,12 +192,14 @@ final class TypeSafetySourceFileTests: XCTestCase {
             """
             #if SOME_FLAG
             public func a(file: StaticString = #fileID, function: StaticString = #function, line: UInt = #line) -> A {
-                knitUnwrap(unsafeResolver.resolve(A.self), callsiteFile: file, callsiteFunction: function, callsiteLine: line)
+                let resolver = unsafeResolver(file: file, function: function, line: line)
+                return knitUnwrap(resolver.resolve(A.self), callsiteFile: file, callsiteFunction: function, callsiteLine: line)
             }
             #endif
             #if SOME_FLAG
             public func fooAlias(file: StaticString = #fileID, function: StaticString = #function, line: UInt = #line) -> A {
-                knitUnwrap(unsafeResolver.resolve(A.self), callsiteFile: file, callsiteFunction: function, callsiteLine: line)
+                let resolver = unsafeResolver(file: file, function: function, line: line)
+                return knitUnwrap(resolver.resolve(A.self), callsiteFile: file, callsiteFunction: function, callsiteLine: line)
             }
             #endif
             """
@@ -200,7 +215,8 @@ final class TypeSafetySourceFileTests: XCTestCase {
             ),
             """
             @_spi(Testing) public func a(file: StaticString = #fileID, function: StaticString = #function, line: UInt = #line) -> A {
-                knitUnwrap(unsafeResolver.resolve(A.self), callsiteFile: file, callsiteFunction: function, callsiteLine: line)
+                let resolver = unsafeResolver(file: file, function: function, line: line)
+                return knitUnwrap(resolver.resolve(A.self), callsiteFile: file, callsiteFunction: function, callsiteLine: line)
             }
             """
         )
@@ -214,10 +230,12 @@ final class TypeSafetySourceFileTests: XCTestCase {
             ),
             """
             public func a(file: StaticString = #fileID, function: StaticString = #function, line: UInt = #line) -> A {
-                knitUnwrap(unsafeResolver.resolve(A.self), callsiteFile: file, callsiteFunction: function, callsiteLine: line)
+                let resolver = unsafeResolver(file: file, function: function, line: line)
+                return knitUnwrap(resolver.resolve(A.self), callsiteFile: file, callsiteFunction: function, callsiteLine: line)
             }
             public func fooAlias(file: StaticString = #fileID, function: StaticString = #function, line: UInt = #line) -> A {
-                knitUnwrap(unsafeResolver.resolve(A.self), callsiteFile: file, callsiteFunction: function, callsiteLine: line)
+                let resolver = unsafeResolver(file: file, function: function, line: line)
+                return knitUnwrap(resolver.resolve(A.self), callsiteFile: file, callsiteFunction: function, callsiteLine: line)
             }
             """
         )
@@ -402,7 +420,8 @@ final class TypeSafetySourceFileTests: XCTestCase {
         /// Generated from ``MainActorAssembly``
         extension Resolver {
             @MainActor func serviceA(file: StaticString = #fileID, function: StaticString = #function, line: UInt = #line) -> ServiceA {
-                knitUnwrap(unsafeResolver.resolve(ServiceA.self), callsiteFile: file, callsiteFunction: function, callsiteLine: line)
+                let resolver = unsafeResolver(file: file, function: function, line: line)
+                return knitUnwrap(resolver.resolve(ServiceA.self), callsiteFile: file, callsiteFunction: function, callsiteLine: line)
             }
         }
         extension MainActorAssembly {
@@ -435,11 +454,13 @@ final class TypeSafetySourceFileTests: XCTestCase {
         /// Generated from ``ModuleAssembly``
         extension Resolver {
             func serviceA(name: ModuleAssembly.ServiceA_ResolutionKey, file: StaticString = #fileID, function: StaticString = #function, line: UInt = #line) -> ServiceA {
-                knitUnwrap(unsafeResolver.resolve(ServiceA.self, name: name.rawValue), callsiteFile: file, callsiteFunction: function, callsiteLine: line)
+                let resolver = unsafeResolver(file: file, function: function, line: line)
+                return knitUnwrap(resolver.resolve(ServiceA.self, name: name.rawValue), callsiteFile: file, callsiteFunction: function, callsiteLine: line)
             }
             #if RELEASE
             func serviceB(name: ModuleAssembly.ServiceB_ResolutionKey, file: StaticString = #fileID, function: StaticString = #function, line: UInt = #line) -> ServiceB {
-                knitUnwrap(unsafeResolver.resolve(ServiceB.self, name: name.rawValue), callsiteFile: file, callsiteFunction: function, callsiteLine: line)
+                let resolver = unsafeResolver(file: file, function: function, line: line)
+                return knitUnwrap(resolver.resolve(ServiceB.self, name: name.rawValue), callsiteFile: file, callsiteFunction: function, callsiteLine: line)
             }
             #endif
         }

--- a/Tests/KnitTests/AbstractRegistrationTests.swift
+++ b/Tests/KnitTests/AbstractRegistrationTests.swift
@@ -12,7 +12,7 @@ final class AbstractRegistrationTests: XCTestCase {
     func testMissingRegistration() {
         let swinjectContainer = Swinject.Container()
         let container = ContainerManager(swinjectContainer: swinjectContainer).register(TestResolver.self)
-        let abstractRegistrations = container._unwrappedSwinjectContainer.registerAbstractContainer()
+        let abstractRegistrations = container._unwrappedSwinjectContainer().registerAbstractContainer()
         container.registerAbstract(String.self)
         container.registerAbstract(String.self, name: "test")
         container.registerAbstract(Optional<Int>.self)
@@ -32,7 +32,7 @@ final class AbstractRegistrationTests: XCTestCase {
     func testFilledRegistrations() {
         let swinjectContainer = Swinject.Container()
         let container = ContainerManager(swinjectContainer: swinjectContainer).register(TestResolver.self)
-        let abstractRegistrations = container._unwrappedSwinjectContainer.registerAbstractContainer()
+        let abstractRegistrations = container._unwrappedSwinjectContainer().registerAbstractContainer()
         container.registerAbstract(String.self)
         container.register(String.self) { _ in "Test" }
 
@@ -41,14 +41,14 @@ final class AbstractRegistrationTests: XCTestCase {
         container.register(Optional<Int>.self) { _ in 1 }
 
         XCTAssertNoThrow(try abstractRegistrations.validate())
-        XCTAssertEqual(container._unwrappedSwinjectContainer.resolve(String.self), "Test")
-        XCTAssertEqual(container._unwrappedSwinjectContainer.resolve(Optional<Int>.self), 1)
+        XCTAssertEqual(container._unwrappedSwinjectContainer().resolve(String.self), "Test")
+        XCTAssertEqual(container._unwrappedSwinjectContainer().resolve(Optional<Int>.self), 1)
     }
 
     func testNamedRegistrations() {
         let swinjectContainer = Swinject.Container()
         let container = ContainerManager(swinjectContainer: swinjectContainer).register(TestResolver.self)
-        let abstractRegistrations = container._unwrappedSwinjectContainer.registerAbstractContainer()
+        let abstractRegistrations = container._unwrappedSwinjectContainer().registerAbstractContainer()
         container.registerAbstract(String.self)
         container.registerAbstract(String.self, name: "test")
 
@@ -65,7 +65,7 @@ final class AbstractRegistrationTests: XCTestCase {
     func testPreRegistered() {
         let swinjectContainer = Swinject.Container()
         let container = ContainerManager(swinjectContainer: swinjectContainer).register(TestResolver.self)
-        let abstractRegistrations = container._unwrappedSwinjectContainer.registerAbstractContainer()
+        let abstractRegistrations = container._unwrappedSwinjectContainer().registerAbstractContainer()
         container.register(String.self) { _ in "Test" }
         container.registerAbstract(String.self)
         XCTAssertNoThrow(try abstractRegistrations.validate())
@@ -168,6 +168,6 @@ private extension Knit.Container {
             file: file,
             concurrency: concurrency
         )
-        _unwrappedSwinjectContainer.addAbstractRegistration(registration)
+        _unwrappedSwinjectContainer().addAbstractRegistration(registration)
     }
 }

--- a/Tests/KnitTests/MainActorTests.swift
+++ b/Tests/KnitTests/MainActorTests.swift
@@ -114,7 +114,7 @@ private final class TestAssembly: AutoInitModuleAssembly {
         container.register(
             Future<CustomGlobalActorClass, Never>.self,
             mainActorFactory: { @MainActor resolver in
-                let mainClassA = resolver.unsafeResolver.resolve(MainClassA.self)!
+                let mainClassA = resolver.unsafeResolver(file: #filePath, function: #function, line: #line).resolve(MainClassA.self)!
 
                 return Future<CustomGlobalActorClass, Never>() { promise in
                     let customGlobalActorClass = await CustomGlobalActorClass(
@@ -137,10 +137,11 @@ private final class TestAssembly: AutoInitModuleAssembly {
         container.register(
             FinalConsumer.self,
             mainActorFactory: { @MainActor resolver in
-                let actorA = resolver.unsafeResolver.resolve(ActorA.self)!
-                let mainClassA = resolver.unsafeResolver.resolve(MainClassA.self)!
-                let customGlobalActorClass = resolver.unsafeResolver.resolve(Future<CustomGlobalActorClass, Never>.self)!
-                let asyncInitClass = resolver.unsafeResolver.resolve(Future<AsyncInitClass, Never>.self)!
+                let r = resolver.unsafeResolver(file: #filePath, function: #function, line: #line)
+                let actorA = r.resolve(ActorA.self)!
+                let mainClassA = r.resolve(MainClassA.self)!
+                let customGlobalActorClass = r.resolve(Future<CustomGlobalActorClass, Never>.self)!
+                let asyncInitClass = r.resolve(Future<AsyncInitClass, Never>.self)!
                 return FinalConsumer(
                     actorA: actorA,
                     mainClassA: mainClassA,

--- a/Tests/KnitTests/ModuleAssemblerTests.swift
+++ b/Tests/KnitTests/ModuleAssemblerTests.swift
@@ -234,7 +234,7 @@ private struct Assembly5: AutoInitModuleAssembly {
 private extension TestResolver {
 
     func service2() -> Service2 {
-        unsafeResolver.resolve(Service2.self)!
+        unsafeResolver(file: #filePath, function: #function, line: #line).resolve(Service2.self)!
     }
 
 }

--- a/Tests/KnitTests/ServiceCollectorTests.swift
+++ b/Tests/KnitTests/ServiceCollectorTests.swift
@@ -88,7 +88,7 @@ final class ServiceCollectorTests: XCTestCase {
     func test_registerIntoCollection() {
         let swinjectContainer = Swinject.Container()
         let container = ContainerManager(swinjectContainer: swinjectContainer).register(Any.self)
-        container._unwrappedSwinjectContainer.addBehavior(ServiceCollector())
+        container._unwrappedSwinjectContainer().addBehavior(ServiceCollector())
 
         // Register some services into a collection
         container.registerIntoCollection(ServiceProtocol.self) { _ in ServiceA() }
@@ -115,7 +115,7 @@ final class ServiceCollectorTests: XCTestCase {
     func test_registerIntoCollection_emptyWithBehavior() {
         let swinjectContainer = Swinject.Container()
         let container = ContainerManager(swinjectContainer: swinjectContainer).register(Any.self)
-        container._unwrappedSwinjectContainer.addBehavior(ServiceCollector())
+        container._unwrappedSwinjectContainer().addBehavior(ServiceCollector())
 
         let collection = container.resolveCollection(ServiceProtocol.self)
         XCTAssertEqual(collection.entries.count, 0)
@@ -136,7 +136,7 @@ final class ServiceCollectorTests: XCTestCase {
     func test_registerIntoCollection_doesntConflictWithArray() throws {
         let swinjectContainer = Swinject.Container()
         let container = ContainerManager(swinjectContainer: swinjectContainer).register(Any.self)
-        container._unwrappedSwinjectContainer.addBehavior(ServiceCollector())
+        container._unwrappedSwinjectContainer().addBehavior(ServiceCollector())
 
         // Register A into a collection
         container.registerIntoCollection(ServiceProtocol.self) { _ in ServiceA() }
@@ -150,7 +150,7 @@ final class ServiceCollectorTests: XCTestCase {
         XCTAssert(collection.entries.first is ServiceA)
 
         // Resolving the array should produce B
-        let array = try XCTUnwrap(container._unwrappedSwinjectContainer.resolve([ServiceProtocol].self))
+        let array = try XCTUnwrap(container._unwrappedSwinjectContainer().resolve([ServiceProtocol].self))
         XCTAssertEqual(array.count, 1)
         XCTAssert(array.first is ServiceB)
     }
@@ -159,7 +159,7 @@ final class ServiceCollectorTests: XCTestCase {
     func test_registerIntoCollection_doesntImplicitlyAggregateInstances() throws {
         let swinjectContainer = Swinject.Container()
         let container = ContainerManager(swinjectContainer: swinjectContainer).register(Any.self)
-        container._unwrappedSwinjectContainer.addBehavior(ServiceCollector())
+        container._unwrappedSwinjectContainer().addBehavior(ServiceCollector())
 
         // Register A and B into a collection
         _ = container.registerIntoCollection(ServiceProtocol.self) { _ in ServiceA() }
@@ -175,14 +175,14 @@ final class ServiceCollectorTests: XCTestCase {
         XCTAssert(collection.entries.last is ServiceB)
 
         // Resolving the service individually should produce B
-        XCTAssert(container.unsafeResolver.resolve(ServiceProtocol.self) is ServiceB)
+        XCTAssert(container._unwrappedSwinjectContainer().resolve(ServiceProtocol.self) is ServiceB)
     }
 
     @MainActor
     func test_registerIntoCollection_allowsDuplicates() {
         let swinjectContainer = Swinject.Container()
         let container = ContainerManager(swinjectContainer: swinjectContainer).register(Any.self)
-        container._unwrappedSwinjectContainer.addBehavior(ServiceCollector())
+        container._unwrappedSwinjectContainer().addBehavior(ServiceCollector())
 
         // Register some duplicate services
         _ = container.registerIntoCollection(ServiceProtocol.self) { _ in CustomService(name: "Dry Cleaning") }
@@ -203,7 +203,7 @@ final class ServiceCollectorTests: XCTestCase {
     func test_registerIntoCollection_supportsTransientScopedObjects() throws {
         let swinjectContainer = Swinject.Container()
         let container = ContainerManager(swinjectContainer: swinjectContainer).register(Any.self)
-        container._unwrappedSwinjectContainer.addBehavior(ServiceCollector())
+        container._unwrappedSwinjectContainer().addBehavior(ServiceCollector())
 
         // Register a service with the `transient` scope.
         // It should be recreated each time the ServiceCollection is resolved.
@@ -224,7 +224,7 @@ final class ServiceCollectorTests: XCTestCase {
     func test_registerIntoCollection_supportsContainerScopedObjects() throws {
         let swinjectContainer = Swinject.Container()
         let container = ContainerManager(swinjectContainer: swinjectContainer).register(Any.self)
-        container._unwrappedSwinjectContainer.addBehavior(ServiceCollector())
+        container._unwrappedSwinjectContainer().addBehavior(ServiceCollector())
 
         // Register a service with the `container` scope.
         // The same instance should be shared, even if the collection is resolved many times.
@@ -245,7 +245,7 @@ final class ServiceCollectorTests: XCTestCase {
     func test_registerIntoCollection_supportsWeakScopedObjects() throws {
         let swinjectContainer = Swinject.Container()
         let container = ContainerManager(swinjectContainer: swinjectContainer).register(Any.self)
-        container._unwrappedSwinjectContainer.addBehavior(ServiceCollector())
+        container._unwrappedSwinjectContainer().addBehavior(ServiceCollector())
 
         // Register a service with the `weak` scope.
         // The same instance should be shared while the instance is alive.

--- a/Tests/KnitTests/SynchronizationTests.swift
+++ b/Tests/KnitTests/SynchronizationTests.swift
@@ -90,11 +90,11 @@ private protocol TestScopedResolver: Knit.Resolver {
 }
 extension TestScopedResolver {
     fileprivate func service1() -> Service1 {
-        self.unsafeResolver.resolve(Service1.self)!
+        self.unsafeResolver(file: #filePath, function: #function, line: #line).resolve(Service1.self)!
     }
 
     fileprivate func service2() -> Service2 {
-        self.unsafeResolver.resolve(Service2.self)!
+        self.unsafeResolver(file: #filePath, function: #function, line: #line).resolve(Service2.self)!
     }
 }
 extension Container<TestScopedResolver>: TestScopedResolver {}


### PR DESCRIPTION
Add file, function, and line information from call site to released container fatalError. This will allow individual retain cycles to be distinguished from each other in crash reporting.