### PR TITLE
Force strict abstract assemblies

### DIFF
--- a/Sources/KnitCodeGen/AssemblyParser.swift
+++ b/Sources/KnitCodeGen/AssemblyParser.swift
@@ -110,7 +110,7 @@ public struct AssemblyParser {
         }
 
         guard let assemblyType = classDeclVisitor.assemblyType else {
-            throw AssemblyParsingError.missingAssemblyType
+            throw AssemblyParsingError.missingAssemblyType(classDeclVisitor.assemblyName)
         }
 
         let replaces: [String]

--- a/Sources/KnitCodeGen/AssemblyParsing.swift
+++ b/Sources/KnitCodeGen/AssemblyParsing.swift
@@ -155,7 +155,7 @@ class ClassDeclVisitor: SyntaxVisitor, IfConfigVisitor {
         do {
             var (registrations, registrationsIntoCollections) = try node.getRegistrations(
                 defaultDirectives: directives,
-                abstractOnly: assemblyType == .abstractAssembly
+                assemblyType: assemblyType
             )
             registrations = registrations.map { registration in
                 var mutable = registration
@@ -286,7 +286,7 @@ extension NamedDeclSyntax {
 
 enum AssemblyParsingError: Error {
     case fileReadError(Error, path: String)
-    case missingAssemblyType
+    case missingAssemblyType(String)
     case missingTargetResolver
     case parsingError
     case noAssembliesFound(String)

--- a/Sources/KnitCodeGen/ConfigurationSet.swift
+++ b/Sources/KnitCodeGen/ConfigurationSet.swift
@@ -187,22 +187,6 @@ extension ConfigurationSet {
             }
     }
 
-    public func validateAbstractRegistrations() throws {
-        for assembly in assemblies {
-            if assembly.assemblyType == .abstractAssembly {
-                continue
-            }
-            for registration in assembly.registrations {
-                if registration.functionName == .registerAbstract {
-                    throw ConfigurationSetParsingError.abstractRegistrationViolation(
-                        service: registration.service,
-                        assembly: assembly.assemblyName
-                    )
-                }
-            }
-        }
-    }
-
 }
 
 enum ConfigurationSetParsingError: LocalizedError {

--- a/Sources/knit-cli/GenCommand.swift
+++ b/Sources/knit-cli/GenCommand.swift
@@ -65,9 +65,6 @@ struct GenCommand: ParsableCommand {
                   """)
     var moduleNameRegex: String?
 
-    @Flag(help: "When true, only abstract modules will be allowed to contain abstract registrations")
-    var strictAbstract: Bool = false
-
     public init() {}
 
     public func run() throws {
@@ -86,9 +83,6 @@ struct GenCommand: ParsableCommand {
             )
 
             try parsedConfig.validateNoDuplicateRegistrations()
-            if strictAbstract {
-                try parsedConfig.validateAbstractRegistrations()
-            }
 
             if let jsonDataOutputPath {
                 let data = try JSONEncoder().encode(parsedConfig.allAssemblies)

--- a/Tests/KnitCodeGenTests/AssemblyParsingTests.swift
+++ b/Tests/KnitCodeGenTests/AssemblyParsingTests.swift
@@ -667,6 +667,28 @@ final class AssemblyParsingTests: XCTestCase {
         )
     }
 
+    func testNonAbstractAssemblyAbstractRegistrations() throws {
+        let sourceFile: SourceFileSyntax = """
+            class MyAssembly: AutoInitModuleAssembly {
+                typealias TargetResolver = TestResolver
+                func assemble(container: Container) {
+                    container.registerAbstract(A.self) { }
+                }
+            }
+        """
+
+        _ = try assertParsesSyntaxTree(
+            sourceFile,
+            assertErrorsToPrint: { errors in
+                XCTAssertEqual(errors.count, 1)
+                XCTAssertEqual(
+                    errors.first?.localizedDescription,
+                    "`AutoInitModuleAssembly`'s cannot contain registerAbstract registrations"
+                )
+            }
+        )
+    }
+
     func testAssemblyReplaces() throws {
         let sourceFile: SourceFileSyntax = """
             class TestAssembly: ModuleAssembly {

--- a/Tests/KnitCodeGenTests/ConfigurationSetTests.swift
+++ b/Tests/KnitCodeGenTests/ConfigurationSetTests.swift
@@ -303,7 +303,6 @@ final class ConfigurationSetTests: XCTestCase {
             moduleDependencies: []
         )
         XCTAssertNoThrow(try configSet.validateNoDuplicateRegistrations())
-        XCTAssertNoThrow(try configSet.validateAbstractRegistrations())
     }
 
     func testValidateDuplicates_multipleTargetResolvers() {
@@ -317,21 +316,6 @@ final class ConfigurationSetTests: XCTestCase {
         )
 
         XCTAssertNoThrow(try configSet.validateNoDuplicateRegistrations())
-        XCTAssertNoThrow(try configSet.validateAbstractRegistrations())
-    }
-
-    func testValidateAbstractRegistrations() {
-        var config1 = Configuration(
-            assemblyName: "Assembly1",
-            moduleName: "Module1",
-            registrations: [
-                .init(service: "RealService", functionName: .register),
-                .init(service: "AbstractService", functionName: .registerAbstract),
-            ],
-            targetResolver: "TestResolver"
-        )
-        let set = ConfigurationSet(assemblies: [config1], externalTestingAssemblies: [], moduleDependencies: [])
-        XCTAssertThrowsError(try set.validateAbstractRegistrations())
     }
 
     func testPerformanceGenDisabled() {


### PR DESCRIPTION
The way I implemented this the first time helped to cleanup cash-ios but it didn't do a good job of surfacing the errors in a friendly way. This version raises errors in the same pathway for the `nonAbstract` error.

I realised that there are significant performance benefits possible by enforcing splitting out abstract assemblies so I got rid of it as a configurable parameter to allow deleting the replacement code in a future PR.