### PR TITLE
Turn Knit.Resolver into a class type

### DIFF
--- a/Sources/Knit/Container.swift
+++ b/Sources/Knit/Container.swift
@@ -11,24 +11,11 @@ import Swinject
 
  The Knit.Container also performs the function of a weak wrapper of the `Swinject.Container`.
  */
-public class Container<TargetResolver>: Knit.Resolver {
+public class Container<TargetResolver: Resolver> {
 
     // MARK: - Knit.Resolver
 
-    public var resolver: TargetResolver {
-        self as! TargetResolver
-    }
-
-    /// Returns `true` if the backing container is still available in memory, otherwise `false`.
-    public var isAvailable: Bool {
-        _swinjectContainer != nil
-    }
-
-    // MARK: - Swinject.Resolver
-
-    public func unsafeResolver(file: StaticString, function: StaticString, line: UInt) -> Swinject.Resolver {
-        _unwrappedSwinjectContainer(file: file, function: function, line: line)
-    }
+    public let resolver: TargetResolver
 
     // MARK: - Private Properties
 
@@ -39,6 +26,7 @@ public class Container<TargetResolver>: Knit.Resolver {
     // This should not be promoted from `fileprivate` access level.
     fileprivate init(_swinjectContainer: Swinject.Container) {
         self._swinjectContainer = _swinjectContainer
+        self.resolver = TargetResolver(_swinjectContainer: _swinjectContainer)
     }
 }
 

--- a/Sources/Knit/Module/ModuleAssembly.swift
+++ b/Sources/Knit/Module/ModuleAssembly.swift
@@ -7,7 +7,7 @@ import Swinject
 
 public protocol ModuleAssembly<TargetResolver> {
 
-    associatedtype TargetResolver
+    associatedtype TargetResolver: Resolver
 
     static var resolverType: Self.TargetResolver.Type { get }
 
@@ -41,9 +41,12 @@ public extension ModuleAssembly {
 
     static func scoped(_ dependencies: [any ModuleAssembly.Type]) -> [any ModuleAssembly.Type] {
         return dependencies.filter {
-            // Default the scoped implementation to match types directly
-            return self.resolverType == $0.resolverType
+            return self.resolverType.is($0.resolverType) 
         }
+    }
+
+    func usesResolver(_ resolverType: Resolver.Type) -> Bool {
+        return type(of: self).resolverType.equal(resolverType)
     }
 
     static var _assemblyFlags: [ModuleAssemblyFlags] {

--- a/Sources/Knit/Resolver.swift
+++ b/Sources/Knit/Resolver.swift
@@ -5,12 +5,50 @@
 import Foundation
 import Swinject
 
-/// This effectively removes all the unsafe resolve methods from the publicly available API.
-public protocol Resolver: AnyObject {
+open class Resolver {
+
+    private weak var _swinjectContainer: Swinject.Container?
 
     /// Returns `true` if the backing container is still available in memory, otherwise `false`.
-    var isAvailable: Bool { get }
+    public var isAvailable: Bool {
+        _swinjectContainer != nil
+    }
 
-    func unsafeResolver(file: StaticString, function: StaticString, line: UInt) -> Swinject.Resolver
+    // MARK: - Swinject.Resolver
+
+    public func unsafeResolver(file: StaticString, function: StaticString, line: UInt) -> Swinject.Resolver {
+        _unwrappedSwinjectContainer(file: file, function: function, line: line)
+    }
+
+    public required init(_swinjectContainer: Swinject.Container) {
+        self._swinjectContainer = _swinjectContainer
+    }
+
+    internal static func equal(_ resolverType: Resolver.Type) -> Bool {
+        return self == resolverType
+    }
+
+    public class func `is`(_ resolverType: Resolver.Type) -> Bool {
+        return self == resolverType
+    }
+}
+
+extension Resolver {
+
+    // Force unwraps the weak Container
+    func _unwrappedSwinjectContainer(
+        file: StaticString = #fileID,
+        function: StaticString = #function,
+        line: UInt = #line
+    ) -> Swinject.Container {
+        guard let _swinjectContainer else {
+            fatalError(
+                "\(function) incorrectly accessed the container for \(self) which has already been released",
+                file: file,
+                line: line
+            )
+        }
+        return _swinjectContainer
+    }
 
 }

--- a/Sources/Knit/ServiceCollection/Container+ServiceCollection.swift
+++ b/Sources/Knit/ServiceCollection/Container+ServiceCollection.swift
@@ -30,7 +30,7 @@ extension Container {
             name: makeUniqueCollectionRegistrationName(),
             factory: { r in
                 MainActor.assumeIsolated {
-                    let resolver = r.resolve(Container<TargetResolver>.self)! as! TargetResolver
+                    let resolver = r.resolve(Container<TargetResolver>.self)!.resolver
                     return factory(resolver)
                 }
             }

--- a/Tests/KnitTests/ModuleAssemblyScopingTests.swift
+++ b/Tests/KnitTests/ModuleAssemblyScopingTests.swift
@@ -23,15 +23,13 @@ final class ModuleAssemblyScopingTests: XCTestCase {
 
 }
 
-private protocol ParentResolver: Resolver {}
-private protocol ChildResolver: Resolver {}
-private protocol OtherResolver: Resolver {}
-
-extension ChildResolver {
-    static func contains(resolver: Resolver.Type) -> Bool {
-        return resolver == self || resolver == ParentResolver.self
+private class ParentResolver: Resolver {}
+private final class ChildResolver: ParentResolver {
+    override class func `is`(_ resolverType: Resolver.Type) -> Bool {
+        return super.is(resolverType) || resolverType == ParentResolver.self
     }
 }
+private final class OtherResolver: Resolver {}
 
 private struct Assembly1: GeneratedModuleAssembly {
     typealias TargetResolver = ParentResolver
@@ -55,16 +53,4 @@ private struct Assembly4: GeneratedModuleAssembly {
     typealias TargetResolver = ParentResolver
     static var generatedDependencies: [any ModuleAssembly.Type] { [Assembly1.self] }
     func assemble(container: Container<Self.TargetResolver>) {}
-}
-
-private extension ModuleAssembly {
-    // Override the default scoping function to allow assemblies using ParentResolver to be included in ChildResolver
-    static func scoped(_ dependencies: [any ModuleAssembly.Type]) -> [any ModuleAssembly.Type] {
-        return dependencies.filter {
-            if self.resolverType == ChildResolver.self && $0.resolverType == ParentResolver.self {
-                return true
-            }
-            return self.resolverType == $0.resolverType
-        }
-    }
 }

--- a/Tests/KnitTests/ScopedModuleAssemblerTests.swift
+++ b/Tests/KnitTests/ScopedModuleAssemblerTests.swift
@@ -66,7 +66,7 @@ private struct Assembly1: AutoInitModuleAssembly {
     func assemble(container: Knit.Container<Self.TargetResolver>) { }
 }
 
-protocol OutsideResolver: Swinject.Resolver { }
+class OutsideResolver: Knit.Resolver { }
 
 private struct Assembly2: AutoInitModuleAssembly {
     typealias TargetResolver = OutsideResolver

--- a/Tests/KnitTests/SynchronizationTests.swift
+++ b/Tests/KnitTests/SynchronizationTests.swift
@@ -84,11 +84,7 @@ private final class Service2 {
     }
 }
 
-private protocol TestScopedResolver: Knit.Resolver {
-    func service1() -> Service1
-    func service2() -> Service2
-}
-extension TestScopedResolver {
+final class TestScopedResolver: Knit.Resolver {
     fileprivate func service1() -> Service1 {
         self.unsafeResolver(file: #filePath, function: #function, line: #line).resolve(Service1.self)!
     }
@@ -97,4 +93,3 @@ extension TestScopedResolver {
         self.unsafeResolver(file: #filePath, function: #function, line: #line).resolve(Service2.self)!
     }
 }
-extension Container<TestScopedResolver>: TestScopedResolver {}

--- a/Tests/KnitTests/TestResolver.swift
+++ b/Tests/KnitTests/TestResolver.swift
@@ -5,9 +5,7 @@
 @testable import Knit
 import Swinject
 
-protocol TestResolver: Knit.Resolver { }
-
-extension Knit.Container<TestResolver>: TestResolver {}
+final class TestResolver: Knit.Resolver { }
 
 extension ModuleAssembly {
 


### PR DESCRIPTION
This changes the relationship between Knit `Container` and `Resolver` types. 

**Background**

In Swinject the `Resolver` is a protocol implemented by `Container` which is limited to only resolving services rather than being able to register them. When Knit created the wrapper types it followed the same pattern. 
Knit also includes the ability to define parent/child relationships between Resolvers but due to how protocols were used this required that all Containers would conform to all Resolvers which causes issues when trying to cast. The resolver definition ends up looking like

```swift
public protocol AppResolver: Knit.Resolver {}
public protocol AccountResolver: AppResolver {}
// Conform Container to all resolvers
extension Knit.Container: AppResolver, AccountResolver {}
```

**Solution**
Converting `Resolver` to a class type allows creating a more natural hierarchy between resolvers so it's possible to do `(resolver as? AccountResolver)?.myService()` and have it work as expected. This does prevent the Knit Container from conforming to the Resolver but the container shouldn't be used for resolution anyway.
Resolver definitions now no longer require applying the conformance to the container.

```swift
public class AppResolver: Knit.Resolver {}
public class AccountResolver: AppResolver {}
```


