### PR TITLE
Make Combine extensions conditional on Combine being available

### DIFF
--- a/Sources/Knit/Future+Async.swift
+++ b/Sources/Knit/Future+Async.swift
@@ -3,6 +3,7 @@
 //  Knit
 //
 
+#if canImport(Combine)
 import Combine
 
 public extension Future {
@@ -19,3 +20,4 @@ public extension Future {
     }
 
 }
+#endif


### PR DESCRIPTION
Combine is only imported by the Knit library to add a helper to the Future type. 
The Combine import prevents using the library with [Skip Tools](https://skip.dev/) to compile for Android. 
Using a conditional import solves the issue.