### PR TITLE
Add ignoredServices to DuplicateRegistrationDetector

### DIFF
--- a/Sources/Knit/DuplicateRegistrationDetector.swift
+++ b/Sources/Knit/DuplicateRegistrationDetector.swift
@@ -26,9 +26,15 @@ public final class DuplicateRegistrationDetector {
     /// Useful to check that the count of this set is non-zero to confirm the Detector was set up correctly.
     public private(set) var existingRegistrations = Set<Key>()
 
+    /// Service types that should be ignored from this check.
+    /// This should not be used for production environments but may be needed for test configuraitons
+    public var ignoredServices: [Any.Type]
+
     public init(
+        ignoredServices: [Any.Type] = [],
         duplicateWasDetected: ((Key) -> Void)? = nil
     ) {
+        self.ignoredServices = ignoredServices
         self.duplicateWasDetected = duplicateWasDetected
     }
 
@@ -50,6 +56,12 @@ extension DuplicateRegistrationDetector: Behavior {
             argumentsType: entry.argumentsType,
             name: name
         )
+
+        // Skip any service types which are expected to have duplicates for testing configurations
+        let isIgnored = ignoredServices.contains { $0 == type }
+        if isIgnored {
+            return
+        }
 
         let preInsertCount = existingRegistrations.count
         existingRegistrations.insert(key)

--- a/Tests/KnitTests/DuplicateRegistrationDetectorTests.swift
+++ b/Tests/KnitTests/DuplicateRegistrationDetectorTests.swift
@@ -133,6 +133,29 @@ final class DuplicateRegistrationDetectorTests: XCTestCase {
         XCTAssertEqual(duplicateRegistrationDetector.detectedKeys.count, 1)
     }
 
+    func testIgnoredServices() throws {
+        var reportedDuplicates = [DuplicateRegistrationDetector.Key]()
+        let duplicateRegistrationDetector = DuplicateRegistrationDetector(
+            ignoredServices: [
+                String.self,
+            ]
+        ) {
+            reportedDuplicates.append($0)
+        }
+        let container = SwinjectContainer(
+            behaviors: [duplicateRegistrationDetector]
+        )
+
+        container.register(String.self, factory: { _ in "one" })
+        container.register(Int.self, factory: { _ in 1 })
+        XCTAssertEqual(reportedDuplicates.count, 0)
+
+        container.register(String.self, factory: { _ in "two" })
+        XCTAssertEqual(reportedDuplicates.count, 0)
+        container.register(Int.self, factory: { _ in 2 })
+        XCTAssertEqual(reportedDuplicates.count, 1)
+    }
+
     func testCustomStringDescription() throws {
         assertCustomStringDescription(key: DuplicateRegistrationDetector.Key(
             serviceType: String.self,


### PR DESCRIPTION
This allows `DuplicateRegistrationDetector` to be run in some CI tests to prevent anything slipping into main.