### PR TITLE
Add generated _uniqueIdentifier to assemblies

### DIFF
--- a/Sources/Knit/Module/DependencyBuilder.swift
+++ b/Sources/Knit/Module/DependencyBuilder.swift
@@ -48,7 +48,7 @@ final class DependencyBuilder {
             }
             let assembly = try instantiate(moduleType: ref.type)
             // Ensure the same assembly isn't added twice
-            let typeName = String(describing: type(of: assembly))
+            let typeName = type(of: assembly)._uniqueIdentifier
             guard !createdTypes.contains(typeName) else {
                 continue
             }

--- a/Sources/Knit/Module/ModuleAssembly.swift
+++ b/Sources/Knit/Module/ModuleAssembly.swift
@@ -29,6 +29,9 @@ public protocol ModuleAssembly<TargetResolver> {
 
     /// Creates an instance of this assembly if the assembly conforms to AutoInitModuleAssembly
     static func _autoInstantiate() -> (any ModuleAssembly)?
+
+    /// An identifier uniquely identifying the module. Defaults to String(describing: self)
+    static var _uniqueIdentifier: String { get }
 }
 
 public extension ModuleAssembly {
@@ -62,6 +65,10 @@ public extension ModuleAssembly {
             return autoInit.init()
         }
         return nil
+    }
+
+    static var _uniqueIdentifier: String {
+        String(describing: self)
     }
 }
 

--- a/Sources/KnitCodeGen/TypeSafetySourceFile.swift
+++ b/Sources/KnitCodeGen/TypeSafetySourceFile.swift
@@ -197,6 +197,10 @@ public enum TypeSafetySourceFile {
             isAutoInit = false
         }
 
+        let uniqueIdAccessorBlock = AccessorBlockSyntax(
+            accessors: .getter(.init(stringLiteral: "\"\(config.moduleName).\(config.assemblyName)\""))
+        )
+
         return try ExtensionDeclSyntax(
             extendedType: TypeSyntax(stringLiteral: config.assemblyName),
             memberBlockBuilder: {
@@ -205,6 +209,12 @@ public enum TypeSafetySourceFile {
                     name: "_assemblyFlags",
                     type: "[ModuleAssemblyFlags]",
                     accessorBlock: accessorBlock
+                )
+                VariableDeclSyntax.makeVar(
+                    keywords: [.public, .static],
+                    name: "_uniqueIdentifier",
+                    type: "String",
+                    accessorBlock: uniqueIdAccessorBlock
                 )
                 if isAutoInit {
                     try FunctionDeclSyntax("public static func _autoInstantiate() -> (any ModuleAssembly)? { \(raw: config.assemblyName)() }")

--- a/Tests/KnitCodeGenTests/ConfigurationSetTests.swift
+++ b/Tests/KnitCodeGenTests/ConfigurationSetTests.swift
@@ -37,6 +37,9 @@ final class ConfigurationSetTests: XCTestCase {
                 public static var _assemblyFlags: [ModuleAssemblyFlags] {
                     []
                 }
+                public static var _uniqueIdentifier: String {
+                    "Module1.Module1Assembly"
+                }
                 public static func _autoInstantiate() -> (any ModuleAssembly)? {
                     nil
                 }
@@ -56,6 +59,9 @@ final class ConfigurationSetTests: XCTestCase {
                 public static var _assemblyFlags: [ModuleAssemblyFlags] {
                     []
                 }
+                public static var _uniqueIdentifier: String {
+                    "Module2.Module2Assembly"
+                }
                 public static func _autoInstantiate() -> (any ModuleAssembly)? {
                     nil
                 }
@@ -70,6 +76,9 @@ final class ConfigurationSetTests: XCTestCase {
             extension Module3Assembly {
                 public static var _assemblyFlags: [ModuleAssemblyFlags] {
                     []
+                }
+                public static var _uniqueIdentifier: String {
+                    "Module3.Module3Assembly"
                 }
                 public static func _autoInstantiate() -> (any ModuleAssembly)? {
                     nil

--- a/Tests/KnitCodeGenTests/TypeSafetySourceFileTests.swift
+++ b/Tests/KnitCodeGenTests/TypeSafetySourceFileTests.swift
@@ -73,6 +73,9 @@ final class TypeSafetySourceFileTests: XCTestCase {
             public static var _assemblyFlags: [ModuleAssemblyFlags] {
                 []
             }
+            public static var _uniqueIdentifier: String {
+                "Module.ModuleAssembly"
+            }
             public static func _autoInstantiate() -> (any ModuleAssembly)? {
                 nil
             }
@@ -327,6 +330,9 @@ final class TypeSafetySourceFileTests: XCTestCase {
             public static var _assemblyFlags: [ModuleAssemblyFlags] {
                 [.autoInit]
             }
+            public static var _uniqueIdentifier: String {
+                "Module.MyFakeAssembly"
+            }
             public static func _autoInstantiate() -> (any ModuleAssembly)? {
                 MyFakeAssembly()
             }
@@ -367,6 +373,9 @@ final class TypeSafetySourceFileTests: XCTestCase {
             public static var _assemblyFlags: [ModuleAssemblyFlags] {
                 [.autoInit]
             }
+            public static var _uniqueIdentifier: String {
+                "Module.MyFakeAssembly"
+            }
             public static func _autoInstantiate() -> (any ModuleAssembly)? {
                 MyFakeAssembly()
             }
@@ -395,6 +404,9 @@ final class TypeSafetySourceFileTests: XCTestCase {
         extension SomeAbstractAssembly {
             public static var _assemblyFlags: [ModuleAssemblyFlags] {
                 [.autoInit, .abstract]
+            }
+            public static var _uniqueIdentifier: String {
+                "Module.SomeAbstractAssembly"
             }
             public static func _autoInstantiate() -> (any ModuleAssembly)? {
                 SomeAbstractAssembly()
@@ -427,6 +439,9 @@ final class TypeSafetySourceFileTests: XCTestCase {
         extension MainActorAssembly {
             public static var _assemblyFlags: [ModuleAssemblyFlags] {
                 []
+            }
+            public static var _uniqueIdentifier: String {
+                "Module.MainActorAssembly"
             }
             public static func _autoInstantiate() -> (any ModuleAssembly)? {
                 nil
@@ -480,6 +495,9 @@ final class TypeSafetySourceFileTests: XCTestCase {
         extension ModuleAssembly {
             public static var _assemblyFlags: [ModuleAssemblyFlags] {
                 []
+            }
+            public static var _uniqueIdentifier: String {
+                "Module.ModuleAssembly"
             }
             public static func _autoInstantiate() -> (any ModuleAssembly)? {
                 nil


### PR DESCRIPTION
Time profiling shows that using `String(describing: type(of: assembly))` is a bottleneck for dependency building. By pre generating an identifier based on the module + assembly name the performance is far better.