### PR TITLE
Release assemblies after the assembler finishes

### DIFF
--- a/Sources/Knit/Module/DependencyBuilder.swift
+++ b/Sources/Knit/Module/DependencyBuilder.swift
@@ -57,6 +57,12 @@ final class DependencyBuilder {
         }
     }
 
+    // The DependencyBuilder stays in memory for debugging, but the assemblies can be released
+    internal func releaseAssemblies() {
+        assemblies = []
+        inputModules = []
+    }
+
     private func instantiate(moduleType: any ModuleAssembly.Type) throws -> any ModuleAssembly {
         let inputModule = inputModules.first(where: { type(of: $0) == moduleType})
         let existingType = inputModules.first { assembly in

--- a/Sources/Knit/Module/ModuleAssembler.swift
+++ b/Sources/Knit/Module/ModuleAssembler.swift
@@ -19,8 +19,8 @@ public final class ModuleAssembler {
     public var resolver: Swinject.Resolver { _swinjectContainer }
 
     // Module types that were registered into the container owned by this ModuleAssembler
-    var registeredModules: [any ModuleAssembly.Type] {
-        builder.assemblies.map { type(of: $0) }
+    var registeredReferences: [AssemblyReference] {
+        builder.assemblyCache.assemblyList
     }
 
     let builder: DependencyBuilder
@@ -136,6 +136,7 @@ public final class ModuleAssembler {
         }
 
         abstractRegistrations.reset()
+        builder.releaseAssemblies()
     }
 
     func isRegistered<T: ModuleAssembly>(_ type: T.Type) -> Bool {

--- a/Tests/KnitTests/ModuleAssemblerTests.swift
+++ b/Tests/KnitTests/ModuleAssemblerTests.swift
@@ -33,9 +33,9 @@ final class ModuleAssemblerTests: XCTestCase {
         let assembler = try ModuleAssembler(
             _modules: [Assembly1()]
         )
-        XCTAssertTrue(assembler.registeredModules.contains(where: {$0 == Assembly1.self}))
-        XCTAssertTrue(assembler.registeredModules.contains(where: {$0 == Assembly2.self}))
-        XCTAssertFalse(assembler.registeredModules.contains(where: {$0 == Assembly3.self}))
+        XCTAssertTrue(assembler.registeredReferences.contains(where: {$0.type == Assembly1.self}))
+        XCTAssertTrue(assembler.registeredReferences.contains(where: {$0.type == Assembly2.self}))
+        XCTAssertFalse(assembler.registeredReferences.contains(where: {$0.type == Assembly3.self}))
     }
 
     @MainActor
@@ -60,7 +60,7 @@ final class ModuleAssemblerTests: XCTestCase {
         XCTAssertTrue(child.isRegistered(Assembly3.self))
         XCTAssertTrue(child.isRegistered(Assembly2.self))
 
-        XCTAssertFalse(child.registeredModules.contains(where: {$0 == Assembly1.self}))
+        XCTAssertFalse(child.registeredReferences.contains(where: {$0.type == Assembly1.self}))
 
         XCTAssertNotNil(child.resolver.resolve(Service1.self))
         XCTAssertNil(parent.resolver.resolve(Service3.self))

--- a/Tests/KnitTests/ModuleAssemblyOverrideTests.swift
+++ b/Tests/KnitTests/ModuleAssemblyOverrideTests.swift
@@ -53,7 +53,7 @@ final class ModuleAssemblyOverrideTests: XCTestCase {
             _modules: [Assembly2()],
             overrideBehavior: .useDefaultOverrides
         )
-        XCTAssertTrue(assembler.registeredModules.contains(where: {$0 == Assembly1Fake.self}))
+        XCTAssertTrue(assembler.registeredReferences.contains(where: {$0.type == Assembly1Fake.self}))
         XCTAssertTrue(assembler.isRegistered(Assembly1Fake.self))
         // Treat Assembly1 as being registered because the mock is
         XCTAssertTrue(assembler.isRegistered(Assembly1.self))
@@ -95,7 +95,7 @@ final class ModuleAssemblyOverrideTests: XCTestCase {
         let assembler = try ModuleAssembler(
             _modules: [Assembly2Fake()]
         )
-        XCTAssertFalse(assembler.registeredModules.contains(where: {$0 == Assembly2.self}))
+        XCTAssertFalse(assembler.registeredReferences.contains(where: {$0.type == Assembly2.self}))
         XCTAssertTrue(assembler.isRegistered(Assembly2.self))
         XCTAssertTrue(assembler.isRegistered(Assembly2Fake.self))
     }
@@ -142,7 +142,7 @@ final class ModuleAssemblyOverrideTests: XCTestCase {
         let parent = try ModuleAssembler(_modules: [NonAutoOverride()])
         let child = try ModuleAssembler(parent: parent, _modules: [Assembly1()], overrideBehavior: .disableDefaultOverrides)
         XCTAssertTrue(child.isRegistered(Assembly1.self))
-        XCTAssertTrue(child.registeredModules.isEmpty)
+        XCTAssertTrue(child.registeredReferences.isEmpty)
 
         XCTAssertEqual(
             child.resolver._dependencyTree().debugDescription,

--- a/Tests/KnitTests/ScopedModuleAssemblerTests.swift
+++ b/Tests/KnitTests/ScopedModuleAssemblerTests.swift
@@ -13,7 +13,7 @@ final class ScopedModuleAssemblerTests: XCTestCase {
     func testScoping() throws {
         // Allows modules at the same level to be registered
         let assembler = try ScopedModuleAssembler<TestResolver>(_modules: [Assembly1()])
-        XCTAssertEqual(assembler.internalAssembler.registeredModules.count, 1)
+        XCTAssertEqual(assembler.internalAssembler.registeredReferences.count, 1)
     }
 
     @MainActor
@@ -23,7 +23,7 @@ final class ScopedModuleAssemblerTests: XCTestCase {
             parent: parent.internalAssembler,
             _modules: [Assembly3()]
         )
-        XCTAssertEqual(assembler.internalAssembler.registeredModules.count, 1)
+        XCTAssertEqual(assembler.internalAssembler.registeredReferences.count, 1)
     }
 
     @MainActor


### PR DESCRIPTION
`DependencyBuilder` collects assemblies for ModuleAssembler to assemble. But once that is complete there isn't a need to hold onto them any longer. Assemblies are usually lightweight so this doesn't save much memory, but does keep the memory graph cleaner.