### PR TITLE
Fix parsing issue for TargetResolver including a module

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -99,6 +99,7 @@ let package = Package(
             name: "KnitMacrosTests",
             dependencies: [
                 "KnitMacrosImplementations",
+                .target(name: "Knit"),
                 .target(name: "KnitMacros"),
                 .target(name: "KnitCodeGen"),
                 .target(name: "Swinject"),

--- a/Sources/KnitCodeGen/AssemblyParsing.swift
+++ b/Sources/KnitCodeGen/AssemblyParsing.swift
@@ -224,13 +224,10 @@ class ClassDeclVisitor: SyntaxVisitor, IfConfigVisitor {
     }
 
     override func visit(_ node: TypeAliasDeclSyntax) -> SyntaxVisitorContinueKind {
-        guard let identifier = node.initializer.value.as(IdentifierTypeSyntax.self) else {
-            return .skipChildren
-        }
         if node.name.text == "TargetResolver" {
-            self.targetResolver = identifier.name.text
+            self.targetResolver = node.initializer.value.description
         } else if node.name.text == "ReplacedAssembly" {
-            self.fakeReplacesType = identifier.name.text
+            self.fakeReplacesType = node.initializer.value.description
         }
 
         return .skipChildren

--- a/Tests/KnitCodeGenTests/AssemblyParsingTests.swift
+++ b/Tests/KnitCodeGenTests/AssemblyParsingTests.swift
@@ -31,6 +31,18 @@ final class AssemblyParsingTests: XCTestCase {
         XCTAssertEqual(config.assemblyShortName, "FooTest")
     }
 
+    func testSubmoduleResolver() throws {
+        let sourceFile: SourceFileSyntax = """
+            import OtherModule
+            class FooTestAssembly: ModuleAssembly {
+                typealias TargetResolver = OtherModule.Resolver
+            }
+            """
+
+        let config = try assertParsesSyntaxTree(sourceFile)
+        XCTAssertEqual(config.targetResolver, "OtherModule.Resolver")
+    }
+
     func testDebugWrappedAssemblyImports() throws {
         let sourceFile: SourceFileSyntax = """
             #if DEBUG


### PR DESCRIPTION
If the resolver type included a period then it would not be parsed and the build would fail.