### PR TITLE
Fix package warnings

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -52,7 +52,7 @@ let package = Package(
         // MARK: - Swinject
         .target(
             name: "Swinject",
-            exclude: ["Container.Arguments.erb", "Resolver.erb"]
+            exclude: ["SwinjectContainer.Arguments.erb", "SwinjectResolver.erb"]
         ),
         .testTarget(
             name: "SwinjectTests",


### PR DESCRIPTION
These files got renamed but I forgot to update the excludes in Package.swift

```
warning: 'knit': Invalid Exclude '/Users/askorulis/Development/knit/Sources/Swinject/Container.Arguments.erb': File not found.
warning: 'knit': Invalid Exclude '/Users/askorulis/Development/knit/Sources/Swinject/Resolver.erb': File not found.
warning: 'knit': found 2 file(s) which are unhandled; explicitly declare them as resources or exclude from the target
    /Users/askorulis/Development/knit/Sources/Swinject/SwinjectResolver.erb
    /Users/askorulis/Development/knit/Sources/Swinject/SwinjectContainer.Arguments.erb
```