### PR TITLE
Use swiftlang SwiftSyntax repository

### DIFF
--- a/Example/KnitExample.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Example/KnitExample.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -13,7 +13,7 @@
     {
       "identity" : "swift-syntax",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-syntax.git",
+      "location" : "https://github.com/swiftlang/swift-syntax",
       "state" : {
         "revision" : "2bc86522d115234d1f588efe2bcb4ce4be8f8b82",
         "version" : "510.0.3"

--- a/Package.resolved
+++ b/Package.resolved
@@ -13,7 +13,7 @@
     {
       "identity" : "swift-syntax",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-syntax.git",
+      "location" : "https://github.com/swiftlang/swift-syntax",
       "state" : {
         "revision" : "0687f71944021d616d34d922343dcef086855920",
         "version" : "600.0.1"

--- a/Package.swift
+++ b/Package.swift
@@ -18,7 +18,7 @@ let package = Package(
         .executable(name: "knit-cli", targets: ["knit-cli"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/apple/swift-syntax.git", "510.0.2"..<"603.0.0"),
+        .package(url: "https://github.com/swiftlang/swift-syntax", "510.0.2"..<"603.0.0"),
         .package(url: "https://github.com/apple/swift-argument-parser", from: "1.4.0"),
     ],
     targets: [


### PR DESCRIPTION
## Summary
- switch SwiftSyntax dependency URL from apple/swift-syntax.git to swiftlang/swift-syntax
- update tracked Package.resolved files to match the canonical repository URL

## Why?
SwiftSyntax moved from the apple GitHub organization to the swiftlang organization. Downstream package graphs can now include both URLs when one dependency still references apple/swift-syntax.git and another references swiftlang/swift-syntax. SwiftPM normalizes both to the same package identity, swift-syntax, which produces duplicate identity warnings and extra repository update work during package resolution.

Using the canonical swiftlang/swift-syntax URL keeps Knit aligned with the current upstream repository location and avoids contributing the legacy URL to downstream dependency graphs.

## Validation
- swift package resolve
- swift build -v
- swift test