### PR TITLE
Add MemberTypeSyntax support for Resolvable macro

### DIFF
--- a/Sources/KnitMacrosImplementations/ResolvableMacro.swift
+++ b/Sources/KnitMacrosImplementations/ResolvableMacro.swift
@@ -114,6 +114,8 @@ public struct ResolvableMacro: PeerMacro {
             return TypeInformation(name: "\(type.wrappedType.description)?")
         } else if let type = typeSyntax.as(SomeOrAnyTypeSyntax.self) {
             return TypeInformation(name: type.description)
+        } else if let type = typeSyntax.as(MemberTypeSyntax.self) {
+            return TypeInformation(name: type.description)
         }
         throw DiagnosticsError(
             diagnostics: [.init(node: typeSyntax, message:  Error.invalidParamType(typeSyntax.description))]

--- a/Tests/KnitMacrosTests/ResolvableTests.swift
+++ b/Tests/KnitMacrosTests/ResolvableTests.swift
@@ -324,4 +324,45 @@ final class ResolvableTests: XCTestCase {
             macros: testMacros
         )
     }
+
+    func test_macro_expansion_nested_type() throws {
+        assertMacroExpansion(
+            """
+            @Resolvable<Resolver>
+            init(arg1: MyType.Nested) {}
+            """,
+            expandedSource: """
+            
+            init(arg1: MyType.Nested) {}
+
+            static func make(resolver: Resolver) -> Self {
+                 return .init(
+                     arg1: resolver.nested()
+                 )
+            }
+            """,
+            macros: testMacros
+        )
+    }
+
+    func test_macro_expansion_nested_type_argument() throws {
+        assertMacroExpansion(
+            """
+            @Resolvable<Resolver>
+            init(@Argument arg1: MyType.Nested) {}
+            """,
+            expandedSource: """
+            
+            init(@Argument arg1: MyType.Nested) {}
+
+            static func make(resolver: Resolver, arg1: MyType.Nested) -> Self {
+                 return .init(
+                     arg1: arg1
+                 )
+            }
+            """,
+            macros: testMacros
+        )
+    }
+
 }


### PR DESCRIPTION
Allows for nested types that contain a `.`