### PR TITLE
Fix build issues when MemberImportVisibility is enabled

### DIFF
--- a/Scripts/gencode
+++ b/Scripts/gencode
@@ -4,7 +4,7 @@
 # It generates high-arity overloads of generic functions using the file templates listed below.
 # The generated files are checked in since they are not dynamic and don't change often.
 
-files="Sources/Swinject/Container.Arguments Sources/Swinject/Resolver"
+files="Sources/Swinject/SwinjectContainer.Arguments Sources/Swinject/SwinjectResolver"
 
 for file in $files; do
   echo "Generating code to $file.swift"

--- a/Sources/Knit/Container+MainActorRegistration.swift
+++ b/Sources/Knit/Container+MainActorRegistration.swift
@@ -58,7 +58,7 @@ extension Knit.Container {
         name: String? = nil,
         mainActorFactory: @escaping @MainActor (TargetResolver, Arg1) -> Service
     ) -> ServiceEntry<Service> {
-        return _unwrappedSwinjectContainer().register(serviceType, name: name) { (r: Swinject.Resolver, arg1: Arg1) in
+        return _unwrappedSwinjectContainer().register(serviceType, name: name) { (r: SwinjectResolver, arg1: Arg1) in
             let resolver = r.resolve(Container<TargetResolver>.self)!.resolver
             return MainActor.assumeIsolated {
                 return mainActorFactory(resolver, arg1)
@@ -85,7 +85,7 @@ extension Knit.Container {
         name: String? = nil,
         mainActorFactory: @escaping @MainActor (TargetResolver, Arg1, Arg2) -> Service
     ) -> ServiceEntry<Service> {
-        return _unwrappedSwinjectContainer().register(serviceType, name: name) { (r: Swinject.Resolver, arg1: Arg1, arg2: Arg2) in
+        return _unwrappedSwinjectContainer().register(serviceType, name: name) { (r: SwinjectResolver, arg1: Arg1, arg2: Arg2) in
             let resolver = r.resolve(Container<TargetResolver>.self)!.resolver
             return MainActor.assumeIsolated {
                 return mainActorFactory(resolver, arg1, arg2)
@@ -112,7 +112,7 @@ extension Knit.Container {
         name: String? = nil,
         mainActorFactory: @escaping @MainActor (TargetResolver, Arg1, Arg2, Arg3) -> Service
     ) -> ServiceEntry<Service> {
-        return _unwrappedSwinjectContainer().register(serviceType, name: name) { (r: Swinject.Resolver, arg1: Arg1, arg2: Arg2, arg3: Arg3) in
+        return _unwrappedSwinjectContainer().register(serviceType, name: name) { (r: SwinjectResolver, arg1: Arg1, arg2: Arg2, arg3: Arg3) in
             let resolver = r.resolve(Container<TargetResolver>.self)!.resolver
             return MainActor.assumeIsolated {
                 return mainActorFactory(resolver, arg1, arg2, arg3)
@@ -139,7 +139,7 @@ extension Knit.Container {
         name: String? = nil,
         mainActorFactory: @escaping @MainActor (TargetResolver, Arg1, Arg2, Arg3, Arg4) -> Service
     ) -> ServiceEntry<Service> {
-        return _unwrappedSwinjectContainer().register(serviceType, name: name) { (r: Swinject.Resolver, arg1: Arg1, arg2: Arg2, arg3: Arg3, arg4: Arg4) in
+        return _unwrappedSwinjectContainer().register(serviceType, name: name) { (r: SwinjectResolver, arg1: Arg1, arg2: Arg2, arg3: Arg3, arg4: Arg4) in
             let resolver = r.resolve(Container<TargetResolver>.self)!.resolver
             return MainActor.assumeIsolated {
                 return mainActorFactory(resolver, arg1, arg2, arg3, arg4)
@@ -166,7 +166,7 @@ extension Knit.Container {
         name: String? = nil,
         mainActorFactory: @escaping @MainActor (TargetResolver, Arg1, Arg2, Arg3, Arg4, Arg5) -> Service
     ) -> ServiceEntry<Service> {
-        return _unwrappedSwinjectContainer().register(serviceType, name: name) { (r: Swinject.Resolver, arg1: Arg1, arg2: Arg2, arg3: Arg3, arg4: Arg4, arg5: Arg5) in
+        return _unwrappedSwinjectContainer().register(serviceType, name: name) { (r: SwinjectResolver, arg1: Arg1, arg2: Arg2, arg3: Arg3, arg4: Arg4, arg5: Arg5) in
             let resolver = r.resolve(Container<TargetResolver>.self)!.resolver
             return MainActor.assumeIsolated {
                 return mainActorFactory(resolver, arg1, arg2, arg3, arg4, arg5)
@@ -193,7 +193,7 @@ extension Knit.Container {
         name: String? = nil,
         mainActorFactory: @escaping @MainActor (TargetResolver, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6) -> Service
     ) -> ServiceEntry<Service> {
-        return _unwrappedSwinjectContainer().register(serviceType, name: name) { (r: Swinject.Resolver, arg1: Arg1, arg2: Arg2, arg3: Arg3, arg4: Arg4, arg5: Arg5, arg6: Arg6) in
+        return _unwrappedSwinjectContainer().register(serviceType, name: name) { (r: SwinjectResolver, arg1: Arg1, arg2: Arg2, arg3: Arg3, arg4: Arg4, arg5: Arg5, arg6: Arg6) in
             let resolver = r.resolve(Container<TargetResolver>.self)!.resolver
             return MainActor.assumeIsolated {
                 return mainActorFactory(resolver, arg1, arg2, arg3, arg4, arg5, arg6)
@@ -220,7 +220,7 @@ extension Knit.Container {
         name: String? = nil,
         mainActorFactory: @escaping @MainActor (TargetResolver, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7) -> Service
     ) -> ServiceEntry<Service> {
-        return _unwrappedSwinjectContainer().register(serviceType, name: name) { (r: Swinject.Resolver, arg1: Arg1, arg2: Arg2, arg3: Arg3, arg4: Arg4, arg5: Arg5, arg6: Arg6, arg7: Arg7) in
+        return _unwrappedSwinjectContainer().register(serviceType, name: name) { (r: SwinjectResolver, arg1: Arg1, arg2: Arg2, arg3: Arg3, arg4: Arg4, arg5: Arg5, arg6: Arg6, arg7: Arg7) in
             let resolver = r.resolve(Container<TargetResolver>.self)!.resolver
             return MainActor.assumeIsolated {
                 return mainActorFactory(resolver, arg1, arg2, arg3, arg4, arg5, arg6, arg7)
@@ -247,7 +247,7 @@ extension Knit.Container {
         name: String? = nil,
         mainActorFactory: @escaping @MainActor (TargetResolver, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8) -> Service
     ) -> ServiceEntry<Service> {
-        return _unwrappedSwinjectContainer().register(serviceType, name: name) { (r: Swinject.Resolver, arg1: Arg1, arg2: Arg2, arg3: Arg3, arg4: Arg4, arg5: Arg5, arg6: Arg6, arg7: Arg7, arg8: Arg8) in
+        return _unwrappedSwinjectContainer().register(serviceType, name: name) { (r: SwinjectResolver, arg1: Arg1, arg2: Arg2, arg3: Arg3, arg4: Arg4, arg5: Arg5, arg6: Arg6, arg7: Arg7, arg8: Arg8) in
             let resolver = r.resolve(Container<TargetResolver>.self)!.resolver
             return MainActor.assumeIsolated {
                 return mainActorFactory(resolver, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8)
@@ -274,7 +274,7 @@ extension Knit.Container {
         name: String? = nil,
         mainActorFactory: @escaping @MainActor (TargetResolver, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8, Arg9) -> Service
     ) -> ServiceEntry<Service> {
-        return _unwrappedSwinjectContainer().register(serviceType, name: name) { (r: Swinject.Resolver, arg1: Arg1, arg2: Arg2, arg3: Arg3, arg4: Arg4, arg5: Arg5, arg6: Arg6, arg7: Arg7, arg8: Arg8, arg9: Arg9) in
+        return _unwrappedSwinjectContainer().register(serviceType, name: name) { (r: SwinjectResolver, arg1: Arg1, arg2: Arg2, arg3: Arg3, arg4: Arg4, arg5: Arg5, arg6: Arg6, arg7: Arg7, arg8: Arg8, arg9: Arg9) in
             let resolver = r.resolve(Container<TargetResolver>.self)!.resolver
             return MainActor.assumeIsolated {
                 return mainActorFactory(resolver, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9)

--- a/Sources/Knit/Container+Registration.swift
+++ b/Sources/Knit/Container+Registration.swift
@@ -56,7 +56,7 @@ extension Container {
         name: String? = nil,
         factory: @escaping (TargetResolver, Arg1) -> Service
     ) -> ServiceEntry<Service> {
-        return _unwrappedSwinjectContainer().register(serviceType, name: name) { (r: Swinject.Resolver, arg1: Arg1) in
+        return _unwrappedSwinjectContainer().register(serviceType, name: name) { (r: SwinjectResolver, arg1: Arg1) in
             let resolver = r.resolve(Container<TargetResolver>.self)!.resolver
             return factory(resolver, arg1)
         }
@@ -81,7 +81,7 @@ extension Container {
         name: String? = nil,
         factory: @escaping (TargetResolver, Arg1, Arg2) -> Service
     ) -> ServiceEntry<Service> {
-        return _unwrappedSwinjectContainer().register(serviceType, name: name) { (r: Swinject.Resolver, arg1: Arg1, arg2: Arg2) in
+        return _unwrappedSwinjectContainer().register(serviceType, name: name) { (r: SwinjectResolver, arg1: Arg1, arg2: Arg2) in
             let resolver = r.resolve(Container<TargetResolver>.self)!.resolver
             return factory(resolver, arg1, arg2)
         }
@@ -106,7 +106,7 @@ extension Container {
         name: String? = nil,
         factory: @escaping (TargetResolver, Arg1, Arg2, Arg3) -> Service
     ) -> ServiceEntry<Service> {
-        return _unwrappedSwinjectContainer().register(serviceType, name: name) { (r: Swinject.Resolver, arg1: Arg1, arg2: Arg2, arg3: Arg3) in
+        return _unwrappedSwinjectContainer().register(serviceType, name: name) { (r: SwinjectResolver, arg1: Arg1, arg2: Arg2, arg3: Arg3) in
             let resolver = r.resolve(Container<TargetResolver>.self)!.resolver
             return factory(resolver, arg1, arg2, arg3)
         }
@@ -131,7 +131,7 @@ extension Container {
         name: String? = nil,
         factory: @escaping (TargetResolver, Arg1, Arg2, Arg3, Arg4) -> Service
     ) -> ServiceEntry<Service> {
-        return _unwrappedSwinjectContainer().register(serviceType, name: name) { (r: Swinject.Resolver, arg1: Arg1, arg2: Arg2, arg3: Arg3, arg4: Arg4) in
+        return _unwrappedSwinjectContainer().register(serviceType, name: name) { (r: SwinjectResolver, arg1: Arg1, arg2: Arg2, arg3: Arg3, arg4: Arg4) in
             let resolver = r.resolve(Container<TargetResolver>.self)!.resolver
             return factory(resolver, arg1, arg2, arg3, arg4)
         }
@@ -156,7 +156,7 @@ extension Container {
         name: String? = nil,
         factory: @escaping (TargetResolver, Arg1, Arg2, Arg3, Arg4, Arg5) -> Service
     ) -> ServiceEntry<Service> {
-        return _unwrappedSwinjectContainer().register(serviceType, name: name) { (r: Swinject.Resolver, arg1: Arg1, arg2: Arg2, arg3: Arg3, arg4: Arg4, arg5: Arg5) in
+        return _unwrappedSwinjectContainer().register(serviceType, name: name) { (r: SwinjectResolver, arg1: Arg1, arg2: Arg2, arg3: Arg3, arg4: Arg4, arg5: Arg5) in
             let resolver = r.resolve(Container<TargetResolver>.self)!.resolver
             return factory(resolver, arg1, arg2, arg3, arg4, arg5)
         }
@@ -181,7 +181,7 @@ extension Container {
         name: String? = nil,
         factory: @escaping (TargetResolver, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6) -> Service
     ) -> ServiceEntry<Service> {
-        return _unwrappedSwinjectContainer().register(serviceType, name: name) { (r: Swinject.Resolver, arg1: Arg1, arg2: Arg2, arg3: Arg3, arg4: Arg4, arg5: Arg5, arg6: Arg6) in
+        return _unwrappedSwinjectContainer().register(serviceType, name: name) { (r: SwinjectResolver, arg1: Arg1, arg2: Arg2, arg3: Arg3, arg4: Arg4, arg5: Arg5, arg6: Arg6) in
             let resolver = r.resolve(Container<TargetResolver>.self)!.resolver
             return factory(resolver, arg1, arg2, arg3, arg4, arg5, arg6)
         }
@@ -206,7 +206,7 @@ extension Container {
         name: String? = nil,
         factory: @escaping (TargetResolver, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7) -> Service
     ) -> ServiceEntry<Service> {
-        return _unwrappedSwinjectContainer().register(serviceType, name: name) { (r: Swinject.Resolver, arg1: Arg1, arg2: Arg2, arg3: Arg3, arg4: Arg4, arg5: Arg5, arg6: Arg6, arg7: Arg7) in
+        return _unwrappedSwinjectContainer().register(serviceType, name: name) { (r: SwinjectResolver, arg1: Arg1, arg2: Arg2, arg3: Arg3, arg4: Arg4, arg5: Arg5, arg6: Arg6, arg7: Arg7) in
             let resolver = r.resolve(Container<TargetResolver>.self)!.resolver
             return factory(resolver, arg1, arg2, arg3, arg4, arg5, arg6, arg7)
         }
@@ -231,7 +231,7 @@ extension Container {
         name: String? = nil,
         factory: @escaping (TargetResolver, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8) -> Service
     ) -> ServiceEntry<Service> {
-        return _unwrappedSwinjectContainer().register(serviceType, name: name) { (r: Swinject.Resolver, arg1: Arg1, arg2: Arg2, arg3: Arg3, arg4: Arg4, arg5: Arg5, arg6: Arg6, arg7: Arg7, arg8: Arg8) in
+        return _unwrappedSwinjectContainer().register(serviceType, name: name) { (r: SwinjectResolver, arg1: Arg1, arg2: Arg2, arg3: Arg3, arg4: Arg4, arg5: Arg5, arg6: Arg6, arg7: Arg7, arg8: Arg8) in
             let resolver = r.resolve(Container<TargetResolver>.self)!.resolver
             return factory(resolver, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8)
         }
@@ -256,7 +256,7 @@ extension Container {
         name: String? = nil,
         factory: @escaping (TargetResolver, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8, Arg9) -> Service
     ) -> ServiceEntry<Service> {
-        return _unwrappedSwinjectContainer().register(serviceType, name: name) { (r: Swinject.Resolver, arg1: Arg1, arg2: Arg2, arg3: Arg3, arg4: Arg4, arg5: Arg5, arg6: Arg6, arg7: Arg7, arg8: Arg8, arg9: Arg9) in
+        return _unwrappedSwinjectContainer().register(serviceType, name: name) { (r: SwinjectResolver, arg1: Arg1, arg2: Arg2, arg3: Arg3, arg4: Arg4, arg5: Arg5, arg6: Arg6, arg7: Arg7, arg8: Arg8, arg9: Arg9) in
             let resolver = r.resolve(Container<TargetResolver>.self)!.resolver
             return factory(resolver, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9)
         }

--- a/Sources/Knit/Container.swift
+++ b/Sources/Knit/Container.swift
@@ -6,10 +6,10 @@ import Foundation
 import Swinject
 
 /**
- A light-weight wrapper around the `Swinject.Container` that adds type information about the `TargetResolver`.
+ A light-weight wrapper around the `SwinjectContainer` that adds type information about the `TargetResolver`.
  This allows us to provide registration APIs that are specified to the `TargetResolver`.
 
- The Knit.Container also performs the function of a weak wrapper of the `Swinject.Container`.
+ The Knit.Container also performs the function of a weak wrapper of the `SwinjectContainer`.
  */
 public class Container<TargetResolver>: Knit.Resolver {
 
@@ -24,20 +24,20 @@ public class Container<TargetResolver>: Knit.Resolver {
         _swinjectContainer != nil
     }
 
-    // MARK: - Swinject.Resolver
+    // MARK: - SwinjectResolver
 
-    public func unsafeResolver(file: StaticString, function: StaticString, line: UInt) -> Swinject.Resolver {
+    public func unsafeResolver(file: StaticString, function: StaticString, line: UInt) -> SwinjectResolver {
         _unwrappedSwinjectContainer(file: file, function: function, line: line)
     }
 
     // MARK: - Private Properties
 
-    private weak var _swinjectContainer: Swinject.Container?
+    private weak var _swinjectContainer: SwinjectContainer?
 
     // MARK: - Life Cycle
 
     // This should not be promoted from `fileprivate` access level.
-    fileprivate init(_swinjectContainer: Swinject.Container) {
+    fileprivate init(_swinjectContainer: SwinjectContainer) {
         self._swinjectContainer = _swinjectContainer
     }
 }
@@ -49,7 +49,7 @@ extension Container {
         file: StaticString = #fileID,
         function: StaticString = #function,
         line: UInt = #line
-    ) -> Swinject.Container {
+    ) -> SwinjectContainer {
         guard let _swinjectContainer else {
             fatalError(
                 """
@@ -71,7 +71,7 @@ extension Container {
 internal final class ContainerManager {
 
     // swinjectContainer is weak since the container will own this manager
-    private weak var swinjectContainer: Swinject.Container!
+    private weak var swinjectContainer: SwinjectContainer!
 
     // ContainerManager from the parent of the SwinjectContainer
     private let parent: ContainerManager?
@@ -84,7 +84,7 @@ internal final class ContainerManager {
 
     init(
         parent: ContainerManager? = nil,
-        swinjectContainer: Swinject.Container,
+        swinjectContainer: SwinjectContainer,
         autoConfigureContainers: Bool = false
     ) {
         self.parent = parent

--- a/Sources/Knit/DuplicateRegistrationDetector.swift
+++ b/Sources/Knit/DuplicateRegistrationDetector.swift
@@ -39,7 +39,7 @@ public final class DuplicateRegistrationDetector {
 extension DuplicateRegistrationDetector: Behavior {
 
     public func container<Type, Service>(
-        _ container: Swinject.Container,
+        _ container: SwinjectContainer,
         didRegisterType type: Type.Type,
         toService entry: ServiceEntry<Service>,
         withName name: String?

--- a/Sources/Knit/Exports.swift
+++ b/Sources/Knit/Exports.swift
@@ -1,0 +1,7 @@
+//
+// Copyright © Block, Inc. All rights reserved.
+//
+
+import Foundation
+
+@_exported import Swinject

--- a/Sources/Knit/Module/Container+AbstractRegistration.swift
+++ b/Sources/Knit/Module/Container+AbstractRegistration.swift
@@ -37,7 +37,7 @@ extension Container {
 
 }
 
-extension Swinject.Container {
+extension SwinjectContainer {
 
     // Must be called before using `registerAbstract`
     func registerAbstractContainer() -> AbstractRegistrationContainer {
@@ -80,7 +80,7 @@ public protocol AbstractRegistration {
     /// Register a placeholder registration to fill the unfulfilled abstract registration
     /// This placeholder cannot be resolved
     func registerPlaceholder(
-        container: Swinject.Container,
+        container: SwinjectContainer,
         errorFormatter: ModuleAssemblerErrorFormatter,
         dependencyTree: DependencyTree
     )
@@ -115,7 +115,7 @@ fileprivate struct RealAbstractRegistration<ServiceType>: AbstractRegistration {
     let concurrency: ConcurrencyAttribute
 
     func registerPlaceholder(
-        container: Swinject.Container,
+        container: SwinjectContainer,
         errorFormatter: ModuleAssemblerErrorFormatter,
         dependencyTree: DependencyTree
     ) {
@@ -137,7 +137,7 @@ fileprivate struct OptionalAbstractRegistration<UnwrappedServiceType>: AbstractR
     typealias ServiceType = Optional<UnwrappedServiceType>
 
     func registerPlaceholder(
-        container: Swinject.Container,
+        container: SwinjectContainer,
         errorFormatter: ModuleAssemblerErrorFormatter,
         dependencyTree: DependencyTree
     ) {
@@ -176,7 +176,7 @@ public struct AbstractRegistrationErrors: LocalizedError {
 
 // MARK: -
 
-extension Swinject.Container {
+extension SwinjectContainer {
 
     final class AbstractRegistrationContainer: Behavior {
 
@@ -189,7 +189,7 @@ extension Swinject.Container {
         }
 
         func container<Type, Service>(
-            _ container: Swinject.Container,
+            _ container: SwinjectContainer,
             didRegisterType type: Type.Type,
             toService entry: ServiceEntry<Service>,
             withName name: String?

--- a/Sources/Knit/Module/ModuleAssembler.swift
+++ b/Sources/Knit/Module/ModuleAssembler.swift
@@ -9,14 +9,14 @@ import Swinject
 public final class ModuleAssembler {
 
     /// The container that registrations have been placed in. Prefer using resolver unless mutable access is required
-    let _swinjectContainer: Swinject.Container
+    let _swinjectContainer: SwinjectContainer
     let containerManager: ContainerManager
     let parent: ModuleAssembler?
     let serviceCollector: ServiceCollector
     private let autoConfigureContainers: Bool
 
     /// The unsafe resolver for this ModuleAssembler's container
-    public var resolver: Swinject.Resolver { _swinjectContainer }
+    public var resolver: SwinjectResolver { _swinjectContainer }
 
     // Module types that were registered into the container owned by this ModuleAssembler
     var registeredReferences: [AssemblyReference] {
@@ -47,7 +47,7 @@ public final class ModuleAssembler {
         overrideBehavior: OverrideBehavior = .defaultOverridesWhenTesting,
         assemblyValidation: ((any ModuleAssembly.Type) throws -> Void)? = nil,
         errorFormatter: ModuleAssemblerErrorFormatter = DefaultModuleAssemblerErrorFormatter(),
-        postAssemble: ((Swinject.Container) -> Void)? = nil,
+        postAssemble: ((SwinjectContainer) -> Void)? = nil,
         file: StaticString = #fileID,
         line: UInt = #line
     ) {
@@ -83,8 +83,8 @@ public final class ModuleAssembler {
         assemblyValidation: ((any ModuleAssembly.Type) throws -> Void)? = nil,
         errorFormatter: ModuleAssemblerErrorFormatter = DefaultModuleAssemblerErrorFormatter(),
         behaviors: [Behavior] = [],
-        preAssemble: ((Swinject.Container) -> Void)?,
-        postAssemble: ((Swinject.Container) -> Void)? = nil,
+        preAssemble: ((SwinjectContainer) -> Void)?,
+        postAssemble: ((SwinjectContainer) -> Void)? = nil,
         autoConfigureContainers: Bool
     ) throws {
         self.builder = try DependencyBuilder(
@@ -97,7 +97,7 @@ public final class ModuleAssembler {
         )
 
         self.parent = parent
-        let _swinjectContainer = Swinject.Container(
+        let _swinjectContainer = SwinjectContainer(
             parent: parent?._swinjectContainer,
             behaviors: behaviors
         )
@@ -154,7 +154,7 @@ public final class ModuleAssembler {
 }
 
 // Publicly expose the dependency tree so it can be used for debugging
-public extension Swinject.Resolver {
+public extension SwinjectResolver {
     func _dependencyTree(file: StaticString = #fileID, function: StaticString = #function, line: UInt = #line) -> DependencyTree {
         return knitUnwrap(resolve(DependencyTree.self), callsiteFile: file, callsiteFunction: function, callsiteLine: line)
     }

--- a/Sources/Knit/Module/ScopedModuleAssembler.swift
+++ b/Sources/Knit/Module/ScopedModuleAssembler.swift
@@ -14,8 +14,8 @@ public final class ScopedModuleAssembler<TargetResolver> {
         internalAssembler.resolver.resolve(Knit.Container<TargetResolver>.self)!.resolver
     }
 
-    /// Access the underlying Swinject.Resolver to resolve without type safety.
-    var unsafeResolver: Swinject.Resolver {
+    /// Access the underlying SwinjectResolver to resolve without type safety.
+    var unsafeResolver: SwinjectResolver {
         internalAssembler.resolver
     }
 

--- a/Sources/Knit/Resolver+Additions.swift
+++ b/Sources/Knit/Resolver+Additions.swift
@@ -4,7 +4,7 @@
 
 import Swinject
 
-public extension Swinject.Resolver {
+public extension SwinjectResolver {
 
     /// Force unwrap that improves single line error logging to help track test failures
     /// This is used in knit generated type safe functions

--- a/Sources/Knit/Resolver.swift
+++ b/Sources/Knit/Resolver.swift
@@ -11,6 +11,6 @@ public protocol Resolver: AnyObject {
     /// Returns `true` if the backing container is still available in memory, otherwise `false`.
     var isAvailable: Bool { get }
 
-    func unsafeResolver(file: StaticString, function: StaticString, line: UInt) -> Swinject.Resolver
+    func unsafeResolver(file: StaticString, function: StaticString, line: UInt) -> SwinjectResolver
 
 }

--- a/Sources/Knit/ServiceCollection/Resolver+ServiceCollection.swift
+++ b/Sources/Knit/ServiceCollection/Resolver+ServiceCollection.swift
@@ -4,7 +4,7 @@
 
 import Swinject
 
-extension Swinject.Resolver {
+extension SwinjectResolver {
 
     /// Resolves a collection of all services registered using
     /// ``Container/registerIntoCollection(_:factory:)``

--- a/Sources/Knit/ServiceCollection/ServiceCollector.swift
+++ b/Sources/Knit/ServiceCollection/ServiceCollector.swift
@@ -25,7 +25,7 @@ public final class ServiceCollector: Behavior {
 
     /// Maps a service type to an array of service factories
     /// Note: We use `ObjectIdentifier` to represent the service type since `Any.Type` isn't Hashable.
-    private var factoriesByService: [ObjectIdentifier: [(Swinject.Resolver) -> Any]] = [:]
+    private var factoriesByService: [ObjectIdentifier: [(SwinjectResolver) -> Any]] = [:]
 
     private let parent: ServiceCollector?
 
@@ -34,7 +34,7 @@ public final class ServiceCollector: Behavior {
     }
 
     public func container<Type, Service>(
-        _ container: Swinject.Container,
+        _ container: SwinjectContainer,
         didRegisterType type: Type.Type,
         toService entry: ServiceEntry<Service>,
         withName name: String?
@@ -61,7 +61,7 @@ public final class ServiceCollector: Behavior {
         factoriesByService[ObjectIdentifier(Service.self)] = factories
     }
     
-    private func resolveServices<Service>(resolver: Swinject.Resolver) -> ServiceCollection<Service> {
+    private func resolveServices<Service>(resolver: SwinjectResolver) -> ServiceCollection<Service> {
         let parentCollection: ServiceCollection<Service>? = parent?.resolveServices(resolver: resolver)
         let factories = self.factoriesByService[ObjectIdentifier(Service.self)] ?? []
         let entries = factories.map { $0(resolver) as! Service }

--- a/Sources/KnitTesting/Resolver+Asserts.swift
+++ b/Sources/KnitTesting/Resolver+Asserts.swift
@@ -6,7 +6,7 @@ import Knit
 import Swinject
 import XCTest
 
-public extension Swinject.Resolver {
+public extension SwinjectResolver {
 
     func assertTypeResolved<T>(
         _ result: T?,

--- a/Sources/Swinject/Behavior.swift
+++ b/Sources/Swinject/Behavior.swift
@@ -16,7 +16,7 @@ public protocol Behavior {
     /// - Remark: `Type` and `Service` can be different types in the case of type forwarding (commonly used as `.implements()`).
     /// `Type` will represent the forwarded type key, and `Service` will represent the destination.
     func container<Type, Service>(
-        _ container: Container,
+        _ container: SwinjectContainer,
         didRegisterType type: Type.Type,
         toService entry: ServiceEntry<Service>,
         withName name: String?

--- a/Sources/Swinject/DebugHelper.swift
+++ b/Sources/Swinject/DebugHelper.swift
@@ -25,7 +25,7 @@ internal final class LoggingDebugHelper: DebugHelper {
             .filter { $0.1 is ServiceEntry<Service> }
             .map { "\t{ " + $0.1.describeWithKey($0.0) + " }" }
 
-        Container.log(output.joined(separator: "\n"))
+        SwinjectContainer.log(output.joined(separator: "\n"))
     }
 }
 

--- a/Sources/Swinject/InstanceWrapper.swift
+++ b/Sources/Swinject/InstanceWrapper.swift
@@ -4,7 +4,7 @@
 
 protocol InstanceWrapper {
     static var wrappedType: Any.Type { get }
-    init?(inContainer container: Container, withInstanceFactory factory: ((GraphIdentifier?) -> Any?)?)
+    init?(inContainer container: SwinjectContainer, withInstanceFactory factory: ((GraphIdentifier?) -> Any?)?)
 }
 
 /// Wrapper to enable delayed dependency instantiation.
@@ -15,9 +15,9 @@ public final class Lazy<Service>: InstanceWrapper {
 
     private let factory: (GraphIdentifier?) -> Any?
     private let graphIdentifier: GraphIdentifier?
-    private weak var container: Container?
+    private weak var container: SwinjectContainer?
 
-    init?(inContainer container: Container, withInstanceFactory factory: ((GraphIdentifier?) -> Any?)?) {
+    init?(inContainer container: SwinjectContainer, withInstanceFactory factory: ((GraphIdentifier?) -> Any?)?) {
         guard let factory = factory else { return nil }
         self.factory = factory
         graphIdentifier = container.currentObjectGraph
@@ -50,7 +50,7 @@ public final class Provider<Service>: InstanceWrapper {
 
     private let factory: (GraphIdentifier?) -> Any?
 
-    init?(inContainer _: Container, withInstanceFactory factory: ((GraphIdentifier?) -> Any?)?) {
+    init?(inContainer _: SwinjectContainer, withInstanceFactory factory: ((GraphIdentifier?) -> Any?)?) {
         guard let factory = factory else { return nil }
         self.factory = factory
     }
@@ -65,7 +65,7 @@ public final class Provider<Service>: InstanceWrapper {
 extension Optional: InstanceWrapper {
     static var wrappedType: Any.Type { return Wrapped.self }
 
-    init?(inContainer _: Container, withInstanceFactory factory: ((GraphIdentifier?) -> Any?)?) {
+    init?(inContainer _: SwinjectContainer, withInstanceFactory factory: ((GraphIdentifier?) -> Any?)?) {
         self = factory?(.none) as? Wrapped
     }
 }

--- a/Sources/Swinject/ServiceEntry.swift
+++ b/Sources/Swinject/ServiceEntry.swift
@@ -17,12 +17,12 @@ internal protocol ServiceEntryProtocol: AnyObject {
 /// Represents an entry of a registered service type.
 /// As a returned instance from ``Container/register(_:name:factory:)-8gy9r``, some configurations can be added.
 public final class ServiceEntry<Service>: ServiceEntryProtocol {
-    fileprivate var initCompletedActions: [(Resolver, Service) -> Void] = []
+    fileprivate var initCompletedActions: [(SwinjectResolver, Service) -> Void] = []
     public let serviceType: Any.Type
     public let argumentsType: Any.Type
 
     internal let factory: FunctionType
-    internal weak var container: Container?
+    internal weak var container: SwinjectContainer?
 
     internal var objectScope: ObjectScopeProtocol = ObjectScope.graph
     internal lazy var storage: InstanceStorage = { [unowned self] in
@@ -32,7 +32,7 @@ public final class ServiceEntry<Service>: ServiceEntryProtocol {
     internal var initCompleted: FunctionType? {
         guard !initCompletedActions.isEmpty else { return nil }
 
-        return { [weak self] (resolver: Resolver, service: Any) -> Void in
+        return { [weak self] (resolver: SwinjectResolver, service: Any) -> Void in
             guard let strongSelf = self else { return }
             strongSelf.initCompletedActions.forEach { $0(resolver, service as! Service) }
         }
@@ -85,7 +85,7 @@ public final class ServiceEntry<Service>: ServiceEntryProtocol {
     ///
     /// - Returns: `self` to add another configuration fluently.
     @discardableResult
-    public func initCompleted(_ completed: @escaping (Resolver, Service) -> Void) -> Self {
+    public func initCompleted(_ completed: @escaping (SwinjectResolver, Service) -> Void) -> Self {
         initCompletedActions.append(completed)
         return self
     }

--- a/Sources/Swinject/SwinjectContainer.Arguments.erb
+++ b/Sources/Swinject/SwinjectContainer.Arguments.erb
@@ -6,9 +6,9 @@
 //
 // NOTICE:
 //
-// Container.Arguments.swift is generated from Container.Arguments.erb by ERB.
-// Do NOT modify Container.Arguments.swift directly.
-// Instead, modify Container.Arguments.erb and run `Scripts/gencode` at the project root directory to generate the code.
+// SwinjectContainer.Arguments.swift is generated from SwinjectContainer.Arguments.erb by ERB.
+// Do NOT modify SwinjectContainer.Arguments.swift directly.
+// Instead, modify SwinjectContainer.Arguments.erb and run `Scripts/gencode` at the project root directory to generate the code.
 //
 
 <% arg_count = 9 %>
@@ -17,7 +17,7 @@ import Foundation
 
 // MARK: - Registration with Arguments
 
-extension Container {
+extension SwinjectContainer {
 <% (1..arg_count).each do |i| %>
 <%   arg_types = (1..i).map { |n| "Arg#{n}" }.join(", ") %>
 <%   arg_description = i == 1 ? "#{i} argument" : "#{i} arguments" %>
@@ -29,7 +29,7 @@ extension Container {
     ///                  that have the same service and factory types.
     ///   - factory:     The closure to specify how the service type is resolved with the dependencies of the type.
     ///                  It is invoked when the `Container` needs to instantiate the instance.
-    ///                  It takes a `Resolver` instance and <%= arg_description %> to inject dependencies to the instance,
+    ///                  It takes a `SwinjectResolver` instance and <%= arg_description %> to inject dependencies to the instance,
     ///                  and returns the instance of the component type for the service.
     ///
     /// - Returns: A registered `ServiceEntry` to configure more settings with method chaining.
@@ -37,7 +37,7 @@ extension Container {
     public func register<Service, <%= arg_types %>>(
         _ serviceType: Service.Type,
         name: String? = nil,
-        factory: @escaping (Resolver, <%= arg_types %>) -> Service
+        factory: @escaping (SwinjectResolver, <%= arg_types %>) -> Service
     ) -> ServiceEntry<Service> {
         return _register(serviceType, factory: factory, name: name)
     }
@@ -45,9 +45,9 @@ extension Container {
 <% end %>
 }
 
-// MARK: - Resolver with Arguments
+// MARK: - SwinjectResolver with Arguments
 
-extension Container {
+extension SwinjectContainer {
 <% (1..arg_count).each do |i| %>
 <%   arg_types = (1..i).map { |n| "Arg#{n}" }.join(", ") %>
 <%   arg_param_def = i == 1 ? "argument: Arg1" : "arguments arg1: Arg1, " + (2..i).map{ |n| "_ arg#{n}: Arg#{n}" }.join(", ") %>
@@ -62,7 +62,7 @@ extension Container {
     ///   - <%= arg_param_name %>:   <%= arg_param_description.capitalize %> to pass to the factory closure.
     ///
     /// - Returns: The resolved service type instance, or nil if no registration for the service type
-    ///            and <%= arg_param_description %> is found in the `Container`.
+    ///            and <%= arg_param_description %> is found in the `SwinjectContainer`.
     public func resolve<Service, <%= arg_types %>>(
         _ serviceType: Service.Type,
         <%= arg_param_def %>) -> Service?
@@ -78,16 +78,16 @@ extension Container {
     ///   - <%= arg_param_name %>:   <%= arg_param_description.capitalize %> to pass to the factory closure.
     ///
     /// - Returns: The resolved service type instance, or nil if no registration for the service type,
-    ///            <%= arg_param_description %> and name is found in the `Container`.
+    ///            <%= arg_param_description %> and name is found in the `SwinjectContainer`.
     public func resolve<Service, <%= arg_types %>>(
         _ serviceType: Service.Type,
         name: String?,
         <%= arg_param_def %>) -> Service?
     {
-        typealias FactoryType = ((Resolver, <%= arg_types %>)) -> Any
+        typealias FactoryType = ((SwinjectResolver, <%= arg_types %>)) -> Any
         return _resolve(
             name: name,
-            invoker: { (resolver: Resolver, factory: FactoryType) in
+            invoker: { (resolver: SwinjectResolver, factory: FactoryType) in
                 factory((resolver, <%= arg_param_call %>))
             }
         )

--- a/Sources/Swinject/SwinjectContainer.Arguments.swift
+++ b/Sources/Swinject/SwinjectContainer.Arguments.swift
@@ -6,9 +6,9 @@
 //
 // NOTICE:
 //
-// Container.Arguments.swift is generated from Container.Arguments.erb by ERB.
-// Do NOT modify Container.Arguments.swift directly.
-// Instead, modify Container.Arguments.erb and run `Scripts/gencode` at the project root directory to generate the code.
+// SwinjectContainer.Arguments.swift is generated from SwinjectContainer.Arguments.erb by ERB.
+// Do NOT modify SwinjectContainer.Arguments.swift directly.
+// Instead, modify SwinjectContainer.Arguments.erb and run `Scripts/gencode` at the project root directory to generate the code.
 //
 
 
@@ -16,7 +16,7 @@ import Foundation
 
 // MARK: - Registration with Arguments
 
-extension Container {
+extension SwinjectContainer {
     /// Adds a registration for the specified service with the factory closure to specify how the service is resolved with dependencies.
     ///
     /// - Parameters:
@@ -25,7 +25,7 @@ extension Container {
     ///                  that have the same service and factory types.
     ///   - factory:     The closure to specify how the service type is resolved with the dependencies of the type.
     ///                  It is invoked when the `Container` needs to instantiate the instance.
-    ///                  It takes a `Resolver` instance and 1 argument to inject dependencies to the instance,
+    ///                  It takes a `SwinjectResolver` instance and 1 argument to inject dependencies to the instance,
     ///                  and returns the instance of the component type for the service.
     ///
     /// - Returns: A registered `ServiceEntry` to configure more settings with method chaining.
@@ -33,7 +33,7 @@ extension Container {
     public func register<Service, Arg1>(
         _ serviceType: Service.Type,
         name: String? = nil,
-        factory: @escaping (Resolver, Arg1) -> Service
+        factory: @escaping (SwinjectResolver, Arg1) -> Service
     ) -> ServiceEntry<Service> {
         return _register(serviceType, factory: factory, name: name)
     }
@@ -46,7 +46,7 @@ extension Container {
     ///                  that have the same service and factory types.
     ///   - factory:     The closure to specify how the service type is resolved with the dependencies of the type.
     ///                  It is invoked when the `Container` needs to instantiate the instance.
-    ///                  It takes a `Resolver` instance and 2 arguments to inject dependencies to the instance,
+    ///                  It takes a `SwinjectResolver` instance and 2 arguments to inject dependencies to the instance,
     ///                  and returns the instance of the component type for the service.
     ///
     /// - Returns: A registered `ServiceEntry` to configure more settings with method chaining.
@@ -54,7 +54,7 @@ extension Container {
     public func register<Service, Arg1, Arg2>(
         _ serviceType: Service.Type,
         name: String? = nil,
-        factory: @escaping (Resolver, Arg1, Arg2) -> Service
+        factory: @escaping (SwinjectResolver, Arg1, Arg2) -> Service
     ) -> ServiceEntry<Service> {
         return _register(serviceType, factory: factory, name: name)
     }
@@ -67,7 +67,7 @@ extension Container {
     ///                  that have the same service and factory types.
     ///   - factory:     The closure to specify how the service type is resolved with the dependencies of the type.
     ///                  It is invoked when the `Container` needs to instantiate the instance.
-    ///                  It takes a `Resolver` instance and 3 arguments to inject dependencies to the instance,
+    ///                  It takes a `SwinjectResolver` instance and 3 arguments to inject dependencies to the instance,
     ///                  and returns the instance of the component type for the service.
     ///
     /// - Returns: A registered `ServiceEntry` to configure more settings with method chaining.
@@ -75,7 +75,7 @@ extension Container {
     public func register<Service, Arg1, Arg2, Arg3>(
         _ serviceType: Service.Type,
         name: String? = nil,
-        factory: @escaping (Resolver, Arg1, Arg2, Arg3) -> Service
+        factory: @escaping (SwinjectResolver, Arg1, Arg2, Arg3) -> Service
     ) -> ServiceEntry<Service> {
         return _register(serviceType, factory: factory, name: name)
     }
@@ -88,7 +88,7 @@ extension Container {
     ///                  that have the same service and factory types.
     ///   - factory:     The closure to specify how the service type is resolved with the dependencies of the type.
     ///                  It is invoked when the `Container` needs to instantiate the instance.
-    ///                  It takes a `Resolver` instance and 4 arguments to inject dependencies to the instance,
+    ///                  It takes a `SwinjectResolver` instance and 4 arguments to inject dependencies to the instance,
     ///                  and returns the instance of the component type for the service.
     ///
     /// - Returns: A registered `ServiceEntry` to configure more settings with method chaining.
@@ -96,7 +96,7 @@ extension Container {
     public func register<Service, Arg1, Arg2, Arg3, Arg4>(
         _ serviceType: Service.Type,
         name: String? = nil,
-        factory: @escaping (Resolver, Arg1, Arg2, Arg3, Arg4) -> Service
+        factory: @escaping (SwinjectResolver, Arg1, Arg2, Arg3, Arg4) -> Service
     ) -> ServiceEntry<Service> {
         return _register(serviceType, factory: factory, name: name)
     }
@@ -109,7 +109,7 @@ extension Container {
     ///                  that have the same service and factory types.
     ///   - factory:     The closure to specify how the service type is resolved with the dependencies of the type.
     ///                  It is invoked when the `Container` needs to instantiate the instance.
-    ///                  It takes a `Resolver` instance and 5 arguments to inject dependencies to the instance,
+    ///                  It takes a `SwinjectResolver` instance and 5 arguments to inject dependencies to the instance,
     ///                  and returns the instance of the component type for the service.
     ///
     /// - Returns: A registered `ServiceEntry` to configure more settings with method chaining.
@@ -117,7 +117,7 @@ extension Container {
     public func register<Service, Arg1, Arg2, Arg3, Arg4, Arg5>(
         _ serviceType: Service.Type,
         name: String? = nil,
-        factory: @escaping (Resolver, Arg1, Arg2, Arg3, Arg4, Arg5) -> Service
+        factory: @escaping (SwinjectResolver, Arg1, Arg2, Arg3, Arg4, Arg5) -> Service
     ) -> ServiceEntry<Service> {
         return _register(serviceType, factory: factory, name: name)
     }
@@ -130,7 +130,7 @@ extension Container {
     ///                  that have the same service and factory types.
     ///   - factory:     The closure to specify how the service type is resolved with the dependencies of the type.
     ///                  It is invoked when the `Container` needs to instantiate the instance.
-    ///                  It takes a `Resolver` instance and 6 arguments to inject dependencies to the instance,
+    ///                  It takes a `SwinjectResolver` instance and 6 arguments to inject dependencies to the instance,
     ///                  and returns the instance of the component type for the service.
     ///
     /// - Returns: A registered `ServiceEntry` to configure more settings with method chaining.
@@ -138,7 +138,7 @@ extension Container {
     public func register<Service, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6>(
         _ serviceType: Service.Type,
         name: String? = nil,
-        factory: @escaping (Resolver, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6) -> Service
+        factory: @escaping (SwinjectResolver, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6) -> Service
     ) -> ServiceEntry<Service> {
         return _register(serviceType, factory: factory, name: name)
     }
@@ -151,7 +151,7 @@ extension Container {
     ///                  that have the same service and factory types.
     ///   - factory:     The closure to specify how the service type is resolved with the dependencies of the type.
     ///                  It is invoked when the `Container` needs to instantiate the instance.
-    ///                  It takes a `Resolver` instance and 7 arguments to inject dependencies to the instance,
+    ///                  It takes a `SwinjectResolver` instance and 7 arguments to inject dependencies to the instance,
     ///                  and returns the instance of the component type for the service.
     ///
     /// - Returns: A registered `ServiceEntry` to configure more settings with method chaining.
@@ -159,7 +159,7 @@ extension Container {
     public func register<Service, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7>(
         _ serviceType: Service.Type,
         name: String? = nil,
-        factory: @escaping (Resolver, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7) -> Service
+        factory: @escaping (SwinjectResolver, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7) -> Service
     ) -> ServiceEntry<Service> {
         return _register(serviceType, factory: factory, name: name)
     }
@@ -172,7 +172,7 @@ extension Container {
     ///                  that have the same service and factory types.
     ///   - factory:     The closure to specify how the service type is resolved with the dependencies of the type.
     ///                  It is invoked when the `Container` needs to instantiate the instance.
-    ///                  It takes a `Resolver` instance and 8 arguments to inject dependencies to the instance,
+    ///                  It takes a `SwinjectResolver` instance and 8 arguments to inject dependencies to the instance,
     ///                  and returns the instance of the component type for the service.
     ///
     /// - Returns: A registered `ServiceEntry` to configure more settings with method chaining.
@@ -180,7 +180,7 @@ extension Container {
     public func register<Service, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8>(
         _ serviceType: Service.Type,
         name: String? = nil,
-        factory: @escaping (Resolver, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8) -> Service
+        factory: @escaping (SwinjectResolver, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8) -> Service
     ) -> ServiceEntry<Service> {
         return _register(serviceType, factory: factory, name: name)
     }
@@ -193,7 +193,7 @@ extension Container {
     ///                  that have the same service and factory types.
     ///   - factory:     The closure to specify how the service type is resolved with the dependencies of the type.
     ///                  It is invoked when the `Container` needs to instantiate the instance.
-    ///                  It takes a `Resolver` instance and 9 arguments to inject dependencies to the instance,
+    ///                  It takes a `SwinjectResolver` instance and 9 arguments to inject dependencies to the instance,
     ///                  and returns the instance of the component type for the service.
     ///
     /// - Returns: A registered `ServiceEntry` to configure more settings with method chaining.
@@ -201,16 +201,16 @@ extension Container {
     public func register<Service, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8, Arg9>(
         _ serviceType: Service.Type,
         name: String? = nil,
-        factory: @escaping (Resolver, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8, Arg9) -> Service
+        factory: @escaping (SwinjectResolver, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8, Arg9) -> Service
     ) -> ServiceEntry<Service> {
         return _register(serviceType, factory: factory, name: name)
     }
 
 }
 
-// MARK: - Resolver with Arguments
+// MARK: - SwinjectResolver with Arguments
 
-extension Container {
+extension SwinjectContainer {
     /// Retrieves the instance with the specified service type and 1 argument to the factory closure.
     ///
     /// - Parameters:
@@ -218,7 +218,7 @@ extension Container {
     ///   - argument:   1 argument to pass to the factory closure.
     ///
     /// - Returns: The resolved service type instance, or nil if no registration for the service type
-    ///            and 1 argument is found in the `Container`.
+    ///            and 1 argument is found in the `SwinjectContainer`.
     public func resolve<Service, Arg1>(
         _ serviceType: Service.Type,
         argument: Arg1) -> Service?
@@ -234,16 +234,16 @@ extension Container {
     ///   - argument:   1 argument to pass to the factory closure.
     ///
     /// - Returns: The resolved service type instance, or nil if no registration for the service type,
-    ///            1 argument and name is found in the `Container`.
+    ///            1 argument and name is found in the `SwinjectContainer`.
     public func resolve<Service, Arg1>(
         _ serviceType: Service.Type,
         name: String?,
         argument: Arg1) -> Service?
     {
-        typealias FactoryType = ((Resolver, Arg1)) -> Any
+        typealias FactoryType = ((SwinjectResolver, Arg1)) -> Any
         return _resolve(
             name: name,
-            invoker: { (resolver: Resolver, factory: FactoryType) in
+            invoker: { (resolver: SwinjectResolver, factory: FactoryType) in
                 factory((resolver, argument))
             }
         )
@@ -256,7 +256,7 @@ extension Container {
     ///   - arguments:   List of 2 arguments to pass to the factory closure.
     ///
     /// - Returns: The resolved service type instance, or nil if no registration for the service type
-    ///            and list of 2 arguments is found in the `Container`.
+    ///            and list of 2 arguments is found in the `SwinjectContainer`.
     public func resolve<Service, Arg1, Arg2>(
         _ serviceType: Service.Type,
         arguments arg1: Arg1, _ arg2: Arg2) -> Service?
@@ -272,16 +272,16 @@ extension Container {
     ///   - arguments:   List of 2 arguments to pass to the factory closure.
     ///
     /// - Returns: The resolved service type instance, or nil if no registration for the service type,
-    ///            list of 2 arguments and name is found in the `Container`.
+    ///            list of 2 arguments and name is found in the `SwinjectContainer`.
     public func resolve<Service, Arg1, Arg2>(
         _ serviceType: Service.Type,
         name: String?,
         arguments arg1: Arg1, _ arg2: Arg2) -> Service?
     {
-        typealias FactoryType = ((Resolver, Arg1, Arg2)) -> Any
+        typealias FactoryType = ((SwinjectResolver, Arg1, Arg2)) -> Any
         return _resolve(
             name: name,
-            invoker: { (resolver: Resolver, factory: FactoryType) in
+            invoker: { (resolver: SwinjectResolver, factory: FactoryType) in
                 factory((resolver, arg1, arg2))
             }
         )
@@ -294,7 +294,7 @@ extension Container {
     ///   - arguments:   List of 3 arguments to pass to the factory closure.
     ///
     /// - Returns: The resolved service type instance, or nil if no registration for the service type
-    ///            and list of 3 arguments is found in the `Container`.
+    ///            and list of 3 arguments is found in the `SwinjectContainer`.
     public func resolve<Service, Arg1, Arg2, Arg3>(
         _ serviceType: Service.Type,
         arguments arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3) -> Service?
@@ -310,16 +310,16 @@ extension Container {
     ///   - arguments:   List of 3 arguments to pass to the factory closure.
     ///
     /// - Returns: The resolved service type instance, or nil if no registration for the service type,
-    ///            list of 3 arguments and name is found in the `Container`.
+    ///            list of 3 arguments and name is found in the `SwinjectContainer`.
     public func resolve<Service, Arg1, Arg2, Arg3>(
         _ serviceType: Service.Type,
         name: String?,
         arguments arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3) -> Service?
     {
-        typealias FactoryType = ((Resolver, Arg1, Arg2, Arg3)) -> Any
+        typealias FactoryType = ((SwinjectResolver, Arg1, Arg2, Arg3)) -> Any
         return _resolve(
             name: name,
-            invoker: { (resolver: Resolver, factory: FactoryType) in
+            invoker: { (resolver: SwinjectResolver, factory: FactoryType) in
                 factory((resolver, arg1, arg2, arg3))
             }
         )
@@ -332,7 +332,7 @@ extension Container {
     ///   - arguments:   List of 4 arguments to pass to the factory closure.
     ///
     /// - Returns: The resolved service type instance, or nil if no registration for the service type
-    ///            and list of 4 arguments is found in the `Container`.
+    ///            and list of 4 arguments is found in the `SwinjectContainer`.
     public func resolve<Service, Arg1, Arg2, Arg3, Arg4>(
         _ serviceType: Service.Type,
         arguments arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3, _ arg4: Arg4) -> Service?
@@ -348,16 +348,16 @@ extension Container {
     ///   - arguments:   List of 4 arguments to pass to the factory closure.
     ///
     /// - Returns: The resolved service type instance, or nil if no registration for the service type,
-    ///            list of 4 arguments and name is found in the `Container`.
+    ///            list of 4 arguments and name is found in the `SwinjectContainer`.
     public func resolve<Service, Arg1, Arg2, Arg3, Arg4>(
         _ serviceType: Service.Type,
         name: String?,
         arguments arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3, _ arg4: Arg4) -> Service?
     {
-        typealias FactoryType = ((Resolver, Arg1, Arg2, Arg3, Arg4)) -> Any
+        typealias FactoryType = ((SwinjectResolver, Arg1, Arg2, Arg3, Arg4)) -> Any
         return _resolve(
             name: name,
-            invoker: { (resolver: Resolver, factory: FactoryType) in
+            invoker: { (resolver: SwinjectResolver, factory: FactoryType) in
                 factory((resolver, arg1, arg2, arg3, arg4))
             }
         )
@@ -370,7 +370,7 @@ extension Container {
     ///   - arguments:   List of 5 arguments to pass to the factory closure.
     ///
     /// - Returns: The resolved service type instance, or nil if no registration for the service type
-    ///            and list of 5 arguments is found in the `Container`.
+    ///            and list of 5 arguments is found in the `SwinjectContainer`.
     public func resolve<Service, Arg1, Arg2, Arg3, Arg4, Arg5>(
         _ serviceType: Service.Type,
         arguments arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3, _ arg4: Arg4, _ arg5: Arg5) -> Service?
@@ -386,16 +386,16 @@ extension Container {
     ///   - arguments:   List of 5 arguments to pass to the factory closure.
     ///
     /// - Returns: The resolved service type instance, or nil if no registration for the service type,
-    ///            list of 5 arguments and name is found in the `Container`.
+    ///            list of 5 arguments and name is found in the `SwinjectContainer`.
     public func resolve<Service, Arg1, Arg2, Arg3, Arg4, Arg5>(
         _ serviceType: Service.Type,
         name: String?,
         arguments arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3, _ arg4: Arg4, _ arg5: Arg5) -> Service?
     {
-        typealias FactoryType = ((Resolver, Arg1, Arg2, Arg3, Arg4, Arg5)) -> Any
+        typealias FactoryType = ((SwinjectResolver, Arg1, Arg2, Arg3, Arg4, Arg5)) -> Any
         return _resolve(
             name: name,
-            invoker: { (resolver: Resolver, factory: FactoryType) in
+            invoker: { (resolver: SwinjectResolver, factory: FactoryType) in
                 factory((resolver, arg1, arg2, arg3, arg4, arg5))
             }
         )
@@ -408,7 +408,7 @@ extension Container {
     ///   - arguments:   List of 6 arguments to pass to the factory closure.
     ///
     /// - Returns: The resolved service type instance, or nil if no registration for the service type
-    ///            and list of 6 arguments is found in the `Container`.
+    ///            and list of 6 arguments is found in the `SwinjectContainer`.
     public func resolve<Service, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6>(
         _ serviceType: Service.Type,
         arguments arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3, _ arg4: Arg4, _ arg5: Arg5, _ arg6: Arg6) -> Service?
@@ -424,16 +424,16 @@ extension Container {
     ///   - arguments:   List of 6 arguments to pass to the factory closure.
     ///
     /// - Returns: The resolved service type instance, or nil if no registration for the service type,
-    ///            list of 6 arguments and name is found in the `Container`.
+    ///            list of 6 arguments and name is found in the `SwinjectContainer`.
     public func resolve<Service, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6>(
         _ serviceType: Service.Type,
         name: String?,
         arguments arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3, _ arg4: Arg4, _ arg5: Arg5, _ arg6: Arg6) -> Service?
     {
-        typealias FactoryType = ((Resolver, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6)) -> Any
+        typealias FactoryType = ((SwinjectResolver, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6)) -> Any
         return _resolve(
             name: name,
-            invoker: { (resolver: Resolver, factory: FactoryType) in
+            invoker: { (resolver: SwinjectResolver, factory: FactoryType) in
                 factory((resolver, arg1, arg2, arg3, arg4, arg5, arg6))
             }
         )
@@ -446,7 +446,7 @@ extension Container {
     ///   - arguments:   List of 7 arguments to pass to the factory closure.
     ///
     /// - Returns: The resolved service type instance, or nil if no registration for the service type
-    ///            and list of 7 arguments is found in the `Container`.
+    ///            and list of 7 arguments is found in the `SwinjectContainer`.
     public func resolve<Service, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7>(
         _ serviceType: Service.Type,
         arguments arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3, _ arg4: Arg4, _ arg5: Arg5, _ arg6: Arg6, _ arg7: Arg7) -> Service?
@@ -462,16 +462,16 @@ extension Container {
     ///   - arguments:   List of 7 arguments to pass to the factory closure.
     ///
     /// - Returns: The resolved service type instance, or nil if no registration for the service type,
-    ///            list of 7 arguments and name is found in the `Container`.
+    ///            list of 7 arguments and name is found in the `SwinjectContainer`.
     public func resolve<Service, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7>(
         _ serviceType: Service.Type,
         name: String?,
         arguments arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3, _ arg4: Arg4, _ arg5: Arg5, _ arg6: Arg6, _ arg7: Arg7) -> Service?
     {
-        typealias FactoryType = ((Resolver, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7)) -> Any
+        typealias FactoryType = ((SwinjectResolver, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7)) -> Any
         return _resolve(
             name: name,
-            invoker: { (resolver: Resolver, factory: FactoryType) in
+            invoker: { (resolver: SwinjectResolver, factory: FactoryType) in
                 factory((resolver, arg1, arg2, arg3, arg4, arg5, arg6, arg7))
             }
         )
@@ -484,7 +484,7 @@ extension Container {
     ///   - arguments:   List of 8 arguments to pass to the factory closure.
     ///
     /// - Returns: The resolved service type instance, or nil if no registration for the service type
-    ///            and list of 8 arguments is found in the `Container`.
+    ///            and list of 8 arguments is found in the `SwinjectContainer`.
     public func resolve<Service, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8>(
         _ serviceType: Service.Type,
         arguments arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3, _ arg4: Arg4, _ arg5: Arg5, _ arg6: Arg6, _ arg7: Arg7, _ arg8: Arg8) -> Service?
@@ -500,16 +500,16 @@ extension Container {
     ///   - arguments:   List of 8 arguments to pass to the factory closure.
     ///
     /// - Returns: The resolved service type instance, or nil if no registration for the service type,
-    ///            list of 8 arguments and name is found in the `Container`.
+    ///            list of 8 arguments and name is found in the `SwinjectContainer`.
     public func resolve<Service, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8>(
         _ serviceType: Service.Type,
         name: String?,
         arguments arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3, _ arg4: Arg4, _ arg5: Arg5, _ arg6: Arg6, _ arg7: Arg7, _ arg8: Arg8) -> Service?
     {
-        typealias FactoryType = ((Resolver, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8)) -> Any
+        typealias FactoryType = ((SwinjectResolver, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8)) -> Any
         return _resolve(
             name: name,
-            invoker: { (resolver: Resolver, factory: FactoryType) in
+            invoker: { (resolver: SwinjectResolver, factory: FactoryType) in
                 factory((resolver, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8))
             }
         )
@@ -522,7 +522,7 @@ extension Container {
     ///   - arguments:   List of 9 arguments to pass to the factory closure.
     ///
     /// - Returns: The resolved service type instance, or nil if no registration for the service type
-    ///            and list of 9 arguments is found in the `Container`.
+    ///            and list of 9 arguments is found in the `SwinjectContainer`.
     public func resolve<Service, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8, Arg9>(
         _ serviceType: Service.Type,
         arguments arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3, _ arg4: Arg4, _ arg5: Arg5, _ arg6: Arg6, _ arg7: Arg7, _ arg8: Arg8, _ arg9: Arg9) -> Service?
@@ -538,16 +538,16 @@ extension Container {
     ///   - arguments:   List of 9 arguments to pass to the factory closure.
     ///
     /// - Returns: The resolved service type instance, or nil if no registration for the service type,
-    ///            list of 9 arguments and name is found in the `Container`.
+    ///            list of 9 arguments and name is found in the `SwinjectContainer`.
     public func resolve<Service, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8, Arg9>(
         _ serviceType: Service.Type,
         name: String?,
         arguments arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3, _ arg4: Arg4, _ arg5: Arg5, _ arg6: Arg6, _ arg7: Arg7, _ arg8: Arg8, _ arg9: Arg9) -> Service?
     {
-        typealias FactoryType = ((Resolver, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8, Arg9)) -> Any
+        typealias FactoryType = ((SwinjectResolver, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8, Arg9)) -> Any
         return _resolve(
             name: name,
-            invoker: { (resolver: Resolver, factory: FactoryType) in
+            invoker: { (resolver: SwinjectResolver, factory: FactoryType) in
                 factory((resolver, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9))
             }
         )

--- a/Sources/Swinject/SwinjectContainer.Logging.swift
+++ b/Sources/Swinject/SwinjectContainer.Logging.swift
@@ -4,7 +4,7 @@
 
 public typealias LoggingFunctionType = (String) -> Void
 
-public extension Container {
+public extension SwinjectContainer {
     /// Function to be used for logging debugging data.
     /// Default implementation writes to standard output.
     static var loggingFunction: LoggingFunctionType? {

--- a/Sources/Swinject/SwinjectContainer.TypeForwarding.swift
+++ b/Sources/Swinject/SwinjectContainer.TypeForwarding.swift
@@ -2,7 +2,7 @@
 //  Copyright © 2019 Swinject Contributors. All rights reserved.
 //
 
-extension Container {
+extension SwinjectContainer {
     /// Adds the registration for `type` which resolves in the same way, as would the type
     /// used to create the original `service` - i.e. using the same object scope,
     /// arguments and `initCompleted` closures.

--- a/Sources/Swinject/SwinjectResolver.erb
+++ b/Sources/Swinject/SwinjectResolver.erb
@@ -6,14 +6,14 @@
 //
 // NOTICE:
 //
-// Resolver.swift is generated from Resolver.erb by ERB.
-// Do NOT modify Container.Arguments.swift directly.
-// Instead, modify Resolver.erb and run `Scripts/gencode` at the project root directory to generate the code.
+// SwinjectResolver.swift is generated from Resolver.erb by ERB.
+// Do NOT modify SwinjectResolver.swift directly.
+// Instead, modify SwinjectResolver.erb and run `Scripts/gencode` at the project root directory to generate the code.
 //
 
 <% arg_count = 9 %>
 
-public protocol Resolver: AnyObject {
+public protocol SwinjectResolver: AnyObject {
     /// Retrieves the instance with the specified service type.
     ///
     /// - Parameter serviceType: The service type to resolve.

--- a/Sources/Swinject/SwinjectResolver.swift
+++ b/Sources/Swinject/SwinjectResolver.swift
@@ -6,13 +6,13 @@
 //
 // NOTICE:
 //
-// Resolver.swift is generated from Resolver.erb by ERB.
-// Do NOT modify Container.Arguments.swift directly.
-// Instead, modify Resolver.erb and run `Scripts/gencode` at the project root directory to generate the code.
+// SwinjectResolver.swift is generated from Resolver.erb by ERB.
+// Do NOT modify SwinjectResolver.swift directly.
+// Instead, modify SwinjectResolver.erb and run `Scripts/gencode` at the project root directory to generate the code.
 //
 
 
-public protocol Resolver: AnyObject {
+public protocol SwinjectResolver: AnyObject {
     /// Retrieves the instance with the specified service type.
     ///
     /// - Parameter serviceType: The service type to resolve.

--- a/Sources/Swinject/_Resolver.swift
+++ b/Sources/Swinject/_Resolver.swift
@@ -21,6 +21,6 @@ public protocol _Resolver {
     func _resolve<Service, Arguments>(
         name: String?,
         option: ServiceKeyOption?,
-        invoker: @escaping (Resolver, (Arguments) -> Any) -> Any
+        invoker: @escaping (SwinjectResolver, (Arguments) -> Any) -> Any
     ) -> Service?
 }

--- a/Tests/KnitMacrosTests/SwinjectResolutionTests.swift
+++ b/Tests/KnitMacrosTests/SwinjectResolutionTests.swift
@@ -23,14 +23,14 @@ final class SwinjectResolutionTests: XCTestCase {
     }
     
     func test_default_value() {
-        let emptyContainer = Container()
+        let emptyContainer = SwinjectContainer()
         emptyContainer.register(Service3.self, factory: Service3.make)
         let defaultedService = emptyContainer.resolve(Service3.self)
         XCTAssertEqual(defaultedService?.value, 2)
     }
 
     func test_argument() {
-        let container = Container()
+        let container = SwinjectContainer()
         container.register(Service4.self, factory: Service4.make)
         
         let service = container.resolve(Service4.self, argument: Float(5))
@@ -38,7 +38,7 @@ final class SwinjectResolutionTests: XCTestCase {
     }
     
     func test_named_parameter() {
-        let container = Container()
+        let container = SwinjectContainer()
         container.register(Float.self, name: "float2") { _ in 2}
         container.register(Service5.self, factory: Service5.make)
         
@@ -47,7 +47,7 @@ final class SwinjectResolutionTests: XCTestCase {
     }
 
     func test_static_function() {
-        let container = Container()
+        let container = SwinjectContainer()
         container.register(Service3.self, factory: Service3.makeService(resolver:))
 
         let service = container.resolve(Service3.self)
@@ -60,7 +60,7 @@ private struct Service1 {
     let string: String
     let value: Int
     
-    @Resolvable<Swinject.Resolver>
+    @Resolvable<SwinjectResolver>
     init(string: String, value: Int) {
         self.string = string
         self.value = value
@@ -70,7 +70,7 @@ private struct Service1 {
 private struct Service2 {
     let closure: () -> Void
     
-    @Resolvable<Swinject.Resolver>
+    @Resolvable<SwinjectResolver>
     init(closure: @escaping () -> Void) {
         self.closure = closure
     }
@@ -80,12 +80,12 @@ private struct Service3 {
     
     let value: Int
     
-    @Resolvable<Swinject.Resolver>
+    @Resolvable<SwinjectResolver>
     init(@UseDefault defaultedValue: Int = 2) {
         self.value = defaultedValue
     }
 
-    @Resolvable<Swinject.Resolver>
+    @Resolvable<SwinjectResolver>
     static func makeService() -> Service3 {
         return .init(defaultedValue: 5)
     }
@@ -93,7 +93,7 @@ private struct Service3 {
 
 private struct Service4 {
     let value: Float
-    @Resolvable<Swinject.Resolver>
+    @Resolvable<SwinjectResolver>
     init(@Argument value: Float) {
         self.value = value
     }
@@ -101,15 +101,15 @@ private struct Service4 {
 
 private struct Service5 {
     let value: Float
-    @Resolvable<Swinject.Resolver>
+    @Resolvable<SwinjectResolver>
     init(@Named("float2") value: Float) {
         self.value = value
     }
 }
 
 private enum Factory {
-    static var container: Swinject.Container {
-        let container = Container()
+    static var container: SwinjectContainer {
+        let container = SwinjectContainer()
         container.register(String.self) { _ in "Test" }
         container.register(Int.self) { _ in 5 }
         container.register((()->Void).self) { _ in
@@ -128,7 +128,7 @@ enum FloatName: String {
     case float2
 }
 
-private extension Swinject.Resolver {
+private extension SwinjectResolver {
 
     func float(name: FloatName) -> Float {
         resolve(Float.self, name: name.rawValue)!

--- a/Tests/KnitTests/AbstractRegistrationTests.swift
+++ b/Tests/KnitTests/AbstractRegistrationTests.swift
@@ -10,7 +10,7 @@ import XCTest
 final class AbstractRegistrationTests: XCTestCase {
 
     func testMissingRegistration() {
-        let swinjectContainer = Swinject.Container()
+        let swinjectContainer = SwinjectContainer()
         let container = ContainerManager(swinjectContainer: swinjectContainer).register(TestResolver.self)
         let abstractRegistrations = container._unwrappedSwinjectContainer().registerAbstractContainer()
         container.registerAbstract(String.self)
@@ -30,7 +30,7 @@ final class AbstractRegistrationTests: XCTestCase {
     }
 
     func testFilledRegistrations() {
-        let swinjectContainer = Swinject.Container()
+        let swinjectContainer = SwinjectContainer()
         let container = ContainerManager(swinjectContainer: swinjectContainer).register(TestResolver.self)
         let abstractRegistrations = container._unwrappedSwinjectContainer().registerAbstractContainer()
         container.registerAbstract(String.self)
@@ -46,7 +46,7 @@ final class AbstractRegistrationTests: XCTestCase {
     }
 
     func testNamedRegistrations() {
-        let swinjectContainer = Swinject.Container()
+        let swinjectContainer = SwinjectContainer()
         let container = ContainerManager(swinjectContainer: swinjectContainer).register(TestResolver.self)
         let abstractRegistrations = container._unwrappedSwinjectContainer().registerAbstractContainer()
         container.registerAbstract(String.self)
@@ -63,7 +63,7 @@ final class AbstractRegistrationTests: XCTestCase {
     }
 
     func testPreRegistered() {
-        let swinjectContainer = Swinject.Container()
+        let swinjectContainer = SwinjectContainer()
         let container = ContainerManager(swinjectContainer: swinjectContainer).register(TestResolver.self)
         let abstractRegistrations = container._unwrappedSwinjectContainer().registerAbstractContainer()
         container.register(String.self) { _ in "Test" }
@@ -144,7 +144,7 @@ private struct AnyPublisherAbstractRegistration<UnwrappedServiceType>: AbstractR
     var serviceDescription: String { String(describing: ServiceType.self) }
 
     func registerPlaceholder(
-        container: Swinject.Container,
+        container: SwinjectContainer,
         errorFormatter: any Knit.ModuleAssemblerErrorFormatter,
         dependencyTree: Knit.DependencyTree
     ) {

--- a/Tests/KnitTests/DuplicateRegistrationDetectorTests.swift
+++ b/Tests/KnitTests/DuplicateRegistrationDetectorTests.swift
@@ -13,7 +13,7 @@ final class DuplicateRegistrationDetectorTests: XCTestCase {
         let duplicateRegistrationDetector = DuplicateRegistrationDetector(duplicateWasDetected: { key in
             reportedDuplicates.append(key)
         })
-        let container = Container(
+        let container = SwinjectContainer(
             behaviors: [duplicateRegistrationDetector]
         )
 
@@ -25,7 +25,7 @@ final class DuplicateRegistrationDetectorTests: XCTestCase {
         XCTAssertEqual(reportedDuplicates.count, 1)
         let firstReport = try XCTUnwrap(reportedDuplicates.first)
         XCTAssert(firstReport.serviceType == String.self)
-        XCTAssert(firstReport.argumentsType == (Swinject.Resolver).self)
+        XCTAssert(firstReport.argumentsType == (SwinjectResolver).self)
         XCTAssertEqual(firstReport.name, nil)
 
         container.register(String.self, factory: { _ in "three" })
@@ -37,7 +37,7 @@ final class DuplicateRegistrationDetectorTests: XCTestCase {
         let duplicateRegistrationDetector = DuplicateRegistrationDetector(duplicateWasDetected: { key in
             reportedDuplicates.append(key)
         })
-        let container = Container(
+        let container = SwinjectContainer(
             behaviors: [duplicateRegistrationDetector]
         )
 
@@ -51,7 +51,7 @@ final class DuplicateRegistrationDetectorTests: XCTestCase {
         XCTAssertEqual(reportedDuplicates.count, 1)
         let firstReport = try XCTUnwrap(reportedDuplicates.first)
         XCTAssert(firstReport.serviceType == String.self)
-        XCTAssert(firstReport.argumentsType == (Swinject.Resolver).self)
+        XCTAssert(firstReport.argumentsType == (SwinjectResolver).self)
         XCTAssertEqual(firstReport.name, "nameOne")
     }
 
@@ -60,7 +60,7 @@ final class DuplicateRegistrationDetectorTests: XCTestCase {
         let duplicateRegistrationDetector = DuplicateRegistrationDetector(duplicateWasDetected: { key in
             reportedDuplicates.append(key)
         })
-        let container = Container(
+        let container = SwinjectContainer(
             behaviors: [duplicateRegistrationDetector]
         )
 
@@ -74,7 +74,7 @@ final class DuplicateRegistrationDetectorTests: XCTestCase {
         XCTAssertEqual(reportedDuplicates.count, 1)
         let firstReport = try XCTUnwrap(reportedDuplicates.first)
         XCTAssert(firstReport.serviceType == String.self)
-        XCTAssert(firstReport.argumentsType == (Swinject.Resolver, Int).self)
+        XCTAssert(firstReport.argumentsType == (SwinjectResolver, Int).self)
         XCTAssertEqual(firstReport.name, nil)
     }
 
@@ -83,7 +83,7 @@ final class DuplicateRegistrationDetectorTests: XCTestCase {
         let duplicateRegistrationDetector = DuplicateRegistrationDetector(duplicateWasDetected: { key in
             reportedDuplicates.append(key)
         })
-        let container = Container(
+        let container = SwinjectContainer(
             behaviors: [duplicateRegistrationDetector]
         )
 
@@ -102,12 +102,12 @@ final class DuplicateRegistrationDetectorTests: XCTestCase {
         let parentDuplicateRegistrationDetector = DuplicateRegistrationDetector(duplicateWasDetected: { key in
             reportedDuplicates.append(key)
         })
-        let parentContainer = Container(behaviors: [parentDuplicateRegistrationDetector])
+        let parentContainer = SwinjectContainer(behaviors: [parentDuplicateRegistrationDetector])
 
         let childDuplicateRegistrationDetector = DuplicateRegistrationDetector(duplicateWasDetected: { key in
             reportedDuplicates.append(key)
         })
-        let childContainer = Container(parent: parentContainer, behaviors: [childDuplicateRegistrationDetector])
+        let childContainer = SwinjectContainer(parent: parentContainer, behaviors: [childDuplicateRegistrationDetector])
 
         parentContainer.register(String.self, factory: { _ in "parent" })
         childContainer.register(String.self, factory: { _ in "child" })
@@ -118,7 +118,7 @@ final class DuplicateRegistrationDetectorTests: XCTestCase {
     func testTypeForwarding() throws {
         // A forwarded type (`.implements()`) should not cause a duplicate registration
         let duplicateRegistrationDetector = DuplicateRegistrationDetector()
-        let container = Container(behaviors: [duplicateRegistrationDetector])
+        let container = SwinjectContainer(behaviors: [duplicateRegistrationDetector])
 
         XCTAssertEqual(duplicateRegistrationDetector.detectedKeys.count, 0)
         container.register(String.self, factory: { _ in "string"} )

--- a/Tests/KnitTests/ModuleAssemblerTests.swift
+++ b/Tests/KnitTests/ModuleAssemblerTests.swift
@@ -102,21 +102,21 @@ final class ModuleAssemblerTests: XCTestCase {
 
         var services = assembler._swinjectContainer.services.filter { (key, value) in
             // Filter out registrations for `AbstractRegistrationContainer` and `DependencyTree`
-            return key.serviceType != Container.AbstractRegistrationContainer.self &&
+            return key.serviceType != SwinjectContainer.AbstractRegistrationContainer.self &&
             key.serviceType != DependencyTree.self && key.serviceType != ContainerManager.self
         }
         XCTAssertEqual(services.count, 3)
 
         XCTAssertNotNil(services.removeValue(forKey: .init(
             serviceType: Assembly5Protocol.self,
-            argumentsType: (Swinject.Resolver).self,
+            argumentsType: (SwinjectResolver).self,
             name: nil
         )), "Service entry for Assembly5Protocol without name should exist")
         XCTAssertEqual(services.count, 2)
 
         XCTAssertNotNil(services.removeValue(forKey: .init(
             serviceType: Assembly5Protocol.self,
-            argumentsType: (Swinject.Resolver).self,
+            argumentsType: (SwinjectResolver).self,
             name: "testName"
         )), "Service entry for Assembly5Protocol with name should exist")
         

--- a/Tests/KnitTests/ScopedModuleAssemblerTests.swift
+++ b/Tests/KnitTests/ScopedModuleAssemblerTests.swift
@@ -50,7 +50,7 @@ final class ScopedModuleAssemblerTests: XCTestCase {
         let foundBehaviors = container.behaviors.filter { behavior in
             let behaviorType = type(of: behavior)
             return behaviorType != ServiceCollector.self &&
-                behaviorType != Container.AbstractRegistrationContainer.self
+                behaviorType != SwinjectContainer.AbstractRegistrationContainer.self
         }
         // There should only be one behavior left
         XCTAssertEqual(foundBehaviors.count, 1)
@@ -66,7 +66,7 @@ private struct Assembly1: AutoInitModuleAssembly {
     func assemble(container: Knit.Container<Self.TargetResolver>) { }
 }
 
-protocol OutsideResolver: Swinject.Resolver { }
+protocol OutsideResolver: SwinjectResolver { }
 
 private struct Assembly2: AutoInitModuleAssembly {
     typealias TargetResolver = OutsideResolver
@@ -83,7 +83,7 @@ private struct Assembly3: AutoInitModuleAssembly {
 private final class TestBehavior: Behavior {
 
     func container<Type, Service>(
-        _ container: Swinject.Container,
+        _ container: SwinjectContainer,
         didRegisterType type: Type.Type,
         toService entry: Swinject.ServiceEntry<Service>,
         withName name: String?

--- a/Tests/KnitTests/ServiceCollectorTests.swift
+++ b/Tests/KnitTests/ServiceCollectorTests.swift
@@ -86,7 +86,7 @@ final class ServiceCollectorTests: XCTestCase {
 
     @MainActor
     func test_registerIntoCollection() {
-        let swinjectContainer = Swinject.Container()
+        let swinjectContainer = SwinjectContainer()
         let container = ContainerManager(swinjectContainer: swinjectContainer).register(Any.self)
         container._unwrappedSwinjectContainer().addBehavior(ServiceCollector())
 
@@ -113,7 +113,7 @@ final class ServiceCollectorTests: XCTestCase {
 
     @MainActor
     func test_registerIntoCollection_emptyWithBehavior() {
-        let swinjectContainer = Swinject.Container()
+        let swinjectContainer = SwinjectContainer()
         let container = ContainerManager(swinjectContainer: swinjectContainer).register(Any.self)
         container._unwrappedSwinjectContainer().addBehavior(ServiceCollector())
 
@@ -123,7 +123,7 @@ final class ServiceCollectorTests: XCTestCase {
 
     @MainActor
     func test_registerIntoCollection_emptyWithoutBehavior() {
-        let swinjectContainer = Swinject.Container()
+        let swinjectContainer = SwinjectContainer()
         let container = ContainerManager(swinjectContainer: swinjectContainer).register(Any.self)
 
         let collection = container.resolveCollection(ServiceProtocol.self)
@@ -134,7 +134,7 @@ final class ServiceCollectorTests: XCTestCase {
     /// A conflict here would be confusing and surprising to the user.
     @MainActor
     func test_registerIntoCollection_doesntConflictWithArray() throws {
-        let swinjectContainer = Swinject.Container()
+        let swinjectContainer = SwinjectContainer()
         let container = ContainerManager(swinjectContainer: swinjectContainer).register(Any.self)
         container._unwrappedSwinjectContainer().addBehavior(ServiceCollector())
 
@@ -157,7 +157,7 @@ final class ServiceCollectorTests: XCTestCase {
 
     @MainActor
     func test_registerIntoCollection_doesntImplicitlyAggregateInstances() throws {
-        let swinjectContainer = Swinject.Container()
+        let swinjectContainer = SwinjectContainer()
         let container = ContainerManager(swinjectContainer: swinjectContainer).register(Any.self)
         container._unwrappedSwinjectContainer().addBehavior(ServiceCollector())
 
@@ -180,7 +180,7 @@ final class ServiceCollectorTests: XCTestCase {
 
     @MainActor
     func test_registerIntoCollection_allowsDuplicates() {
-        let swinjectContainer = Swinject.Container()
+        let swinjectContainer = SwinjectContainer()
         let container = ContainerManager(swinjectContainer: swinjectContainer).register(Any.self)
         container._unwrappedSwinjectContainer().addBehavior(ServiceCollector())
 
@@ -201,7 +201,7 @@ final class ServiceCollectorTests: XCTestCase {
 
     @MainActor
     func test_registerIntoCollection_supportsTransientScopedObjects() throws {
-        let swinjectContainer = Swinject.Container()
+        let swinjectContainer = SwinjectContainer()
         let container = ContainerManager(swinjectContainer: swinjectContainer).register(Any.self)
         container._unwrappedSwinjectContainer().addBehavior(ServiceCollector())
 
@@ -222,7 +222,7 @@ final class ServiceCollectorTests: XCTestCase {
 
     @MainActor
     func test_registerIntoCollection_supportsContainerScopedObjects() throws {
-        let swinjectContainer = Swinject.Container()
+        let swinjectContainer = SwinjectContainer()
         let container = ContainerManager(swinjectContainer: swinjectContainer).register(Any.self)
         container._unwrappedSwinjectContainer().addBehavior(ServiceCollector())
 
@@ -243,7 +243,7 @@ final class ServiceCollectorTests: XCTestCase {
 
     @MainActor
     func test_registerIntoCollection_supportsWeakScopedObjects() throws {
-        let swinjectContainer = Swinject.Container()
+        let swinjectContainer = SwinjectContainer()
         let container = ContainerManager(swinjectContainer: swinjectContainer).register(Any.self)
         container._unwrappedSwinjectContainer().addBehavior(ServiceCollector())
 

--- a/Tests/KnitTests/TestResolver.swift
+++ b/Tests/KnitTests/TestResolver.swift
@@ -26,7 +26,7 @@ extension ModuleAssembler {
         assemblyValidation: ((any ModuleAssembly.Type) throws -> Void)? = nil,
         errorFormatter: ModuleAssemblerErrorFormatter = DefaultModuleAssemblerErrorFormatter(),
         behaviors: [Behavior] = [],
-        postAssemble: ((Swinject.Container) -> Void)? = nil
+        postAssemble: ((SwinjectContainer) -> Void)? = nil
     ) throws {
         try self.init(
             parent: parent,

--- a/Tests/SwinjectTests/BehaviorFakes.swift
+++ b/Tests/SwinjectTests/BehaviorFakes.swift
@@ -10,7 +10,7 @@ class BehaviorSpy: Behavior {
     var types = [Any.Type]()
 
     func container<Type, Service>(
-        _: Container,
+        _: SwinjectContainer,
         didRegisterType type: Type.Type,
         toService entry: ServiceEntry<Service>,
         withName name: String?

--- a/Tests/SwinjectTests/ContainerTests.Arguments.swift
+++ b/Tests/SwinjectTests/ContainerTests.Arguments.swift
@@ -6,10 +6,10 @@ import XCTest
 @testable import Swinject
 
 class ContainerTests_Arguments: XCTestCase {
-    var container: Container!
+    var container: SwinjectContainer!
 
     override func setUpWithError() throws {
-        container = Container()
+        container = SwinjectContainer()
     }
 
     func testContainierAccepts1Argument() {

--- a/Tests/SwinjectTests/ContainerTests.Behavior.swift
+++ b/Tests/SwinjectTests/ContainerTests.Behavior.swift
@@ -6,10 +6,10 @@ import XCTest
 @testable import Swinject
 
 class ContainerTests_Behavior: XCTestCase {
-    var container: Container!
+    var container: SwinjectContainer!
 
     override func setUpWithError() throws {
-        container = Container()
+        container = SwinjectContainer()
     }
 
     // MARK: Adding service
@@ -88,7 +88,7 @@ class ContainerTests_Behavior: XCTestCase {
     func testConvenienceInitializerAddsBehaviorsToContainer() {
         let spy1 = BehaviorSpy()
         let spy2 = BehaviorSpy()
-        container = Container(behaviors: [spy1, spy2])
+        container = SwinjectContainer(behaviors: [spy1, spy2])
 
         container.register(Dog.self) { _ in Dog() }
 

--- a/Tests/SwinjectTests/ContainerTests.Circularity.swift
+++ b/Tests/SwinjectTests/ContainerTests.Circularity.swift
@@ -6,10 +6,10 @@ import XCTest
 @testable import Swinject
 
 class ContainerTests_Circularity: XCTestCase {
-    var container: Container!
+    var container: SwinjectContainer!
 
     override func setUpWithError() throws {
-        container = Container()
+        container = SwinjectContainer()
     }
 
     // MARK: Two objects

--- a/Tests/SwinjectTests/ContainerTests.CustomScope.swift
+++ b/Tests/SwinjectTests/ContainerTests.CustomScope.swift
@@ -6,10 +6,10 @@ import XCTest
 @testable import Swinject
 
 class ContainerTests_CustomScope: XCTestCase {
-    var container: Container!
+    var container: SwinjectContainer!
 
     override func setUpWithError() throws {
-        container = Container()
+        container = SwinjectContainer()
     }
 
     // MARK: Resolving from custom scope
@@ -75,7 +75,7 @@ class ContainerTests_CustomScope: XCTestCase {
     func testContainerRemovesInstanceFromServiceRegisteredInParentContainer() {
         let storage = FakeStorage()
         let custom = ObjectScope(storageFactory: { storage })
-        let child = Container(parent: container)
+        let child = SwinjectContainer(parent: container)
 
         container.register(Int.self) { _ in 0 }.inObjectScope(custom)
         storage.instance = 42

--- a/Tests/SwinjectTests/ContainerTests.CustomStringConvertible.swift
+++ b/Tests/SwinjectTests/ContainerTests.CustomStringConvertible.swift
@@ -6,10 +6,10 @@ import XCTest
 @testable import Swinject
 
 class ContainerTests_CustomStringConvertible: XCTestCase {
-    var container: Container!
+    var container: SwinjectContainer!
 
     override func setUpWithError() throws {
-        container = Container()
+        container = SwinjectContainer()
     }
 
     func testContainerDescribesEmptyDescriptionWithoutServiceRegistrations() {
@@ -21,7 +21,7 @@ class ContainerTests_CustomStringConvertible: XCTestCase {
 
         XCTAssertEqual(container.description,
             "[\n"
-            + "    { Service: Animal, Factory: Resolver -> Animal, ObjectScope: graph }\n"
+            + "    { Service: Animal, Factory: SwinjectResolver -> Animal, ObjectScope: graph }\n"
             + "]")
     }
 
@@ -30,7 +30,7 @@ class ContainerTests_CustomStringConvertible: XCTestCase {
 
         XCTAssertEqual(container.description,
             "[\n"
-            + "    { Service: Animal, Name: \"My Cat\", Factory: Resolver -> Animal, ObjectScope: graph }\n"
+            + "    { Service: Animal, Name: \"My Cat\", Factory: SwinjectResolver -> Animal, ObjectScope: graph }\n"
             + "]")
     }
 
@@ -39,7 +39,7 @@ class ContainerTests_CustomStringConvertible: XCTestCase {
 
         XCTAssertEqual(container.description,
             "[\n"
-            + "    { Service: Animal, Factory: (Resolver, String, Bool) -> Animal, ObjectScope: graph }\n"
+            + "    { Service: Animal, Factory: (SwinjectResolver, String, Bool) -> Animal, ObjectScope: graph }\n"
             + "]")
     }
 
@@ -49,7 +49,7 @@ class ContainerTests_CustomStringConvertible: XCTestCase {
 
         XCTAssertEqual(container.description,
             "[\n"
-            + "    { Service: Animal, Factory: Resolver -> Animal, ObjectScope: container }\n"
+            + "    { Service: Animal, Factory: SwinjectResolver -> Animal, ObjectScope: container }\n"
             + "]")
     }
 
@@ -59,7 +59,7 @@ class ContainerTests_CustomStringConvertible: XCTestCase {
 
         XCTAssertEqual(container.description,
             "[\n"
-            + "    { Service: Animal, Factory: Resolver -> Animal, ObjectScope: graph, "
+            + "    { Service: Animal, Factory: SwinjectResolver -> Animal, ObjectScope: graph, "
             + "InitCompleted: Specified 1 closures }\n"
             + "]")
     }
@@ -70,8 +70,8 @@ class ContainerTests_CustomStringConvertible: XCTestCase {
 
         XCTAssertEqual(container.description,
             "[\n"
-            + "    { Service: Animal, Name: \"1\", Factory: Resolver -> Animal, ObjectScope: graph },\n"
-            + "    { Service: Animal, Name: \"2\", Factory: Resolver -> Animal, ObjectScope: graph }\n"
+            + "    { Service: Animal, Name: \"1\", Factory: SwinjectResolver -> Animal, ObjectScope: graph },\n"
+            + "    { Service: Animal, Name: \"2\", Factory: SwinjectResolver -> Animal, ObjectScope: graph }\n"
             + "]")
     }
 }

--- a/Tests/SwinjectTests/ContainerTests.DebugHelper.swift
+++ b/Tests/SwinjectTests/ContainerTests.DebugHelper.swift
@@ -15,9 +15,9 @@ class ContainerTests_DebugHelper: XCTestCase {
     // MARK: Resolution fails
 
     func testContainerShouldCallDebugHelperWithFailingServiceAndKey() {
-        let container = Container(debugHelper: spy)
+        let container = SwinjectContainer(debugHelper: spy)
 
-        _ = container._resolve(name: "name") { (_: Resolver, _: (Int) -> Any) in 1 as Double } as Double?
+        _ = container._resolve(name: "name") { (_: SwinjectResolver, _: (Int) -> Any) in 1 as Double } as Double?
 
         XCTAssertEqual("\(spy.serviceType)", "Double")
         XCTAssertEqual(spy.key, ServiceKey(
@@ -29,7 +29,7 @@ class ContainerTests_DebugHelper: XCTestCase {
     }
 
     func testContainerShouldCallHelperWithAllRegistrations() {
-        let container = Container(debugHelper: spy)
+        let container = SwinjectContainer(debugHelper: spy)
         container.register(Int.self) { _ in 0 }
         container.register(Double.self) { _ in 0 }
 
@@ -39,9 +39,9 @@ class ContainerTests_DebugHelper: XCTestCase {
     }
 
     func testContainerShouldCallHelperWithParentRegistrations() {
-        let parent = Container()
+        let parent = SwinjectContainer()
         parent.register(Int.self) { _ in 0 }
-        let container = Container(parent: parent, debugHelper: spy)
+        let container = SwinjectContainer(parent: parent, debugHelper: spy)
         container.register(Double.self) { _ in 0 }
 
         _ = container.resolve(String.self)

--- a/Tests/SwinjectTests/ContainerTests.GraphCaching.swift
+++ b/Tests/SwinjectTests/ContainerTests.GraphCaching.swift
@@ -6,10 +6,10 @@ import XCTest
 @testable import Swinject
 
 class ContainerTests_GraphCaching: XCTestCase {
-    var container: Container!
+    var container: SwinjectContainer!
 
     override func setUpWithError() throws {
-        container = Container()
+        container = SwinjectContainer()
     }
 
     // MARK: Restoration
@@ -23,7 +23,7 @@ class ContainerTests_GraphCaching: XCTestCase {
     func testIdentifierIsNotNilDuringGraphResolution() {
         var identifier: GraphIdentifier?
         container.register(Dog.self) {
-            identifier = ($0 as? Container)?.currentObjectGraph
+            identifier = ($0 as? SwinjectContainer)?.currentObjectGraph
             return Dog()
         }
 
@@ -35,7 +35,7 @@ class ContainerTests_GraphCaching: XCTestCase {
     func testIdentifierIsDifferentForSeparateGraphResolutions() {
         var identifiers = [GraphIdentifier?]()
         container.register(Dog.self) {
-            identifiers.append(($0 as? Container)?.currentObjectGraph)
+            identifiers.append(($0 as? SwinjectContainer)?.currentObjectGraph)
             return Dog()
         }
 
@@ -49,12 +49,12 @@ class ContainerTests_GraphCaching: XCTestCase {
     func testIdentifierIsSameDuringGraphResolution() {
         var identifiers = [GraphIdentifier?]()
         container.register(Dog.self) {
-            identifiers.append(($0 as? Container)?.currentObjectGraph)
+            identifiers.append(($0 as? SwinjectContainer)?.currentObjectGraph)
             _ = $0.resolve(Cat.self)
             return Dog()
         }
         container.register(Cat.self) {
-            identifiers.append(($0 as? Container)?.currentObjectGraph)
+            identifiers.append(($0 as? SwinjectContainer)?.currentObjectGraph)
             return Cat()
         }
 
@@ -78,7 +78,7 @@ class ContainerTests_GraphCaching: XCTestCase {
         let restoredIdentifier = GraphIdentifier()
         var identifier: GraphIdentifier?
         container.register(Dog.self) {
-            identifier = ($0 as? Container)?.currentObjectGraph
+            identifier = ($0 as? SwinjectContainer)?.currentObjectGraph
             return Dog()
         }
 
@@ -106,7 +106,7 @@ class ContainerTests_GraphCaching: XCTestCase {
     func testContainerRestoresInstancesFromPreviousGraphsIfAvailable() {
         var graph: GraphIdentifier!
         container.register(Dog.self) {
-            graph = ($0 as? Container)?.currentObjectGraph
+            graph = ($0 as? SwinjectContainer)?.currentObjectGraph
             return Dog()
         }.inObjectScope(.graph)
 
@@ -125,7 +125,7 @@ class ContainerTests_GraphCaching: XCTestCase {
     func testContainerResolvesGraphScopeIfAvailable() {
         var graph: GraphIdentifier?
         container.register(Dog.self) {
-            graph = ($0 as? Container)?.resolve(GraphIdentifier.self)
+            graph = ($0 as? SwinjectContainer)?.resolve(GraphIdentifier.self)
             return Dog()
         }
         let _ = container.resolve(Dog.self)!
@@ -135,7 +135,7 @@ class ContainerTests_GraphCaching: XCTestCase {
     func testContainerManualScopeSetResolvesGraph() {
         var graph: GraphIdentifier!
         container.register(Dog.self) {
-            graph = ($0 as? Container)?.resolve(GraphIdentifier.self)
+            graph = ($0 as? SwinjectContainer)?.resolve(GraphIdentifier.self)
             return Dog()
         }.inObjectScope(.graph)
 

--- a/Tests/SwinjectTests/ContainerTests.Speed.swift
+++ b/Tests/SwinjectTests/ContainerTests.Speed.swift
@@ -9,10 +9,10 @@ import XCTest
 /// this test, but good to run before/after changes to see changes.
 @available(iOS 13.0, *)
 class ContainerSpeedTests: XCTestCase {
-    var container: Container!
+    var container: SwinjectContainer!
 
     override func setUpWithError() throws {
-        container = Container()
+        container = SwinjectContainer()
 
         container.register(Animal.self) { _ in Cat() }
         container.register(Animal.self) { _, arg in Cat(name: arg) }
@@ -40,7 +40,7 @@ class ContainerSpeedTests: XCTestCase {
     }
 }
 
-fileprivate extension Container {
+fileprivate extension SwinjectContainer {
     func resolveCats() {
         for _ in 0..<500_000 {
             _ = resolve(Animal.self) as? Cat

--- a/Tests/SwinjectTests/ContainerTests.TypeForwarding.swift
+++ b/Tests/SwinjectTests/ContainerTests.TypeForwarding.swift
@@ -6,10 +6,10 @@ import XCTest
 @testable import Swinject
 
 class ContainerTests_TypeForwarding: XCTestCase {
-    var container: Container!
+    var container: SwinjectContainer!
 
     override func setUpWithError() throws {
-        container = Container()
+        container = SwinjectContainer()
     }
 
     // MARK: Container method

--- a/Tests/SwinjectTests/ContainerTests.swift
+++ b/Tests/SwinjectTests/ContainerTests.swift
@@ -6,10 +6,10 @@ import XCTest
 @testable import Swinject
 
 class ContainerTests: XCTestCase {
-    var container: Container!
+    var container: SwinjectContainer!
 
     override func setUpWithError() throws {
-        container = Container()
+        container = SwinjectContainer()
     }
 
     // MARK: Resolution of a non-registered service
@@ -64,8 +64,8 @@ class ContainerTests: XCTestCase {
     // MARK: Container hierarchy
 
     func testContainerResolvesServiceRegisteredOnParentContainer() {
-        let parent = Container()
-        let child = Container(parent: parent)
+        let parent = SwinjectContainer()
+        let child = SwinjectContainer(parent: parent)
 
         parent.register(Animal.self) { _ in Cat() }
         let cat = child.resolve(Animal.self)
@@ -73,8 +73,8 @@ class ContainerTests: XCTestCase {
     }
 
     func testContainerDoesNotResolveServiceRegistredOnChildContainer() {
-        let parent = Container()
-        let child = Container(parent: parent)
+        let parent = SwinjectContainer()
+        let child = SwinjectContainer(parent: parent)
 
         child.register(Animal.self) { _ in Cat() }
         let cat = parent.resolve(Animal.self)
@@ -82,8 +82,8 @@ class ContainerTests: XCTestCase {
     }
 
     func testContainerDoesNotCreateZombies() {
-        let parent = Container()
-        let child = Container(parent: parent)
+        let parent = SwinjectContainer()
+        let child = SwinjectContainer(parent: parent)
 
         parent.register(Cat.self) { _ in Cat() }
         weak var weakCat = child.resolve(Cat.self)
@@ -91,8 +91,8 @@ class ContainerTests: XCTestCase {
     }
 
     func testShadowedRegistration_owningContainerHierarchyAccess() {
-        let parent = Container()
-        let child = Container(parent: parent)
+        let parent = SwinjectContainer()
+        let child = SwinjectContainer(parent: parent)
 
         parent.register(Animal.self, factory: { _ in Dog()})
         child.register(Animal.self, factory: { _ in Cat()})
@@ -107,8 +107,8 @@ class ContainerTests: XCTestCase {
     }
 
     func testShadowedRegistration_owningContainerHierarchyAccess_inObjectScopeContainer() {
-        let parent = Container()
-        let child = Container(parent: parent)
+        let parent = SwinjectContainer()
+        let child = SwinjectContainer(parent: parent)
 
         parent.register(Animal.self, factory: { _ in Dog()})
         child.register(Animal.self, factory: { _ in Cat()})
@@ -143,7 +143,7 @@ class ContainerTests: XCTestCase {
 
     // MARK: Scope
 
-    private func registerCatAndPetOwnerDependingOnFood(_ container: Container) {
+    private func registerCatAndPetOwnerDependingOnFood(_ container: SwinjectContainer) {
         container.register(Animal.self) {
             let cat = Cat()
             cat.favoriteFood = $0.resolve(Food.self)
@@ -212,12 +212,12 @@ class ContainerTests: XCTestCase {
     }
 
     func testContainerSharesObjectFromParentContainerToItsChildWithContainerScope() {
-        let parent = Container()
+        let parent = SwinjectContainer()
         parent.register(Animal.self) { _ in Cat() }
             .inObjectScope(.container)
         parent.register(Animal.self, name: "dog") { _ in Dog() }
             .inObjectScope(.container)
-        let child = Container(parent: parent)
+        let child = SwinjectContainer(parent: parent)
 
         // Case resolving on the parent first.
         let cat1 = parent.resolve(Animal.self) as? Cat
@@ -231,10 +231,10 @@ class ContainerTests: XCTestCase {
     }
 
     func testContainerResolvesServiceInParentContainerToTheSameObjectInGraphWithContainerScope() {
-        let parent = Container()
+        let parent = SwinjectContainer()
         parent.register(Food.self) { _ in Sushi() }
             .inObjectScope(.container)
-        let child = Container(parent: parent)
+        let child = SwinjectContainer(parent: parent)
         registerCatAndPetOwnerDependingOnFood(child)
 
         let owner = child.resolve(Person.self) as? PetOwner
@@ -372,7 +372,7 @@ class ContainerTests: XCTestCase {
             container.removeAll()
             container.register(Animal.self) { _ in Turtle(name: "Ninja") }
                 .inObjectScope(scope)
-            let childContainer = Container(parent: container)
+            let childContainer = SwinjectContainer(parent: container)
 
             var turtle1 = childContainer.resolve(Animal.self)!
             let turtle2 = childContainer.resolve(Animal.self)!
@@ -425,7 +425,7 @@ class ContainerTests: XCTestCase {
     // MARK: Convenience initializers
 
     func testContainerTakesClosureRegisteringServices() {
-        let container = Container {
+        let container = SwinjectContainer {
             $0.register(Animal.self) { _ in Cat() }
         }
 
@@ -435,7 +435,7 @@ class ContainerTests: XCTestCase {
     // MARK: Default object scope
 
     func testContainerRegistersServiceWithGivenObjectScope() {
-        let container = Container(parent: nil, debugHelper: LoggingDebugHelper(), defaultObjectScope: .weak)
+        let container = SwinjectContainer(parent: nil, debugHelper: LoggingDebugHelper(), defaultObjectScope: .weak)
 
         let serviceEntry = container.register(Animal.self) { _ in Siamese(name: "Siam") }
         XCTAssert(serviceEntry.objectScope === ObjectScope.weak)
@@ -444,7 +444,7 @@ class ContainerTests: XCTestCase {
     // MARK: Has Registration
 
     func testContainerHasRegistration() {
-        let container = Container {
+        let container = SwinjectContainer {
             $0.register(Animal.self) { _ in Cat() }
             $0.register(Food.self, name: "Sushi") { _ in Sushi() }
         }

--- a/Tests/SwinjectTests/EmploymentAssembly.swift
+++ b/Tests/SwinjectTests/EmploymentAssembly.swift
@@ -51,7 +51,7 @@ final class EmploymentAssembly {
         self.scope = scope
     }
 
-    func assemble(container: Container) {
+    func assemble(container: SwinjectContainer) {
         container.register(Customer.self) { _ in Customer() }.inObjectScope(scope)
 
         container.register(Employee.self) {

--- a/Tests/SwinjectTests/LazyTests.swift
+++ b/Tests/SwinjectTests/LazyTests.swift
@@ -6,10 +6,10 @@ import XCTest
 import Swinject
 
 class LazyTests: XCTestCase {
-    var container: Container!
+    var container: SwinjectContainer!
 
     override func setUpWithError() throws {
-        container = Container()
+        container = SwinjectContainer()
     }
 
     // MARK: Instance production

--- a/Tests/SwinjectTests/ProviderTests.swift
+++ b/Tests/SwinjectTests/ProviderTests.swift
@@ -6,10 +6,10 @@ import XCTest
 @testable import Swinject
 
 class ProviderTests: XCTestCase {
-    var container: Container!
+    var container: SwinjectContainer!
 
     override func setUpWithError() throws {
-        container = Container()
+        container = SwinjectContainer()
     }
 
     // MARK: Instance production

--- a/Tests/SwinjectTests/ServiceKeyTests.swift
+++ b/Tests/SwinjectTests/ServiceKeyTests.swift
@@ -33,32 +33,32 @@ class ServiceKeyTests: XCTestCase {
     // MARK: Without name
 
     func testServiceKeyEqualsWithTheSameFactoryType() {
-        let key1 = ServiceKey(serviceType: Animal.self, argumentsType: Resolver.self)
-        let key2 = ServiceKey(serviceType: Animal.self, argumentsType: Resolver.self)
+        let key1 = ServiceKey(serviceType: Animal.self, argumentsType: SwinjectResolver.self)
+        let key2 = ServiceKey(serviceType: Animal.self, argumentsType: SwinjectResolver.self)
         XCTAssertEqual(key1, key2)
         XCTAssertEqual(key1.hashValue, key2.hashValue)
 
-        let key3 = ServiceKey(serviceType: Animal.self, argumentsType: (Resolver, String, Bool).self)
-        let key4 = ServiceKey(serviceType: Animal.self, argumentsType: (Resolver, String, Bool).self)
+        let key3 = ServiceKey(serviceType: Animal.self, argumentsType: (SwinjectResolver, String, Bool).self)
+        let key4 = ServiceKey(serviceType: Animal.self, argumentsType: (SwinjectResolver, String, Bool).self)
         XCTAssertEqual(key3, key4)
         XCTAssertEqual(key3.hashValue, key4.hashValue)
     }
 
     func testServiceKeyDoesNotEqualWithDifferentServiceTypesInFactoryTypes() {
-        let key1 = ServiceKey(serviceType: Person.self, argumentsType: Resolver.self)
-        let key2 = ServiceKey(serviceType: Animal.self, argumentsType: Resolver.self)
+        let key1 = ServiceKey(serviceType: Person.self, argumentsType: SwinjectResolver.self)
+        let key2 = ServiceKey(serviceType: Animal.self, argumentsType: SwinjectResolver.self)
         XCTAssertNotEqual(key1, key2)
         XCTAssertNotEqual(key1.hashValue, key2.hashValue)
     }
 
     func testServiceKeyDoesNotEqualWithDifferentArgTypesInFactoryTypes() {
-        let key1 = ServiceKey(serviceType: Animal.self, argumentsType: (Resolver, String).self)
-        let key2 = ServiceKey(serviceType: Animal.self, argumentsType: (Resolver, String, Bool).self)
+        let key1 = ServiceKey(serviceType: Animal.self, argumentsType: (SwinjectResolver, String).self)
+        let key2 = ServiceKey(serviceType: Animal.self, argumentsType: (SwinjectResolver, String, Bool).self)
         XCTAssertNotEqual(key1, key2)
         XCTAssertNotEqual(key1.hashValue, key2.hashValue)
 
-        let key3 = ServiceKey(serviceType: Animal.self, argumentsType: (Resolver, String, Bool).self)
-        let key4 = ServiceKey(serviceType: Animal.self, argumentsType: (Resolver, String, Int).self)
+        let key3 = ServiceKey(serviceType: Animal.self, argumentsType: (SwinjectResolver, String, Bool).self)
+        let key4 = ServiceKey(serviceType: Animal.self, argumentsType: (SwinjectResolver, String, Int).self)
         XCTAssertNotEqual(key3, key4)
         XCTAssertNotEqual(key3.hashValue, key4.hashValue)
     }
@@ -66,19 +66,19 @@ class ServiceKeyTests: XCTestCase {
     // MARK: With name
 
     func testServiceKeyEqualsWithTheSameName() {
-        let key1 = ServiceKey(serviceType: Animal.self, argumentsType: Resolver.self, name: "my factory")
-        let key2 = ServiceKey(serviceType: Animal.self, argumentsType: Resolver.self, name: "my factory")
+        let key1 = ServiceKey(serviceType: Animal.self, argumentsType: SwinjectResolver.self, name: "my factory")
+        let key2 = ServiceKey(serviceType: Animal.self, argumentsType: SwinjectResolver.self, name: "my factory")
         XCTAssertEqual(key1, key2)
         XCTAssertEqual(key1.hashValue, key2.hashValue)
 
         let key3 = ServiceKey(
             serviceType: Animal.self,
-            argumentsType: (Resolver, String, Bool).self,
+            argumentsType: (SwinjectResolver, String, Bool).self,
             name: "my factory"
         )
         let key4 = ServiceKey(
             serviceType: Animal.self,
-            argumentsType: (Resolver, String, Bool).self,
+            argumentsType: (SwinjectResolver, String, Bool).self,
             name: "my factory"
         )
         XCTAssertEqual(key3, key4)
@@ -86,19 +86,19 @@ class ServiceKeyTests: XCTestCase {
     }
 
     func testServiceKeyDoesNotEqualWithDifferentNames() {
-        let key1 = ServiceKey(serviceType: Animal.self, argumentsType: Resolver.self, name: "my factory")
-        let key2 = ServiceKey(serviceType: Animal.self, argumentsType: Resolver.self, name: "your factory")
+        let key1 = ServiceKey(serviceType: Animal.self, argumentsType: SwinjectResolver.self, name: "my factory")
+        let key2 = ServiceKey(serviceType: Animal.self, argumentsType: SwinjectResolver.self, name: "your factory")
         XCTAssertNotEqual(key1, key2)
         XCTAssertNotEqual(key1.hashValue, key2.hashValue)
 
         let key3 = ServiceKey(
             serviceType: Animal.self,
-            argumentsType: (Resolver, String, Bool).self,
+            argumentsType: (SwinjectResolver, String, Bool).self,
             name: "my factory"
         )
         let key4 = ServiceKey(
             serviceType: Animal.self,
-            argumentsType: (Resolver, String, Bool).self,
+            argumentsType: (SwinjectResolver, String, Bool).self,
             name: "your factory"
         )
         XCTAssertNotEqual(key3, key4)
@@ -108,19 +108,19 @@ class ServiceKeyTests: XCTestCase {
     // MARK: With option
 
     func testServiceKeyEqualsWithTheSameOption() {
-        let key1 = ServiceKey(serviceType: Animal.self, argumentsType: Resolver.self, option: Option(option: 1))
-        let key2 = ServiceKey(serviceType: Animal.self, argumentsType: Resolver.self, option: Option(option: 1))
+        let key1 = ServiceKey(serviceType: Animal.self, argumentsType: SwinjectResolver.self, option: Option(option: 1))
+        let key2 = ServiceKey(serviceType: Animal.self, argumentsType: SwinjectResolver.self, option: Option(option: 1))
         XCTAssertEqual(key1, key2)
         XCTAssertEqual(key1.hashValue, key2.hashValue)
 
         let key3 = ServiceKey(
             serviceType: Animal.self,
-            argumentsType: (Resolver, String, Bool).self,
+            argumentsType: (SwinjectResolver, String, Bool).self,
             option: Option(option: 1)
         )
         let key4 = ServiceKey(
             serviceType: Animal.self,
-            argumentsType: (Resolver, String, Bool).self,
+            argumentsType: (SwinjectResolver, String, Bool).self,
             option: Option(option: 1)
         )
         XCTAssertEqual(key3, key4)
@@ -128,19 +128,19 @@ class ServiceKeyTests: XCTestCase {
     }
 
     func testServiceKeyDoesNotEqualWithDifferentOptions() {
-        let key1 = ServiceKey(serviceType: Animal.self, argumentsType: Resolver.self, option: Option(option: 1))
-        let key2 = ServiceKey(serviceType: Animal.self, argumentsType: Resolver.self, option: Option(option: 2))
+        let key1 = ServiceKey(serviceType: Animal.self, argumentsType: SwinjectResolver.self, option: Option(option: 1))
+        let key2 = ServiceKey(serviceType: Animal.self, argumentsType: SwinjectResolver.self, option: Option(option: 2))
         XCTAssertNotEqual(key1, key2)
         XCTAssertNotEqual(key1.hashValue, key2.hashValue)
 
         let key3 = ServiceKey(
             serviceType: Animal.self,
-            argumentsType: (Resolver, String, Bool).self,
+            argumentsType: (SwinjectResolver, String, Bool).self,
             option: Option(option: 1)
         )
         let key4 = ServiceKey(
             serviceType: Animal.self,
-            argumentsType: (Resolver, String, Bool).self,
+            argumentsType: (SwinjectResolver, String, Bool).self,
             option: Option(option: 2)
         )
         XCTAssertNotEqual(key3, key4)

--- a/Tests/SwinjectTests/SynchronizedTests.swift
+++ b/Tests/SwinjectTests/SynchronizedTests.swift
@@ -11,7 +11,7 @@ class SynchronizedResolverTests: XCTestCase {
     // MARK: Multiple threads
 
     func testSynchronizedResolverCanResolveCircularDependencies() {
-        let container = Container { container in
+        let container = SwinjectContainer { container in
             container.register(ParentProtocol.self) { _ in Parent() }
                 .initCompleted { r, s in
                     let parent = s as! Parent
@@ -35,11 +35,11 @@ class SynchronizedResolverTests: XCTestCase {
 
     func testSynchronizedResolverCanAccessParentAndChildContainersWithoutDeadlock() {
         let runInObjectScope = { (scope: ObjectScope) in
-            let parentContainer = Container { container in
+            let parentContainer = SwinjectContainer { container in
                 container.register(Animal.self) { _ in Cat() }
                     .inObjectScope(scope)
             }
-            let childResolver = Container(parent: parentContainer)
+            let childResolver = SwinjectContainer(parent: parentContainer)
             // swiftlint:disable opening_brace
             onMultipleThreads(actions: [
                 { _ = parentContainer.resolve(Animal.self) as! Cat },
@@ -55,9 +55,9 @@ class SynchronizedResolverTests: XCTestCase {
 
     func testSynchronizedResolverUsesDistinctGraphIdentifier() {
         var graphs = Set<GraphIdentifier>()
-        let container = Container {
+        let container = SwinjectContainer {
             $0.register(Dog.self) {
-                graphs.insert(($0 as! Container).currentObjectGraph!)
+                graphs.insert(($0 as! SwinjectContainer).currentObjectGraph!)
                 return Dog()
             }
         }
@@ -69,7 +69,7 @@ class SynchronizedResolverTests: XCTestCase {
     
     func testSynchronizedResolverSynchronousReadsWrites() {
         let iterationCount = 3_000
-        let container = Container()
+        let container = SwinjectContainer()
         let registerExpectation = expectation(description: "register")
         let resolveExpectations = (0..<iterationCount).map { expectation(description: String(describing: $0)) }
         let resolutionLock = NSLock()
@@ -98,7 +98,7 @@ class SynchronizedResolverTests: XCTestCase {
     // MARK: Nested resolve
 
     func testSynchronizedResolverCanMakeItWithoutDeadlock() {
-        let container = Container()
+        let container = SwinjectContainer()
         let threadSafeResolver = container
         container.register(ChildProtocol.self) { _ in Child() }
         container.register(ParentProtocol.self) { _ in
@@ -120,9 +120,9 @@ class SynchronizedResolverTests: XCTestCase {
 
     func testSynchronizedResolverSynchronizesProviderTypes() {
         var graphs = Set<GraphIdentifier>()
-        let container = Container()
+        let container = SwinjectContainer()
         container.register(Animal.self) {
-            graphs.insert(($0 as! Container).currentObjectGraph!)
+            graphs.insert(($0 as! SwinjectContainer).currentObjectGraph!)
             return Dog()
         }
 
@@ -136,7 +136,7 @@ class SynchronizedResolverTests: XCTestCase {
 
     func testSynchronizedResolverSynchronizesLazyTypes() {
         // Lazy types might share graph identifiers and persistent entities.
-        let container = Container()
+        let container = SwinjectContainer()
         container.register(Dog.self) { _ in
             return Dog()
         }
@@ -155,9 +155,9 @@ class SynchronizedResolverTests: XCTestCase {
 
     func testSynchronizedResolverSafelyDereferencesLazyTypes() {
         var graphs = Set<GraphIdentifier>()
-        let container = Container()
+        let container = SwinjectContainer()
         container.register(Animal.self) {
-            graphs.insert(($0 as! Container).currentObjectGraph!)
+            graphs.insert(($0 as! SwinjectContainer).currentObjectGraph!)
             return Dog()
         }
         .inObjectScope(.container)
@@ -178,7 +178,7 @@ class SynchronizedResolverTests: XCTestCase {
     }
 
     func testGraphIdentifierRestoredAfterLazyResolve() {
-        let container = Container()
+        let container = SwinjectContainer()
         container.register(LazilyResolvedProtocol.self) { _ in
             LazilyResolved()
         }


### PR DESCRIPTION
If a project uses the `MemberImportVisibility` compiler flag then it requires that Swinject is imported in order to access functions from Swinject, like `.implements`. To a large degree this would require all consumers of Knit to also import Swinject. To solve this I've added `@_exported import Swinject`.

But now that Swinject is always imported there will be constant conflicts between the Container and Resolver types. So I've renamed the Swinject versions to `SwinjectContainer` and `SwinjectResolver`