### PR TITLE
Update Package.swift to 6.0

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: macos-latest
     strategy:
       matrix:
-        swift-version: ["5.10", "6.0", "6.1"]
+        swift-version: ["6.0", "6.1"]
     steps:
     - uses: actions/checkout@v4
     - uses: swift-actions/setup-swift@v2

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.10
+// swift-tools-version: 6.0
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import CompilerPluginSupport


### PR DESCRIPTION
I've seen odd CI build failures that happen on 5.10. Easier to drop the unused version rather than trying to dig through the issues.