### PR TITLE
Add strict abstract option to gen command

### DIFF
--- a/Sources/KnitCodeGen/ConfigurationSet.swift
+++ b/Sources/KnitCodeGen/ConfigurationSet.swift
@@ -187,11 +187,28 @@ extension ConfigurationSet {
             }
     }
 
+    public func validateAbstractRegistrations() throws {
+        for assembly in assemblies {
+            if assembly.assemblyType == .abstractAssembly {
+                continue
+            }
+            for registration in assembly.registrations {
+                if registration.functionName == .registerAbstract {
+                    throw ConfigurationSetParsingError.abstractRegistrationViolation(
+                        service: registration.service,
+                        assembly: assembly.assemblyName
+                    )
+                }
+            }
+        }
+    }
+
 }
 
 enum ConfigurationSetParsingError: LocalizedError {
 
     case detectedDuplicateRegistration(service: String, name: String?, arguments: [String])
+    case abstractRegistrationViolation(service: String, assembly: String)
 
     var errorDescription: String? {
         switch self {
@@ -202,6 +219,12 @@ enum ConfigurationSetParsingError: LocalizedError {
                     Name (optional): \(name ?? "`nil`")
                     Arguments: \(arguments)
                     """
+        case let .abstractRegistrationViolation(service, assembly):
+            return """
+            Detected abstract registration in non abstract assembly
+            Service type: \(service)
+            Assembly: \(assembly)
+            """
         }
     }
 

--- a/Sources/knit-cli/GenCommand.swift
+++ b/Sources/knit-cli/GenCommand.swift
@@ -65,6 +65,9 @@ struct GenCommand: ParsableCommand {
                   """)
     var moduleNameRegex: String?
 
+    @Flag(help: "When true, only abstract modules will be allowed to contain abstract registrations")
+    var strictAbstract: Bool = false
+
     public init() {}
 
     public func run() throws {
@@ -83,6 +86,9 @@ struct GenCommand: ParsableCommand {
             )
 
             try parsedConfig.validateNoDuplicateRegistrations()
+            if strictAbstract {
+                try parsedConfig.validateAbstractRegistrations()
+            }
 
             if let jsonDataOutputPath {
                 let data = try JSONEncoder().encode(parsedConfig.allAssemblies)

--- a/Tests/KnitCodeGenTests/ConfigurationSetTests.swift
+++ b/Tests/KnitCodeGenTests/ConfigurationSetTests.swift
@@ -303,6 +303,7 @@ final class ConfigurationSetTests: XCTestCase {
             moduleDependencies: []
         )
         XCTAssertNoThrow(try configSet.validateNoDuplicateRegistrations())
+        XCTAssertNoThrow(try configSet.validateAbstractRegistrations())
     }
 
     func testValidateDuplicates_multipleTargetResolvers() {
@@ -316,6 +317,21 @@ final class ConfigurationSetTests: XCTestCase {
         )
 
         XCTAssertNoThrow(try configSet.validateNoDuplicateRegistrations())
+        XCTAssertNoThrow(try configSet.validateAbstractRegistrations())
+    }
+
+    func testValidateAbstractRegistrations() {
+        var config1 = Configuration(
+            assemblyName: "Assembly1",
+            moduleName: "Module1",
+            registrations: [
+                .init(service: "RealService", functionName: .register),
+                .init(service: "AbstractService", functionName: .registerAbstract),
+            ],
+            targetResolver: "TestResolver"
+        )
+        let set = ConfigurationSet(assemblies: [config1], externalTestingAssemblies: [], moduleDependencies: [])
+        XCTAssertThrowsError(try set.validateAbstractRegistrations())
     }
 
     func testPerformanceGenDisabled() {


### PR DESCRIPTION
This adds optional enforcement that all abstract registrations are declared in abstract assemblies.