### PR TITLE
Cleanup sendable conformance for DependencyBuilderError

### DIFF
--- a/Sources/Knit/Module/DependencyBuilder.swift
+++ b/Sources/Knit/Module/DependencyBuilder.swift
@@ -82,7 +82,10 @@ final class DependencyBuilder {
             return created
         }
 
-        throw DependencyBuilderError.moduleNotProvided(moduleType, dependencyTree.sourcePathString(moduleType: moduleType))
+        throw DependencyBuilderError.moduleNotProvided(
+            String(describing: moduleType),
+            dependencyTree.sourcePathString(moduleType: moduleType)
+        )
     }
 
     private func gatherDependencies(
@@ -112,7 +115,7 @@ final class DependencyBuilder {
             do {
                 try assemblyValidation(resolved)
             } catch {
-                throw DependencyBuilderError.assemblyValidationFailure(resolved, reason: error)
+                throw DependencyBuilderError.assemblyValidationFailure(String(describing: resolved), reason: error)
             }
         }
 
@@ -160,16 +163,16 @@ final class DependencyBuilder {
 
         let type = defaultType.erasedType
         guard type.doesReplace(type: moduleType) else {
-            throw DependencyBuilderError.invalidDefault(type, moduleType)
+            throw DependencyBuilderError.invalidDefault(String(describing: type), String(describing: moduleType))
         }
         return type
     }
 }
 
 public enum DependencyBuilderError: LocalizedError {
-    case moduleNotProvided(_ moduleType: any ModuleAssembly.Type, _ sourcePath: String)
-    case invalidDefault(_ overrideType: any ModuleAssembly.Type, _ moduleType: any ModuleAssembly.Type)
-    case assemblyValidationFailure(_ moduleType: any ModuleAssembly.Type, reason: Swift.Error)
+    case moduleNotProvided(_ moduleType: String, _ sourcePath: String)
+    case invalidDefault(_ overrideType: String, _ moduleType: String)
+    case assemblyValidationFailure(_ moduleType: String, reason: Swift.Error)
 
     public var errorDescription: String? {
         switch self {

--- a/Sources/Knit/Module/ScopedModuleAssembler.swift
+++ b/Sources/Knit/Module/ScopedModuleAssembler.swift
@@ -67,7 +67,10 @@ public final class ScopedModuleAssembler<TargetResolver> {
                     actual: String(describing: moduleAssemblyType.resolverType)
                 )
 
-                throw DependencyBuilderError.assemblyValidationFailure(moduleAssemblyType, reason: scopingError)
+                throw DependencyBuilderError.assemblyValidationFailure(
+                    String(describing: moduleAssemblyType),
+                    reason: scopingError
+                )
             }
         }
         self.internalAssembler = try ModuleAssembler(

--- a/Tests/KnitTests/DependencyBuilderTests.swift
+++ b/Tests/KnitTests/DependencyBuilderTests.swift
@@ -160,7 +160,7 @@ final class DependencyBuilderTests: XCTestCase {
                 )
 
                 if case let DependencyBuilderError.assemblyValidationFailure(moduleType, reason: reasonError) = error {
-                    XCTAssert(moduleType == Assembly1.self)
+                    XCTAssert(moduleType == "Assembly1")
                     if case DependencyBuilderTestError.failedValidation = reasonError {
                         // Correct `reasonError`
                     } else {


### PR DESCRIPTION
This is a warning being raised in some build environments. There isn't any need to keep the actual types around, they are only used for logging so converting them to Strings early instead.